### PR TITLE
fix(Hyperlink): Add Hyperlink component to exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import InputSelect from './InputSelect';
 import InputText from './InputText';
 import Tabs from './Tabs';
 import RadioButtonGroup, { RadioButton } from './RadioButtonGroup';
+import Hyperlink from './Hyperlink';
 
 export {
   Button,
@@ -15,4 +16,5 @@ export {
   Tabs,
   RadioButtonGroup,
   RadioButton,
+  Hyperlink,
 };


### PR DESCRIPTION
Related to #67. 

Forgot this because I'm a dummy. (I guess we (definitely) know that nobody is using the `Hyperlink` component (yet)).