### PR TITLE
build(storybook): use addon-info

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -415,63 +415,1986 @@ exports[`Storyshots Dropdown basic usage 1`] = `
 `;
 
 exports[`Storyshots HyperLink minimal usage 1`] = `
-<a
-  href="https://en.wikipedia.org/wiki/Hyperlink"
-  onClick={[Function]}
-  target="_self"
->
-  edX.org
-</a>
+<div>
+  <div
+    style={undefined}
+  >
+    <div
+      style={
+        Object {
+          "WebkitFontSmoothing": "antialiased",
+          "backgroundColor": "#fff",
+          "border": "1px solid #eee",
+          "borderRadius": "2px",
+          "boxShadow": "0px 2px 3px rgba(0, 0, 0, 0.05)",
+          "color": "#444",
+          "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "marginBottom": "20px",
+          "marginTop": "20px",
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "borderBottom": "1px solid #eee",
+            "marginBottom": 10,
+            "paddingTop": 10,
+          }
+        }
+      >
+        <h1
+          style={
+            Object {
+              "fontSize": "35px",
+              "margin": 0,
+              "padding": 0,
+            }
+          }
+        >
+          HyperLink
+        </h1>
+        <h2
+          style={
+            Object {
+              "fontSize": "22px",
+              "fontWeight": 400,
+              "margin": "0 0 10px 0",
+              "padding": 0,
+            }
+          }
+        >
+          minimal usage
+        </h2>
+      </div>
+    </div>
+  </div>
+  <div
+    style={Object {}}
+  >
+    <a
+      href="https://en.wikipedia.org/wiki/Hyperlink"
+      onClick={[Function]}
+      target="_self"
+    >
+      edX.org
+    </a>
+  </div>
+  <div
+    style={undefined}
+  >
+    <div
+      style={
+        Object {
+          "WebkitFontSmoothing": "antialiased",
+          "backgroundColor": "#fff",
+          "border": "1px solid #eee",
+          "borderRadius": "2px",
+          "boxShadow": "0px 2px 3px rgba(0, 0, 0, 0.05)",
+          "color": "#444",
+          "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "marginBottom": "20px",
+          "marginTop": "20px",
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      
+      <div>
+        <h1
+          style={
+            Object {
+              "borderBottom": "1px solid #EEE",
+              "fontSize": "25px",
+              "margin": "20px 0 0 0",
+              "padding": "0 0 5px 0",
+            }
+          }
+        >
+          Story Source
+        </h1>
+        <pre
+          style={
+            Object {
+              "backgroundColor": "#fafafa",
+              "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
+              "fontSize": ".88em",
+              "lineHeight": 1.5,
+              "overflowX": "scroll",
+              "padding": ".5rem",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "paddingLeft": 18,
+                "paddingRight": 3,
+              }
+            }
+          >
+            <span
+              style={
+                Object {
+                  "color": "#777",
+                }
+              }
+            >
+              &lt;
+              Hyperlink
+            </span>
+            <span>
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  destination
+                </span>
+                <span>
+                  =
+                  <span
+                    style={Object {}}
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#22a",
+                          "wordBreak": "break-word",
+                        }
+                      }
+                    >
+                      "
+                      https://en.wikipedia.org/wiki/Hyperlink
+                      "
+                    </span>
+                  </span>
+                </span>
+              </span>
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  content
+                </span>
+                <span>
+                  =
+                  <span
+                    style={Object {}}
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#22a",
+                          "wordBreak": "break-word",
+                        }
+                      }
+                    >
+                      "
+                      edX.org
+                      "
+                    </span>
+                  </span>
+                </span>
+                 
+              </span>
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#777",
+                }
+              }
+            >
+              /&gt;
+            </span>
+          </div>
+        </pre>
+      </div>
+      <div>
+        <h1
+          style={
+            Object {
+              "borderBottom": "1px solid #EEE",
+              "fontSize": "25px",
+              "margin": "20px 0 0 0",
+              "padding": "0 0 5px 0",
+            }
+          }
+        >
+          Prop Types
+        </h1>
+        <div>
+          <h2
+            style={
+              Object {
+                "margin": "20px 0 0 0",
+              }
+            }
+          >
+            "
+            Hyperlink
+            " Component
+          </h2>
+          <table
+            className="css-1ytzlk7"
+          >
+            <thead>
+              <tr>
+                <th
+                  className="css-d52hbj"
+                >
+                  property
+                </th>
+                <th
+                  className="css-d52hbj"
+                >
+                  propType
+                </th>
+                <th
+                  className="css-d52hbj"
+                >
+                  required
+                </th>
+                <th
+                  className="css-d52hbj"
+                >
+                  default
+                </th>
+                <th
+                  className="css-d52hbj"
+                >
+                  description
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  destination
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  yes
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  -
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  content
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  yes
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  -
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  target
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  -
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#22a",
+                        "wordBreak": "break-word",
+                      }
+                    }
+                  >
+                    "
+                    _self
+                    "
+                  </span>
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  onClick
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  -
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  <span>
+                    {
+                    <span
+                      style={
+                        Object {
+                          "color": "#170",
+                        }
+                      }
+                    >
+                      onClick()
+                    </span>
+                    }
+                  </span>
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  externalLinkAlternativeText
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  yes
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#22a",
+                        "wordBreak": "break-word",
+                      }
+                    }
+                  >
+                    "
+                    Opens in a new window
+                    "
+                  </span>
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  externalLinkTitle
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  yes
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#22a",
+                        "wordBreak": "break-word",
+                      }
+                    }
+                  >
+                    "
+                    Opens in a new window
+                    "
+                  </span>
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`Storyshots HyperLink with blank target 1`] = `
-<a
-  href="https://www.edx.org"
-  onClick={[Function]}
-  target="_blank"
->
-  edX.org
-  <span>
-     
-    <span
-      aria-hidden={false}
-      aria-label="Opens in a new window"
-      className="fa fa-external-link"
-      title="Opens in a new window"
-    />
-  </span>
-</a>
+<div>
+  <div
+    style={undefined}
+  >
+    <div
+      style={
+        Object {
+          "WebkitFontSmoothing": "antialiased",
+          "backgroundColor": "#fff",
+          "border": "1px solid #eee",
+          "borderRadius": "2px",
+          "boxShadow": "0px 2px 3px rgba(0, 0, 0, 0.05)",
+          "color": "#444",
+          "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "marginBottom": "20px",
+          "marginTop": "20px",
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "borderBottom": "1px solid #eee",
+            "marginBottom": 10,
+            "paddingTop": 10,
+          }
+        }
+      >
+        <h1
+          style={
+            Object {
+              "fontSize": "35px",
+              "margin": 0,
+              "padding": 0,
+            }
+          }
+        >
+          HyperLink
+        </h1>
+        <h2
+          style={
+            Object {
+              "fontSize": "22px",
+              "fontWeight": 400,
+              "margin": "0 0 10px 0",
+              "padding": 0,
+            }
+          }
+        >
+          with blank target
+        </h2>
+      </div>
+    </div>
+  </div>
+  <div
+    style={Object {}}
+  >
+    <a
+      href="https://www.edx.org"
+      onClick={[Function]}
+      target="_blank"
+    >
+      edX.org
+      <span>
+         
+        <span
+          aria-hidden={false}
+          aria-label="Opens in a new window"
+          className="fa fa-external-link"
+          title="Opens in a new window"
+        />
+      </span>
+    </a>
+  </div>
+  <div
+    style={undefined}
+  >
+    <div
+      style={
+        Object {
+          "WebkitFontSmoothing": "antialiased",
+          "backgroundColor": "#fff",
+          "border": "1px solid #eee",
+          "borderRadius": "2px",
+          "boxShadow": "0px 2px 3px rgba(0, 0, 0, 0.05)",
+          "color": "#444",
+          "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "marginBottom": "20px",
+          "marginTop": "20px",
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      
+      <div>
+        <h1
+          style={
+            Object {
+              "borderBottom": "1px solid #EEE",
+              "fontSize": "25px",
+              "margin": "20px 0 0 0",
+              "padding": "0 0 5px 0",
+            }
+          }
+        >
+          Story Source
+        </h1>
+        <pre
+          style={
+            Object {
+              "backgroundColor": "#fafafa",
+              "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
+              "fontSize": ".88em",
+              "lineHeight": 1.5,
+              "overflowX": "scroll",
+              "padding": ".5rem",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "paddingLeft": 18,
+                "paddingRight": 3,
+              }
+            }
+          >
+            <span
+              style={
+                Object {
+                  "color": "#777",
+                }
+              }
+            >
+              &lt;
+              Hyperlink
+            </span>
+            <span>
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  destination
+                </span>
+                <span>
+                  =
+                  <span
+                    style={Object {}}
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#22a",
+                          "wordBreak": "break-word",
+                        }
+                      }
+                    >
+                      "
+                      https://www.edx.org
+                      "
+                    </span>
+                  </span>
+                </span>
+              </span>
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  content
+                </span>
+                <span>
+                  =
+                  <span
+                    style={Object {}}
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#22a",
+                          "wordBreak": "break-word",
+                        }
+                      }
+                    >
+                      "
+                      edX.org
+                      "
+                    </span>
+                  </span>
+                </span>
+              </span>
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  target
+                </span>
+                <span>
+                  =
+                  <span
+                    style={Object {}}
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#22a",
+                          "wordBreak": "break-word",
+                        }
+                      }
+                    >
+                      "
+                      _blank
+                      "
+                    </span>
+                  </span>
+                </span>
+                 
+              </span>
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#777",
+                }
+              }
+            >
+              /&gt;
+            </span>
+          </div>
+        </pre>
+      </div>
+      <div>
+        <h1
+          style={
+            Object {
+              "borderBottom": "1px solid #EEE",
+              "fontSize": "25px",
+              "margin": "20px 0 0 0",
+              "padding": "0 0 5px 0",
+            }
+          }
+        >
+          Prop Types
+        </h1>
+        <div>
+          <h2
+            style={
+              Object {
+                "margin": "20px 0 0 0",
+              }
+            }
+          >
+            "
+            Hyperlink
+            " Component
+          </h2>
+          <table
+            className="css-1ytzlk7"
+          >
+            <thead>
+              <tr>
+                <th
+                  className="css-d52hbj"
+                >
+                  property
+                </th>
+                <th
+                  className="css-d52hbj"
+                >
+                  propType
+                </th>
+                <th
+                  className="css-d52hbj"
+                >
+                  required
+                </th>
+                <th
+                  className="css-d52hbj"
+                >
+                  default
+                </th>
+                <th
+                  className="css-d52hbj"
+                >
+                  description
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  destination
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  yes
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  -
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  content
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  yes
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  -
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  target
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  -
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#22a",
+                        "wordBreak": "break-word",
+                      }
+                    }
+                  >
+                    "
+                    _self
+                    "
+                  </span>
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  onClick
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  -
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  <span>
+                    {
+                    <span
+                      style={
+                        Object {
+                          "color": "#170",
+                        }
+                      }
+                    >
+                      onClick()
+                    </span>
+                    }
+                  </span>
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  externalLinkAlternativeText
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  yes
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#22a",
+                        "wordBreak": "break-word",
+                      }
+                    }
+                  >
+                    "
+                    Opens in a new window
+                    "
+                  </span>
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  externalLinkTitle
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  yes
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#22a",
+                        "wordBreak": "break-word",
+                      }
+                    }
+                  >
+                    "
+                    Opens in a new window
+                    "
+                  </span>
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`Storyshots HyperLink with icon as content 1`] = `
-<a
-  href="https://www.edx.org"
-  onClick={[Function]}
-  target="_self"
->
-  <span
-    className="fa fa-book"
-  />
-</a>
+<div>
+  <div
+    style={undefined}
+  >
+    <div
+      style={
+        Object {
+          "WebkitFontSmoothing": "antialiased",
+          "backgroundColor": "#fff",
+          "border": "1px solid #eee",
+          "borderRadius": "2px",
+          "boxShadow": "0px 2px 3px rgba(0, 0, 0, 0.05)",
+          "color": "#444",
+          "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "marginBottom": "20px",
+          "marginTop": "20px",
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "borderBottom": "1px solid #eee",
+            "marginBottom": 10,
+            "paddingTop": 10,
+          }
+        }
+      >
+        <h1
+          style={
+            Object {
+              "fontSize": "35px",
+              "margin": 0,
+              "padding": 0,
+            }
+          }
+        >
+          HyperLink
+        </h1>
+        <h2
+          style={
+            Object {
+              "fontSize": "22px",
+              "fontWeight": 400,
+              "margin": "0 0 10px 0",
+              "padding": 0,
+            }
+          }
+        >
+          with icon as content
+        </h2>
+      </div>
+    </div>
+  </div>
+  <div
+    style={Object {}}
+  >
+    <a
+      href="https://www.edx.org"
+      onClick={[Function]}
+      target="_self"
+    >
+      <span
+        className="fa fa-book"
+      />
+    </a>
+  </div>
+  <div
+    style={undefined}
+  >
+    <div
+      style={
+        Object {
+          "WebkitFontSmoothing": "antialiased",
+          "backgroundColor": "#fff",
+          "border": "1px solid #eee",
+          "borderRadius": "2px",
+          "boxShadow": "0px 2px 3px rgba(0, 0, 0, 0.05)",
+          "color": "#444",
+          "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "marginBottom": "20px",
+          "marginTop": "20px",
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      
+      <div>
+        <h1
+          style={
+            Object {
+              "borderBottom": "1px solid #EEE",
+              "fontSize": "25px",
+              "margin": "20px 0 0 0",
+              "padding": "0 0 5px 0",
+            }
+          }
+        >
+          Story Source
+        </h1>
+        <pre
+          style={
+            Object {
+              "backgroundColor": "#fafafa",
+              "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
+              "fontSize": ".88em",
+              "lineHeight": 1.5,
+              "overflowX": "scroll",
+              "padding": ".5rem",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "paddingLeft": 18,
+                "paddingRight": 3,
+              }
+            }
+          >
+            <span
+              style={
+                Object {
+                  "color": "#777",
+                }
+              }
+            >
+              &lt;
+              Hyperlink
+            </span>
+            <span>
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  destination
+                </span>
+                <span>
+                  =
+                  <span
+                    style={Object {}}
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#22a",
+                          "wordBreak": "break-word",
+                        }
+                      }
+                    >
+                      "
+                      https://www.edx.org
+                      "
+                    </span>
+                  </span>
+                </span>
+              </span>
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  content
+                </span>
+                <span>
+                  =
+                  <span
+                    style={Object {}}
+                  >
+                    <span>
+                      {
+                      <span
+                        style={
+                          Object {
+                            "color": "#666",
+                          }
+                        }
+                      >
+                        &lt;span /&gt;
+                      </span>
+                      }
+                    </span>
+                  </span>
+                </span>
+                 
+              </span>
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#777",
+                }
+              }
+            >
+              /&gt;
+            </span>
+          </div>
+        </pre>
+      </div>
+      <div>
+        <h1
+          style={
+            Object {
+              "borderBottom": "1px solid #EEE",
+              "fontSize": "25px",
+              "margin": "20px 0 0 0",
+              "padding": "0 0 5px 0",
+            }
+          }
+        >
+          Prop Types
+        </h1>
+        <div>
+          <h2
+            style={
+              Object {
+                "margin": "20px 0 0 0",
+              }
+            }
+          >
+            "
+            Hyperlink
+            " Component
+          </h2>
+          <table
+            className="css-1ytzlk7"
+          >
+            <thead>
+              <tr>
+                <th
+                  className="css-d52hbj"
+                >
+                  property
+                </th>
+                <th
+                  className="css-d52hbj"
+                >
+                  propType
+                </th>
+                <th
+                  className="css-d52hbj"
+                >
+                  required
+                </th>
+                <th
+                  className="css-d52hbj"
+                >
+                  default
+                </th>
+                <th
+                  className="css-d52hbj"
+                >
+                  description
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  destination
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  yes
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  -
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  content
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  yes
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  -
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  target
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  -
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#22a",
+                        "wordBreak": "break-word",
+                      }
+                    }
+                  >
+                    "
+                    _self
+                    "
+                  </span>
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  onClick
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  -
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  <span>
+                    {
+                    <span
+                      style={
+                        Object {
+                          "color": "#170",
+                        }
+                      }
+                    >
+                      onClick()
+                    </span>
+                    }
+                  </span>
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  externalLinkAlternativeText
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  yes
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#22a",
+                        "wordBreak": "break-word",
+                      }
+                    }
+                  >
+                    "
+                    Opens in a new window
+                    "
+                  </span>
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  externalLinkTitle
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  yes
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#22a",
+                        "wordBreak": "break-word",
+                      }
+                    }
+                  >
+                    "
+                    Opens in a new window
+                    "
+                  </span>
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`Storyshots HyperLink with onClick 1`] = `
-<a
-  href="https://www.edx.org"
-  onClick={[Function]}
-  target="_blank"
->
-  edX.org
-  <span>
-     
-    <span
-      aria-hidden={false}
-      aria-label="Opens in a new window"
-      className="fa fa-external-link"
-      title="Opens in a new window"
-    />
-  </span>
-</a>
+<div>
+  <div
+    style={undefined}
+  >
+    <div
+      style={
+        Object {
+          "WebkitFontSmoothing": "antialiased",
+          "backgroundColor": "#fff",
+          "border": "1px solid #eee",
+          "borderRadius": "2px",
+          "boxShadow": "0px 2px 3px rgba(0, 0, 0, 0.05)",
+          "color": "#444",
+          "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "marginBottom": "20px",
+          "marginTop": "20px",
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "borderBottom": "1px solid #eee",
+            "marginBottom": 10,
+            "paddingTop": 10,
+          }
+        }
+      >
+        <h1
+          style={
+            Object {
+              "fontSize": "35px",
+              "margin": 0,
+              "padding": 0,
+            }
+          }
+        >
+          HyperLink
+        </h1>
+        <h2
+          style={
+            Object {
+              "fontSize": "22px",
+              "fontWeight": 400,
+              "margin": "0 0 10px 0",
+              "padding": 0,
+            }
+          }
+        >
+          with onClick
+        </h2>
+      </div>
+    </div>
+  </div>
+  <div
+    style={Object {}}
+  >
+    <a
+      href="https://www.edx.org"
+      onClick={[Function]}
+      target="_blank"
+    >
+      edX.org
+      <span>
+         
+        <span
+          aria-hidden={false}
+          aria-label="Opens in a new window"
+          className="fa fa-external-link"
+          title="Opens in a new window"
+        />
+      </span>
+    </a>
+  </div>
+  <div
+    style={undefined}
+  >
+    <div
+      style={
+        Object {
+          "WebkitFontSmoothing": "antialiased",
+          "backgroundColor": "#fff",
+          "border": "1px solid #eee",
+          "borderRadius": "2px",
+          "boxShadow": "0px 2px 3px rgba(0, 0, 0, 0.05)",
+          "color": "#444",
+          "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "marginBottom": "20px",
+          "marginTop": "20px",
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      
+      <div>
+        <h1
+          style={
+            Object {
+              "borderBottom": "1px solid #EEE",
+              "fontSize": "25px",
+              "margin": "20px 0 0 0",
+              "padding": "0 0 5px 0",
+            }
+          }
+        >
+          Story Source
+        </h1>
+        <pre
+          style={
+            Object {
+              "backgroundColor": "#fafafa",
+              "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
+              "fontSize": ".88em",
+              "lineHeight": 1.5,
+              "overflowX": "scroll",
+              "padding": ".5rem",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "paddingLeft": 18,
+                "paddingRight": 3,
+              }
+            }
+          >
+            <span
+              style={
+                Object {
+                  "color": "#777",
+                }
+              }
+            >
+              &lt;
+              Hyperlink
+            </span>
+            <span>
+              <span>
+                <span>
+                  <br />
+                    
+                </span>
+                <span
+                  style={Object {}}
+                >
+                  destination
+                </span>
+                <span>
+                  =
+                  <span
+                    style={Object {}}
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#22a",
+                          "wordBreak": "break-word",
+                        }
+                      }
+                    >
+                      "
+                      https://www.edx.org
+                      "
+                    </span>
+                  </span>
+                </span>
+              </span>
+              <span>
+                <span>
+                  <br />
+                    
+                </span>
+                <span
+                  style={Object {}}
+                >
+                  content
+                </span>
+                <span>
+                  =
+                  <span
+                    style={Object {}}
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#22a",
+                          "wordBreak": "break-word",
+                        }
+                      }
+                    >
+                      "
+                      edX.org
+                      "
+                    </span>
+                  </span>
+                </span>
+              </span>
+              <span>
+                <span>
+                  <br />
+                    
+                </span>
+                <span
+                  style={Object {}}
+                >
+                  target
+                </span>
+                <span>
+                  =
+                  <span
+                    style={Object {}}
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#22a",
+                          "wordBreak": "break-word",
+                        }
+                      }
+                    >
+                      "
+                      _blank
+                      "
+                    </span>
+                  </span>
+                </span>
+              </span>
+              <span>
+                <span>
+                  <br />
+                    
+                </span>
+                <span
+                  style={Object {}}
+                >
+                  onClick
+                </span>
+                <span>
+                  =
+                  <span
+                    style={Object {}}
+                  >
+                    <span>
+                      {
+                      <span
+                        style={
+                          Object {
+                            "color": "#170",
+                          }
+                        }
+                      >
+                        onClick()
+                      </span>
+                      }
+                    </span>
+                  </span>
+                </span>
+                <br />
+              </span>
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#777",
+                }
+              }
+            >
+              /&gt;
+            </span>
+          </div>
+        </pre>
+      </div>
+      <div>
+        <h1
+          style={
+            Object {
+              "borderBottom": "1px solid #EEE",
+              "fontSize": "25px",
+              "margin": "20px 0 0 0",
+              "padding": "0 0 5px 0",
+            }
+          }
+        >
+          Prop Types
+        </h1>
+        <div>
+          <h2
+            style={
+              Object {
+                "margin": "20px 0 0 0",
+              }
+            }
+          >
+            "
+            Hyperlink
+            " Component
+          </h2>
+          <table
+            className="css-1ytzlk7"
+          >
+            <thead>
+              <tr>
+                <th
+                  className="css-d52hbj"
+                >
+                  property
+                </th>
+                <th
+                  className="css-d52hbj"
+                >
+                  propType
+                </th>
+                <th
+                  className="css-d52hbj"
+                >
+                  required
+                </th>
+                <th
+                  className="css-d52hbj"
+                >
+                  default
+                </th>
+                <th
+                  className="css-d52hbj"
+                >
+                  description
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  destination
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  yes
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  -
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  content
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  yes
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  -
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  target
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  -
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#22a",
+                        "wordBreak": "break-word",
+                      }
+                    }
+                  >
+                    "
+                    _self
+                    "
+                  </span>
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  onClick
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  -
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  <span>
+                    {
+                    <span
+                      style={
+                        Object {
+                          "color": "#170",
+                        }
+                      }
+                    >
+                      onClick()
+                    </span>
+                    }
+                  </span>
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  externalLinkAlternativeText
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  yes
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#22a",
+                        "wordBreak": "break-word",
+                      }
+                    }
+                  >
+                    "
+                    Opens in a new window
+                    "
+                  </span>
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+              <tr>
+                <td
+                  className="css-1ygfcef"
+                >
+                  externalLinkTitle
+                </td>
+                <td
+                  className="css-1ygfcef"
+                >
+                  <span />
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  yes
+                </td>
+                <td
+                  className="css-d52hbj"
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#22a",
+                        "wordBreak": "break-word",
+                      }
+                    }
+                  >
+                    "
+                    Opens in a new window
+                    "
+                  </span>
+                </td>
+                <td
+                  className="css-d52hbj"
+                />
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`Storyshots Icon basic usage 1`] = `

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,13 +1,21 @@
 import React from 'react';
 import { configure, addDecorator } from '@storybook/react';
 import { setOptions } from '@storybook/addon-options';
+import { setDefaults } from '@storybook/addon-info';
 
 import CssJail from '../src/CssJail';
+
+setDefaults({
+  inline: true,
+  header: true,
+  source: true,
+});
 
 setTimeout(() => setOptions({
   name: '💎 PARAGON',
   url: 'https://github.com/edx/paragon',
   showDownPanel: true,
+  downPanelInRight: true,
 }), 1000);
 
 const req = require.context('../src', true, /\.stories\.jsx$/);

--- a/package-lock.json
+++ b/package-lock.json
@@ -534,6 +534,42 @@
         "global": "4.3.2"
       }
     },
+    "@storybook/addon-info": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-info/-/addon-info-3.3.12.tgz",
+      "integrity": "sha512-WAUgw3TgvHgd+OdydQgpjXRTRW+0a+UHoYPNrmqDFWdiOhcTO2HQHfe3X/wF3w6gY1nUX2dn4uHts8n6fblX1Q==",
+      "dev": true,
+      "requires": {
+        "@storybook/client-logger": "3.3.12",
+        "@storybook/components": "3.3.12",
+        "babel-runtime": "6.26.0",
+        "global": "4.3.2",
+        "marksy": "6.0.3",
+        "nested-object-assign": "1.0.2",
+        "prop-types": "15.6.0",
+        "react-addons-create-fragment": "15.6.2",
+        "util-deprecate": "1.0.2"
+      },
+      "dependencies": {
+        "@storybook/client-logger": {
+          "version": "3.3.12",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-3.3.12.tgz",
+          "integrity": "sha512-+ZkVmNkSpbGhH7YvjbY3GO//D6b7ovn0KPYA2Llr00AoIhxWaSke3hOtoK++bRLHpH0MrbfBDrE0NLyrIvuG2w==",
+          "dev": true
+        },
+        "@storybook/components": {
+          "version": "3.3.12",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.3.12.tgz",
+          "integrity": "sha512-G0YgV629c74vytH1HsuuFHkwD0mDGGMUnGdrH/e9ARHrHXAG2tBpN5w7oUSNj2EPcYBfUT9EPDHchRs8WZoc7A==",
+          "dev": true,
+          "requires": {
+            "glamor": "2.20.40",
+            "glamorous": "4.11.4",
+            "prop-types": "15.6.0"
+          }
+        }
+      }
+    },
     "@storybook/addon-links": {
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.3.10.tgz",
@@ -2991,6 +3027,12 @@
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         }
       }
+    },
+    "babel-standalone": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-standalone/-/babel-standalone-6.26.0.tgz",
+      "integrity": "sha1-Ffs9NfLEVmlYFevx7Zb+fwFbaIY=",
+      "dev": true
     },
     "babel-template": {
       "version": "6.26.0",
@@ -10324,6 +10366,16 @@
         "marked": "0.3.12"
       }
     },
+    "markdown-loader-jest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-loader-jest/-/markdown-loader-jest-0.1.1.tgz",
+      "integrity": "sha512-osdgJgjxP/9C+vcIkTxU5p91C3+IkD2yY+SvG4GcFOOfAK0mixqepDSkNdMIsCf10KK9DfHjPUslnzKLH1tktg==",
+      "dev": true,
+      "requires": {
+        "html-loader": "0.5.5",
+        "markdown-loader": "2.0.2"
+      }
+    },
     "marked": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
@@ -10368,6 +10420,17 @@
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
+      }
+    },
+    "marksy": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/marksy/-/marksy-6.0.3.tgz",
+      "integrity": "sha512-k9r4HIpKlreInh6IVDGxhRs0veCr6WfLwP6lr2HXG8so+N6m6rfFKSpik9ZbvnTfKvdPhehwBWT5W+Fli29Ebg==",
+      "dev": true,
+      "requires": {
+        "babel-standalone": "6.26.0",
+        "he": "1.1.1",
+        "marked": "0.3.12"
       }
     },
     "math-expression-evaluator": {
@@ -10720,6 +10783,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
       "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
+      "dev": true
+    },
+    "nested-object-assign": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nested-object-assign/-/nested-object-assign-1.0.2.tgz",
+      "integrity": "sha512-Ma9vkvU+v0/dPUMNQxu/6Ah2PoU+x52mxkn4FKhofJrzYocSds5eSpgMEdGSjM4IEqkHUqGugioI/+mgq9eBfw==",
       "dev": true
     },
     "no-case": {
@@ -14109,6 +14178,17 @@
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
         "prop-types": "15.6.0"
+      }
+    },
+    "react-addons-create-fragment": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.6.2.tgz",
+      "integrity": "sha1-o5TefCx77Na1R1uhuXrEcs58dPg=",
+      "dev": true,
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
       }
     },
     "react-docgen": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@commitlint/prompt-cli": "^6.0.2",
     "@storybook/addon-actions": "^3.3.10",
     "@storybook/addon-console": "^1.0.0",
+    "@storybook/addon-info": "^3.3.12",
     "@storybook/addon-options": "^3.3.10",
     "@storybook/addon-storyshots": "^3.3.10",
     "@storybook/addons": "^3.3.10",
@@ -76,6 +77,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^22.0.4",
     "jest-cli": "^22.0.4",
+    "markdown-loader-jest": "^0.1.1",
     "node-sass": "^4.5.3",
     "postcss-scss": "^1.0.1",
     "react-router-dom": "^4.1.1",
@@ -91,6 +93,10 @@
     "webpack-dev-server": "^2.4.4"
   },
   "jest": {
+    "transform": {
+      "^.+\\.md?$": "markdown-loader-jest",
+      "^.+\\.jsx?$": "<rootDir>/node_modules/babel-jest"
+    },
     "setupFiles": [
       "./src/setupTest.js"
     ],

--- a/src/Hyperlink/Hyperlink.stories.jsx
+++ b/src/Hyperlink/Hyperlink.stories.jsx
@@ -3,6 +3,9 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { setConsoleOptions } from '@storybook/addon-console';
+import { withInfo } from '@storybook/addon-info';
+import FontAwesomeStyles from 'font-awesome/css/font-awesome.min.css';
+import README from './README.md';
 
 import Hyperlink from './index';
 
@@ -16,31 +19,27 @@ const onClick = (event) => {
   action('HyperLink Click');
 };
 
+const wrapComponent = component => (
+  withInfo({ styles: FontAwesomeStyles }, README)(() => component)
+);
+
 storiesOf('HyperLink', module)
-  .add('minimal usage', () => (
-    <Hyperlink
-      destination="https://en.wikipedia.org/wiki/Hyperlink"
-      content="edX.org"
-    />
-  ))
-  .add('with blank target', () => (
-    <Hyperlink
-      destination="https://www.edx.org"
-      content="edX.org"
-      target="_blank"
-    />
-  ))
-  .add('with onClick', () => (
-    <Hyperlink
-      destination="https://www.edx.org"
-      content="edX.org"
-      target="_blank"
-      onClick={onClick}
-    />
-  ))
-  .add('with icon as content', () => (
-    <Hyperlink
-      destination="https://www.edx.org"
-      content={(<span className="fa fa-book" />)}
-    />
-  ));
+  .add('minimal usage', wrapComponent(<Hyperlink
+    destination="https://en.wikipedia.org/wiki/Hyperlink"
+    content="edX.org"
+  />))
+  .add('with blank target', wrapComponent(<Hyperlink
+    destination="https://www.edx.org"
+    content="edX.org"
+    target="_blank"
+  />))
+  .add('with onClick', wrapComponent(<Hyperlink
+    destination="https://www.edx.org"
+    content="edX.org"
+    target="_blank"
+    onClick={onClick}
+  />))
+  .add('with icon as content', wrapComponent(<Hyperlink
+    destination="https://www.edx.org"
+    content={(<span className="fa fa-book" />)}
+  />));


### PR DESCRIPTION
Ok, let's try this again (after #144 crashed and burned).

[`storybook/addon-info`](https://github.com/storybooks/storybook/tree/master/addons/info) allows you to build storybooks that look like

![image](https://user-images.githubusercontent.com/8136030/36065150-b167ff80-0e64-11e8-8334-514132ea24b5.png)

I would argue this is a significantly better user experience when looking at various stories.