### PR TITLE
feat(semantic-release): implement semantic release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,20 @@
 language: node_js
 
 node_js:
+  - 8
   - 6
+
+cache:
+  directories:
+    - ~/.npm
+
+notifications:
+  email:
+    recipients:
+      - arizzitano@edx.org
+      - jbradley@edx.org
+    on_success: always
+    on_failure: always
 
 script:
   - npm run lint
@@ -9,3 +22,4 @@ script:
 
 after_script:
   - npm run coveralls
+  - npm run semantic-release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/paragon",
-  "version": "1.1.7",
+  "version": "0.0.0-development",
   "description": "Accessible, responsive UI component library based on Bootstrap.",
   "main": "src/index.js",
   "author": "arizzitano",
@@ -13,6 +13,8 @@
     "deploy-storybook": "storybook-to-ghpages",
     "lint": "eslint --ext .js --ext .jsx .",
     "precommit": "npm run lint",
+    "commit": "git-cz",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "snapshot": "jest --updateSnapshot",
     "start": "start-storybook -p 6006",
     "test": "jest --coverage"
@@ -32,6 +34,7 @@
     "@storybook/addon-console": "^1.0.0",
     "@storybook/addon-options": "^3.2.6",
     "@storybook/addon-storyshots": "^3.2.8",
+    "@storybook/channels": "^3.2.15",
     "@storybook/react": "^3.2.12",
     "@storybook/storybook-deployer": "^2.0.0",
     "babel-cli": "^6.24.1",
@@ -42,8 +45,10 @@
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-env": "^1.4.0",
     "babel-preset-react": "^6.24.1",
+    "commitizen": "^2.9.6",
     "coveralls": "^3.0.0",
     "css-loader": "^0.28.4",
+    "cz-conventional-changelog": "^2.1.0",
     "enzyme": "^2.8.2",
     "eslint": "^4.5.0",
     "eslint-config-airbnb": "^15.0.1",
@@ -61,6 +66,7 @@
     "react-router-dom": "^4.1.1",
     "react-test-renderer": "^15.6.1",
     "sass-loader": "^6.0.5",
+    "semantic-release": "^8.2.0",
     "source-map-loader": "^0.2.1",
     "style-loader": "^0.19.0",
     "webpack": "^3.0.0",
@@ -76,5 +82,10 @@
       "/node_modules/",
       "(.stories)\\.(jsx)$"
     ]
+  },
+  "config": {
+    "commitizen": {
+      "path": "cz-conventional-changelog"
+    }
   }
 }


### PR DESCRIPTION
### Implementation Details

* Installed [semantic-release](https://github.com/semantic-release/semantic-release) package
* Added convential commit analyzer
     * [commitizen cli](https://github.com/commitizen/cz-cli)
     * [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog)
* Updated `travis.yml` to run `semantic-release` after build success
     * Added email notifications
     * In order to use `semantic-release` [__at least one Travis build must be Node 8+__](https://github.com/semantic-release/semantic-release#why-does-semantic-release-require-node-version--8). This doesn't seem to be a big issue for this project - there was one package I needed to install (`@storybook/channels`) in order to get the Node 8 build completing successfully

### Example Commit Process (`npm run commit`)
<img width="1076" alt="semantic-commit" src="https://user-images.githubusercontent.com/8136030/32667727-7fed110a-c609-11e7-9542-facf3faf1d16.png">
