### PR TITLE
build(eslint): add browser compatibility linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
     }
   },
   "rules": {
-    "react/no-array-index-key": "off"
+    "react/no-array-index-key": "off",
+    "compat/compat": "error"
   },
   "settings": {
     "import/resolver": {
@@ -16,8 +17,10 @@
     }
   },
   "env": {
-    "jest": true
+    "jest": true,
+    "browser": true
   },
+  "plugins": ["compat"],
   "overrides": {
     "files": ["*.stories.jsx", "*.test.jsx"],
     "rules": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5721,6 +5721,49 @@
         }
       }
     },
+    "eslint-plugin-compat": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-2.2.0.tgz",
+      "integrity": "sha512-nMH9Ibga+VZVLGtyxx8Dry69NN+a7YykNoUA9NtL3QNTeciV4QAAOtBLykKDR0Q37wwtKME+Inlce7JOhy5dbg==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "browserslist": "2.11.3",
+        "caniuse-db": "1.0.30000795",
+        "mdn-browser-compat-data": "0.0.20",
+        "requireindex": "1.1.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "2.11.3",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+          "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "1.0.30000792",
+            "electron-to-chromium": "1.3.31"
+          }
+        },
+        "caniuse-db": {
+          "version": "1.0.30000795",
+          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000795.tgz",
+          "integrity": "sha1-ZE8D+rAN2L0Wk+Xh5w2Gsxxc/s4=",
+          "dev": true
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000792",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz",
+          "integrity": "sha1-0M6pgfgRjzlhRxr7tDyaHlu/AzI=",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.31",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
+          "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-dollar-sign": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-dollar-sign/-/eslint-plugin-dollar-sign-1.0.1.tgz",
@@ -10179,6 +10222,15 @@
         }
       }
     },
+    "mdn-browser-compat-data": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.20.tgz",
+      "integrity": "sha512-DImQhKtc7umi/LI0licM3GVnKTxYoYmFUKnMjomfIvW8dO4B6UeQLWYQhf1jDTfEV9WZGjFTz3DOfcsnZO6WdA==",
+      "dev": true,
+      "requires": {
+        "extend": "3.0.1"
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -14565,6 +14617,12 @@
           "dev": true
         }
       }
+    },
+    "requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
+      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-config-airbnb": "^16.0.0",
     "eslint-config-edx": "^4.0.1",
     "eslint-import-resolver-webpack": "^0.8.1",
+    "eslint-plugin-compat": "^2.1.0",
     "eslint-plugin-jsx-a11y": "^5.1.0",
     "eslint-plugin-react": "^7.1.0",
     "extract-text-webpack-plugin": "^3.0.1",
@@ -102,5 +103,9 @@
     "transformIgnorePatterns": [
       "/node_modules/(?!lodash-es/.*)"
     ]
-  }
+  },
+  "browserslist": [
+    "last 2 versions",
+    "not ie < 11"
+  ]
 }


### PR DESCRIPTION
I came across [`eslint-plugin-compat` ](https://github.com/amilajack/eslint-plugin-compat) that does browser compatibility linting.

I don't know if this is something we think would be a good idea to add, and also what browser versions we should try and support, but I'm opening this to start that discussion!