### PR TITLE
test(table): add button class name checks

### DIFF
--- a/src/Table/Table.test.jsx
+++ b/src/Table/Table.test.jsx
@@ -138,6 +138,8 @@ describe('<Table />', () => {
     it('with correct column buttons', () => {
       const buttons = wrapper.find('button');
       expect(buttons).toHaveLength(2);
+      expect(buttons.at(0).hasClass('btn-header')).toBe(true);
+      expect(buttons.at(1).hasClass('btn-header')).toBe(true);
     });
 
     it('with correct initial sort icons', () => {

--- a/src/Table/index.jsx
+++ b/src/Table/index.jsx
@@ -66,7 +66,7 @@ class Table extends React.Component {
     let heading;
     if (this.props.tableSortable && column.columnSortable) {
       heading = (<Button
-        className={[classNames(styles['btn-header'])]}
+        className={[styles['btn-header']]}
         label={
           <span>
             {column.label}


### PR DESCRIPTION
#118 fixed the `Button` class name for the `Table` component - this just adds tests for the updated class name. It also removes a redundant `classNames` call.