### PR TITLE
docs(readme): document non-changelog commit types

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Paragon currently uses [the default conventional Angular changelog rules](https:
 2. `fix` (`patch` release)
 3. `perf` (`patch` release)
 
+There are other commit types that will not trigger a release that you can use at your own discretion. Suggested prefixes are `docs`, `chore`, `style`, `refactor`, and `test` for non-changelog related tasks.
+
 #### Breaking Changes
 
 Any of the previous `3` commit types **combined with `BREAKING CHANGE` in the commit message body** will trigger a `major` version release.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Paragon currently uses [the default conventional Angular changelog rules](https:
 2. `fix` (`patch` release)
 3. `perf` (`patch` release)
 
-There are other commit types that will not trigger a release that you can use at your own discretion. Suggested prefixes are `docs`, `chore`, `style`, `refactor`, and `test` for non-changelog related tasks.
+[There are other commit types](https://github.com/marionebl/commitlint/blob/master/%40commitlint/config-angular-type-enum/index.js#L1-L12) that will not trigger a release that you can use at your own discretion. Suggested prefixes are `docs`, `chore`, `style`, `refactor`, and `test` for non-changelog related tasks.
 
 #### Breaking Changes
 


### PR DESCRIPTION
Grabbed these from https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular#type