### PR TITLE
chore(travis): only run GitHub pages deploy for master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ script:
 after_success:
   - npm run semantic-release
   - npm run coveralls
-  - npm run deploy-storybook
+  - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run deploy-storybook; fi

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "src/index.js",
   "author": "arizzitano",
   "license": "MIT",
-  "repository": "https://github.com/edx/paragon/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/edx/paragon.git"
+  },
   "scripts": {
     "build": "NODE_ENV=production webpack",
     "build-storybook": "build-storybook",


### PR DESCRIPTION
Related to #79 - we should only deploy GH Pages for the `master` branch