### PR TITLE
fix(Table): add aria-hidden to sort icons in Table

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -1602,6 +1602,7 @@ exports[`Storyshots Table sortable 1`] = `
             </span>
              
             <span
+              aria-hidden={true}
               className="fa fa-sort-desc"
             />
           </span>

--- a/src/Table/index.jsx
+++ b/src/Table/index.jsx
@@ -59,6 +59,7 @@ class Table extends React.Component {
 
     return (<span
       className={classNames(FontAwesomeStyles.fa, FontAwesomeStyles[sortIconClassName])}
+      aria-hidden
     />);
   }
 


### PR DESCRIPTION
add aria-hidden tag to the table headings of sortable columns in a sortable Table so icons are not
read aloud to screen-reader users