### PR TITLE
Using action instead of console.log in checkbox story

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -37,7 +37,7 @@ exports[`Storyshots CheckBox call a function 1`] = `
   <label
     htmlFor="asInput4"
   >
-    check out the console
+    check out the action logger
   </label>
 </div>
 `;

--- a/src/CheckBox/CheckBox.stories.jsx
+++ b/src/CheckBox/CheckBox.stories.jsx
@@ -29,7 +29,7 @@ storiesOf('CheckBox', module)
   .add('call a function', () => (
     <CheckBox
       name="checkbox"
-      label="check out the action tab"
+      label="check out the action logger"
       onChange={action('Checkbox.onChange')}
     />
   ));

--- a/src/CheckBox/CheckBox.stories.jsx
+++ b/src/CheckBox/CheckBox.stories.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions'
+import { action } from '@storybook/addon-actions';
 
 import CheckBox from './index';
 

--- a/src/CheckBox/CheckBox.stories.jsx
+++ b/src/CheckBox/CheckBox.stories.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
-/* eslint-disable no-console */
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions'
 
 import CheckBox from './index';
 
@@ -29,7 +29,7 @@ storiesOf('CheckBox', module)
   .add('call a function', () => (
     <CheckBox
       name="checkbox"
-      label="check out the console"
-      onChange={() => console.log('the checkbox changed state')}
+      label="check out the action tab"
+      onChange={action('Checkbox.onChange')}
     />
   ));


### PR DESCRIPTION
This was using `console.log`, but I noticed that you already had `addon-actions` enabled, so it seemed like this was the better approach.