### PR TITLE
fix(eslint): fix Node 6 eslint errors

### DIFF
--- a/src/Modal/Modal.stories.jsx
+++ b/src/Modal/Modal.stories.jsx
@@ -51,10 +51,6 @@ ModalWrapper.propTypes = {
   body: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
 };
 
-ModalWrapper.defaultProps = {
-  open: false,
-};
-
 storiesOf('Modal', module)
   .add('basic usage', () => (
     <Modal

--- a/src/Modal/index.jsx
+++ b/src/Modal/index.jsx
@@ -89,13 +89,12 @@ class Modal extends React.Component {
   }
 
   renderBody() {
-    let body;
+    let { body } = this.props;
 
-    if (typeof this.props.body === 'string') {
-      body = <p>{this.props.body}</p>;
-    } else {
-      body = this.props.body;
+    if (typeof body === 'string') {
+      body = <p>{body}</p>;
     }
+
     return body;
   }
 

--- a/src/StatusAlert/StatusAlert.test.jsx
+++ b/src/StatusAlert/StatusAlert.test.jsx
@@ -117,10 +117,7 @@ describe('<StatusAlert />', () => {
   });
   describe('focus functions properly', () => {
     it('focus function changes focus', () => {
-      wrapper = mount(<div>
-        <Button label="test" />
-        <StatusAlert {...defaultProps} />
-      </div>);
+      wrapper = mount(<div><Button label="test" /><StatusAlert {...defaultProps} /></div>);
 
       const buttons = wrapper.find('button');
 

--- a/src/Table/Table.test.jsx
+++ b/src/Table/Table.test.jsx
@@ -12,9 +12,15 @@ const props = {
     { key: 'i', label: 'Imaginary Number' },
   ],
   data: [
-    { sq: 1, num: 1, x2: 2, i: 'i' },
-    { sq: 4, num: 2, x2: 4, i: '2i' },
-    { sq: 9, num: 3, x2: 6, i: '3i' },
+    {
+      sq: 1, num: 1, x2: 2, i: 'i',
+    },
+    {
+      sq: 4, num: 2, x2: 4, i: '2i',
+    },
+    {
+      sq: 9, num: 3, x2: 6, i: '3i',
+    },
   ],
 };
 
@@ -62,7 +68,7 @@ describe('<Table />', () => {
     it('with data in the same order as the columns', () => {
       wrapper.find('tr').at(1).find('td').forEach((td, i) => {
         let parsed = Number(td.text());
-        if (isNaN(parsed)) { parsed = td.text(); }
+        if (Number.isNaN(parsed)) { parsed = td.text(); }
         expect(parsed).toEqual(props.data[0][props.columns[i].key]);
       });
     });

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -1,3 +1,8 @@
+// TODO: @jaebradley fix these eslint errors
+
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/anchor-is-valid */
+
 import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';


### PR DESCRIPTION
When working on #101 I noticed that [the Travis build](https://travis-ci.org/edx/paragon/jobs/317368090) had eslint errors for `Node` `6`:

![image](https://user-images.githubusercontent.com/8136030/34072015-030e454e-e24e-11e7-962b-bac7d21fe11c.png)

I confirmed these errors locally when I switched to `Node` `6.12.2` and `npm` `3.10.10`.

![image](https://user-images.githubusercontent.com/8136030/34072035-42e9cfd0-e24e-11e7-98e0-d69664b2a6c9.png)

When I switched back to `Node` `8.9.3` and `npm` `5.5.1`, there weren't any linting errors.
