### PR TITLE
build(webpack): keep babel config only in .babelrc

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,9 +41,6 @@ module.exports = targetProperties.map(config => ({
         use: [
           {
             loader: 'babel-loader',
-            options: {
-              presets: ['env'],
-            },
           },
           { loader: 'source-map-loader' },
         ],


### PR DESCRIPTION
I think that specifying the preset option in the webpack config will override whatever we have in the `.babelrc`, which was causing ES6 code to end up in the themeable target (the "env" preset compiles down to ES6 stuff by default).