### PR TITLE
fix(table): Use class name for button in table heading

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -2169,7 +2169,7 @@ exports[`Storyshots Table sortable 1`] = `
         scope="col"
       >
         <button
-          className="btn"
+          className="btn-header btn"
           onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}

--- a/src/Table/Table.scss
+++ b/src/Table/Table.scss
@@ -2,7 +2,7 @@
 @import "~bootstrap/scss/utilities/_screenreaders.scss";
 @import "~bootstrap/scss/utilities/_spacing.scss";
 
-th .btn {
+.btn-header {
   @extend .p-0;
   font-weight: $font-weight-bold;
 }

--- a/src/Table/index.jsx
+++ b/src/Table/index.jsx
@@ -66,6 +66,7 @@ class Table extends React.Component {
     let heading;
     if (this.props.tableSortable && column.columnSortable) {
       heading = (<Button
+        className={[classNames(styles['btn-header'])]}
         label={
           <span>
             {column.label}


### PR DESCRIPTION
Studio-frontend munges the css names in order to isolate the styles from Studio as a whole. In order to apply the munged class names and thus styles, names need to be referenced from the code. This change renames the css class and provides that class to the table header's button.

@edx/educator-dahlia 