### PR TITLE
logging my failed attempt

### DIFF
--- a/src/Modal/Modal.stories.jsx
+++ b/src/Modal/Modal.stories.jsx
@@ -146,6 +146,15 @@ storiesOf('Modal', module)
       onClose={() => {}}
     />
   ))
+  .add('modal with element closeText', () => (
+    <Modal
+      open
+      title="Modal title."
+      body="Modal body."
+      onClose={() => {}}
+      closeText={(<span lang="en">Cancel</span>)}
+    />
+  ))
   .add('modal with warning variant', () => (
     <Modal
       open

--- a/src/Modal/Modal.test.jsx
+++ b/src/Modal/Modal.test.jsx
@@ -56,6 +56,19 @@ describe('<Modal />', () => {
       expect(wrapper.find('button')).toHaveLength(buttons.length + 2);
     });
 
+    it('uses element type as closeText', () => {
+      const testLabel = (<span lang="en">Cancel</span>);
+      const props = {
+        ...defaultProps,
+        closeText: testLabel,
+      };
+      wrapper = mount(<Modal {...defaultProps} closeText={testLabel} />);
+      // TODO: these will likely fail the first time around
+      expect(wrapper.find('label').children()).toHaveLength(1);
+      expect(wrapper.find('label').children().at(0).text()).toEqual('Cancel');
+      expect(wrapper.find('label').children().at(0).prop('lang')).toEqual('en');
+      });
+
     it('renders Warning Variant', () => {
       wrapper = mount(<Modal {...defaultProps} variant={{ status: Variant.status.WARNING }} />);
 

--- a/src/Modal/index.jsx
+++ b/src/Modal/index.jsx
@@ -209,7 +209,7 @@ Modal.propTypes = {
     PropTypes.element,
     PropTypes.shape(buttonPropTypes),
   ])),
-  closeText: PropTypes.string,
+  closeText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   onClose: PropTypes.func.isRequired,
   variant: PropTypes.shape({
     status: PropTypes.string,


### PR DESCRIPTION
this was a bad idea, [`closeText` is also used as an aria-label, which cannot be an object](https://github.com/edx/paragon/blob/f702b7b5d47ddec3c2845d1b4cc1b07eff031d4c/src/Modal/index.jsx#L177)