### PR TITLE
fix(gh-pages-deploy): fix travis gh pages deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,11 @@ script:
 after_success:
   - npm run travis-deploy-once "npm run semantic-release"
   - npm run coveralls
-  - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run deploy-storybook; fi
+  - npm run storybook
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GH_TOKEN
+  local_dir: .out
+  on:
+    branch: master

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prepublishOnly": "npm run build",
     "semantic-release": "semantic-release",
     "snapshot": "jest --updateSnapshot",
+    "storybook": "build-storybook -o .out",
     "start": "start-storybook -p 6006",
     "test": "jest --coverage",
     "travis-deploy-once": "travis-deploy-once"


### PR DESCRIPTION
Resolves #108 and #74 

So it turns out, when publishing to GH Pages from Travis CI, you (obviously) need to authenticate the `git push` to the `gh-pages` branch.

Right now, [it looks like `storybook-deployer` doesn't authenticate the `git push`](https://github.com/storybooks/storybook-deployer/blob/master/bin/storybook_to_ghpages#L68)
```javascript
publishUtils.exec('git push --force --quiet ' + GIT_URL + ' ' + SOURCE_BRANCH + ':' + TARGET_BRANCH)
```
which is fine for local storybook deployments, but doesn't work for CI deployments.

There are a couple ways to get around this
1. Instead of pushing to a "typical" `git remote` URL (like `https://github.com/edx/paragon.git`)  you push to a URL with the format `https://<access_token>@github.com/<user_name>/<repo_name>.git` (as outlined in [this gist](https://gist.github.com/willprice/e07efd73fb7f13f917ea) and [this gist](https://gist.github.com/domenic/ec8b0fc8ab45f39403dd).
  * I opened [`storybook-deployer#30`](https://github.com/storybooks/storybook-deployer/pull/30) to add this functionality via a `ci` flag
2. [You setup a `deploy` step in `.travis.yml` per Travis CI's GitHub Pages Deployment documentation](https://docs.travis-ci.com/user/deployment/pages/)
  * After the build succeeds, `npm run storybook` executes, which will build the storybook files and output them to an `.out` file
  * This `.out` file will then get deployed to the `gh-pages` branch.

I chose the latter option as it's the most straightforward (for now).