### PR TITLE
fix(table): Buttons in table headings look like headings

### DIFF
--- a/src/Table/Table.scss
+++ b/src/Table/Table.scss
@@ -1,2 +1,8 @@
 @import "~bootstrap/scss/_tables";
 @import "~bootstrap/scss/utilities/_screenreaders.scss";
+@import "~bootstrap/scss/utilities/_spacing.scss";
+
+th .btn {
+  @extend .p-0;
+  font-weight: $font-weight-bold;
+}


### PR DESCRIPTION
UX would like the table headings to look like the standard bootstrap headings. When the column is sortable, the heading is a button. This PR makes those buttons look like headings.

![screen shot 2018-01-05 at 3 01 44 pm](https://user-images.githubusercontent.com/5265058/34626642-97429f70-f22b-11e7-9084-e1ded1a22523.png)

@edx/educator-dahlia @arizzitano 