### PR TITLE
build(travis): suppress emails for successful builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ notifications:
     recipients:
       - arizzitano@edx.org
       - jbradley@edx.org
+    on_success: never
     on_failure: always
   hipchat:
     rooms:


### PR DESCRIPTION
I thought #143 took care of this but apparently not.

![image](https://user-images.githubusercontent.com/8136030/36567967-637b6ae6-17f6-11e8-9bb2-487901bdc75a.png)

![alt-text](https://media.giphy.com/media/xUOxf60LnwVrh70jO8/giphy.gif)

When (if) this build succeeds I (and @arizzitano) shouldn't get a single damn email.