### PR TITLE
Prevent Unnecessary Radio Button and Radio Button Group Rerendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/paragon",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Accessible, responsive UI component library based on Bootstrap.",
   "main": "src/index.js",
   "author": "arizzitano",
@@ -23,6 +23,7 @@
     "prop-types": "^15.5.8",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
+    "react-element-proptypes": "^1.0.0",
     "react-proptype-conditional-require": "^1.0.4"
   },
   "devDependencies": {

--- a/src/RadioButtonGroup/index.jsx
+++ b/src/RadioButtonGroup/index.jsx
@@ -1,37 +1,54 @@
+/* eslint-disable react/no-multi-comp */
+
 import React from 'react';
 import PropTypes from 'prop-types';
+import ElementPropTypes from 'react-element-proptypes';
 
-function RadioButton(props) {
-  const {
-    children,
-    index,
-    isChecked,
-    name,
-    onBlur,
-    onClick,
-    onFocus,
-    onKeyDown,
-    value,
-    ...other
-  } = props;
+class RadioButton extends React.PureComponent {
+  constructor(props) {
+    super(props);
 
-  return (
-    <div>
-      <input
-        type={'radio'}
-        name={name}
-        aria-checked={isChecked}
-        defaultChecked={isChecked}
-        value={value}
-        data-index={index}
-        onBlur={event => onBlur(event)}
-        onClick={event => onClick(event)}
-        onFocus={event => onFocus(event)}
-        onKeyDown={event => onKeyDown(event)}
-        {...other}
-      />{children}
-    </div>
-  );
+    const {
+      onBlur,
+      onClick,
+      onFocus,
+      onKeyDown,
+    } = props;
+
+    this.onBlur = onBlur.bind(this);
+    this.onClick = onClick.bind(this);
+    this.onFocus = onFocus.bind(this);
+    this.onKeyDown = onKeyDown.bind(this);
+  }
+
+  render() {
+    const {
+      children,
+      index,
+      isChecked,
+      name,
+      value,
+      ...other
+    } = this.props;
+
+    return (
+      <div>
+        <input
+          type={'radio'}
+          name={name}
+          aria-checked={isChecked}
+          defaultChecked={isChecked}
+          value={value}
+          data-index={index}
+          onBlur={this.onBlur}
+          onClick={this.onClick}
+          onFocus={this.onFocus}
+          onKeyDown={this.onKeyDown}
+          {...other}
+        />{children}
+      </div>
+    );
+  }
 }
 
 
@@ -40,6 +57,8 @@ class RadioButtonGroup extends React.Component {
     super();
     // Bind the method to the component context
     this.renderChildren = this.renderChildren.bind(this);
+    this.onChange = this.onChange.bind(this);
+
     this.state = {
       selectedIndex: props.selectedIndex,
     };
@@ -57,15 +76,24 @@ class RadioButtonGroup extends React.Component {
 
 
   renderChildren() {
-    return React.Children.map((this.props.children), (child, index) =>
+    const {
+      children,
+      name,
+      onBlur,
+      onClick,
+      onFocus,
+      onKeyDown,
+    } = this.props;
+
+    return React.Children.map((children), (child, index) =>
       React.cloneElement(child, {
-        name: this.props.name,
+        name,
         value: child.props.value,
         isChecked: index === this.state.selectedIndex,
-        onBlur: this.props.onBlur,
-        onClick: this.props.onClick,
-        onFocus: this.props.onFocus,
-        onKeyDown: this.props.onKeyDown,
+        onBlur,
+        onClick,
+        onFocus,
+        onKeyDown,
         index,
       }),
     );
@@ -89,7 +117,7 @@ class RadioButtonGroup extends React.Component {
       <div
         role={'radiogroup'}
         aria-label={label}
-        onChange={event => this.onChange(event)}
+        onChange={this.onChange}
         tabIndex={-1}
         {...other}
       >
@@ -141,7 +169,7 @@ RadioButtonGroup.defaultProps = {
 };
 
 RadioButtonGroup.propTypes = {
-  children: PropTypes.arrayOf(RadioButton).isRequired,
+  children: PropTypes.arrayOf(ElementPropTypes.elementOfType(RadioButton)).isRequired,
   label: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   onBlur: PropTypes.func,


### PR DESCRIPTION
# Discussion
I stumbled across [this great repository for React patterns / anti-patterns](https://github.com/vasanthk/react-bits/) and I realized that the current implementation of `RadioButton` and `RadioButtonGroup` is woefully guilty of
[this React bad practice](https://github.com/vasanthk/react-bits/blob/master/gotchas/01.pure-render-checks.md#bad-1)

```javascript
class App extends PureComponent {
  render() {
    return <MyInput
      onChange={e => this.props.update(e.target.value)}/>;
  }
}
```

Why is this bad? 

Because `e => this.props.update(e.target.value)` creates a new function, which has a different reference, which means that React's shallow equality check is always `false`, which means that this will __always__ re-render 😭 .

Just to make sure, I ran the debugger in `Storybook` and on any `RadioButtonGroup` change every single `RadioButton` re-rendered.