### PR TITLE
fix(build): builds are now es5 compliant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5373,11 +5373,11 @@
       }
     },
     "email-prop-type": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/email-prop-type/-/email-prop-type-1.1.3.tgz",
-      "integrity": "sha512-EXtNRkInrFBtX3m1cmVK30AyvZSP9c0GkOGGiNBXCTmftSc5YWmAJlHqS2OrT6VlnewVAB/7vAvzu1pX0Kzj8w==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/email-prop-type/-/email-prop-type-1.1.4.tgz",
+      "integrity": "sha512-NiYia/pDZ7woY3mLRxHdExQQ+eLfOCTTDHLG/v/W/9Yf2M/OwifoO/sszXDA9WQl3aUZqMW2rigI+h7AW0FtgA==",
       "requires": {
-        "isemail": "3.1.0"
+        "isemail-es5": "3.1.1"
       }
     },
     "emoji-regex": {
@@ -9312,10 +9312,10 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
-    "isemail": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.0.tgz",
-      "integrity": "sha512-Ke15MBbbhyIhZzWheiWuRlTO81tTH4RQvrbJFpVzJce8oyVrCVSDdrcw4TcyMsaS/fMGJSbU3lTsqCGDKwrzww==",
+    "isemail-es5": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isemail-es5/-/isemail-es5-3.1.1.tgz",
+      "integrity": "sha512-ocfNWbNWikQhoEeKS6ArfVouyXHGmjsZzKEX6aCtKcI4ltasAWgMDqcOPE62QMXqmPSV+sYXtY4vsHEgmoazzw==",
       "requires": {
         "punycode": "2.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@edx/edx-bootstrap": "^0.4.2",
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.5",
-    "email-prop-type": "^1.1.3",
+    "email-prop-type": "^1.1.4",
     "font-awesome": "^4.7.0",
     "mailto-link": "^1.0.0",
     "prop-types": "^15.5.8",


### PR DESCRIPTION
As documented in #175, [`hapijs/isemail`](https://github.com/hapijs/isemail) is not `ES5` compliant.

I forked `isemail` to [`jaebradley/isemail`](https://github.com/jaebradley/isemail) and published an `ES5` compliant package at [`isemail-es5`](https://www.npmjs.com/package/isemail-es5).

I then updated [`email-prop-type` to `1.1.4`](https://github.com/jaebradley/email-prop-type/releases/tag/v1.1.4) which uses `isemail-es5` instead of `isemail`.

`static/index.js` and `themable/index.js` now seem to be `ES5` compliant.