### PR TITLE
build(greenkeeper): add lockfile support for greenkeeper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ notifications:
   hipchat:
     rooms:
       secure: iAwlvLMl/Qfv/wI4vbwpo3B0X/f+F5gL+sra0IBf3/wgaY8BuE/PzxrIP+PAF31nAil5gGD3LQvQ/vk/CZhkWgkQGQndK2aYHhUaSmJbCLtIwg6NX+YBz34vGZJawQzf3BDOglx6new+OYjAZtbP0noyMCL6hwp3HmflT+OMI6rhUU35dwQ4GjGSPYkjtdQZHosT5zcungpaBuGRtnUVKPLWBaa1Wl9NK3Vp9GEq5TaR7xg7wNk6dDnMXiHHxb5xp8acFWpf3yCX7NCouW6oWaFx/o4/SvGUFL9hr2pW7yKVEc59spaI/aZ8LNm94iIgFImlTAYdtErmjJytZORgt6AFF90Fbe38ntFjVdo2F/8/qgzzn+GkknPyYXZC/io2jX5919WZLQg2nOAqQyDUa5m0k11YfC7h0E+FldbJKcDmI9CWfzhGJGTXIaQCSkRq2tWfUC9mxO7ssZl+B3u9Ywv+F22QYF46bfsJP+PsLYXDBBDLnCD+zfuOaxP9RPiqRMEkM1QYFlNX0Kl1YsN3a2SparzjWbuKA63HTCMBL+f4npeYI6fkPHxDeligFUzlMeJIWKBnh7T5ZaHMR1B9icq7HOzPuEQ8LChgkeymGsvoU2euH8nbCmHiWafbGAZp39FDKj68YoFdUX3sV8xn9/INyU6j+C4NtKCPFfbC33E=
+before_install:
+  - npm install -g npm@5
+  - npm install -g greenkeeper-lockfile@1
+before_script: greenkeeper-lockfile-update
+after_script: greenkeeper-lockfile-upload
 script:
   - npm run lint
   - npm run test


### PR DESCRIPTION
### Description
[Greenkeeper has lockfile support](https://github.com/greenkeeperio/greenkeeper-lockfile).

Basically, when a Greenkeeper branch / PR first runs on Travis (or another CI services), the [`greenkeeper-lockfile` `npm` package](https://www.npmjs.com/package/greenkeeper-lockfile) runs two commands that will lead to a commit to the pull request with the updated `package-lock.json` file.

I essentially just copied the `.travis.yml` updates from [the `greenkeeper-lockfile` `README`](https://github.com/greenkeeperio/greenkeeper-lockfile#npm).

One thing I omitted was installing `npm` in the `before_install` step like 
```yaml
before_install:
- npm install -g npm
```
I can explicitly add this command, but I was able to get `greenkeeper-lockfile` working without explicitly installing `npm` on a personal package.

Here are screenshots from [that Greenkeeper PR](https://github.com/jaebradley/urban-dictionary-cli/pull/6)

![image](https://user-images.githubusercontent.com/8136030/34828641-32ae22de-f6ac-11e7-860f-ad0333af5620.png)

![image](https://user-images.githubusercontent.com/8136030/34828647-38acb77c-f6ac-11e7-86dd-06573927b039.png)

Once merged, lockfiles should be added for any *additional* Greenkeeper branches but I don't believe they will be added to any *existing* Greenkeeper branch.