### PR TITLE
fix(webpack): transpile isemail to es5

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,7 +37,11 @@ module.exports = targetProperties.map(config => ({
     rules: [
       {
         test: /\.(js|jsx)$/,
-        exclude: /(node_modules)/,
+        include: [
+          path.resolve(__dirname, 'src'),
+          // isemail needs to be transpiled to es5: https://github.com/hapijs/isemail/issues/158
+          path.resolve(__dirname, 'node_modules/isemail'),
+        ],
         use: [
           {
             loader: 'babel-loader',


### PR DESCRIPTION
Paragon's themeable and static builds were including some es6 syntax (arrow functions) because of the isemail package. We have to transpile it to es5 ourselves.

Also, I'm using `include` instead of `exclude` to make it more explicit about what babel is touching.