### PR TITLE
Fix missing repository warning and add unmet peer dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Paragon
 
 [![Build Status](https://travis-ci.org/edx/paragon.svg?branch=master)](https://travis-ci.org/edx/paragon) [![Coveralls](https://img.shields.io/coveralls/edx/paragon.svg?branch=master)](https://coveralls.io/github/edx/paragon) [![Greenkeeper badge](https://badges.greenkeeper.io/edx/paragon.svg)](https://greenkeeper.io/)
+[![npm version](https://badge.fury.io/js/%40edx%2Fparagon.svg)](https://badge.fury.io/js/%40edx%2Fparagon)
 
 Paragon provides accessible React components for use within the Open edX platform and beyond.
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@edx/paragon",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Accessible, responsive UI component library based on Bootstrap.",
   "main": "src/index.js",
   "author": "arizzitano",
   "license": "MIT",
+  "repository": "https://github.com/edx/paragon/",
   "scripts": {
     "build": "NODE_ENV=production webpack",
     "build-storybook": "build-storybook",
@@ -17,7 +18,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@edx/edx-bootstrap": "^0.4.0",
+    "@edx/edx-bootstrap": "^0.4.2",
     "classnames": "^2.2.5",
     "font-awesome": "^4.7.0",
     "prop-types": "^15.5.8",
@@ -31,7 +32,7 @@
     "@storybook/addon-console": "^1.0.0",
     "@storybook/addon-options": "^3.2.6",
     "@storybook/addon-storyshots": "^3.2.8",
-    "@storybook/react": "3.2.11",
+    "@storybook/react": "^3.2.12",
     "@storybook/storybook-deployer": "^2.0.0",
     "babel-cli": "^6.24.1",
     "babel-jest": "^21.0.0",


### PR DESCRIPTION
I was seeing npm warnings for a missing repository field and for an unmet peer dev dependency (`@storybook/react^3.2.12`).

~~There are still two unmet peer dependency warnings for `jquery` and `popper.js` due to `@edx/edx-bootstrap`, which [I created a PR for](https://github.com/edx/edx-bootstrap/pull/22).~~ This should be merged in!

### TODO
- [x] Increase the version before merge