### PR TITLE
style(import): remove unnecessary Hyperlink import

### DIFF
--- a/src/Hyperlink/Hyperlink.stories.jsx
+++ b/src/Hyperlink/Hyperlink.stories.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies, no-console */
 import React from 'react';
-import { storiesOf, addDecorator } from '@storybook/react'; // eslint-disable-line no-unused-vars
+import { storiesOf } from '@storybook/react';
 import centered from '@storybook/addon-centered';
 import { checkA11y } from '@storybook/addon-a11y';
 import { action } from '@storybook/addon-actions';


### PR DESCRIPTION
Resolves #151 

**TL;DR** - **eslint: 1 - Bae Jadley: 0**

![alt-text](https://media.giphy.com/media/LbfT5qdS9m1zy/giphy.gif)

[You only need to import `addDecorator` from `@storybook/react` **when adding a decorator globally**](https://storybook.js.org/addons/introduction/#storybook-decorators). 

And when you do, you actually call the gosh darn method, vs. you know, not calling the imported method (`#chainedmethods`).

![image](https://user-images.githubusercontent.com/8136030/37093548-b38fd8fa-21dd-11e8-92f6-a7851015ffab.png)

This import was a remnant from when I was thinking of installing it globally before deciding to just install it a Story at a time. 

This means I can change the `disable-line` in #160.

cc: @Mjloturco 