### PR TITLE
build(email): only send emails on failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ notifications:
     recipients:
       - arizzitano@edx.org
       - jbradley@edx.org
-    on_success: always
     on_failure: always
   hipchat:
     rooms:


### PR DESCRIPTION
[`Greenkeeper`](https://greenkeeper.io) is great, [but part of how it works is that for in-range dependency updates that pass Travis, it deletes the branch](https://greenkeeper.io/docs.html#greenkeeper-step-by-step).

![image](https://user-images.githubusercontent.com/8136030/36063372-018480d0-0e4a-11e8-8c1a-27356a5ddb3c.png)

Currently emails are sent on success and failure (sorry @arizzitano) which leads to a lot of noise. We should only send emails on failure.
