### PR TITLE
feat(table): Add tableFixed option to set col widths

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -4909,7 +4909,9 @@ exports[`Storyshots Table default heading 1`] = `
   <thead
     className="thead-default"
   >
-    <tr>
+    <tr
+      className=""
+    >
       <th
         className=""
         scope="col"
@@ -4933,59 +4935,272 @@ exports[`Storyshots Table default heading 1`] = `
     </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Lil Bub
       </td>
-      <td>
+      <td
+        className=""
+      >
         weird tongue
       </td>
-      <td>
+      <td
+        className=""
+      >
         brown tabby
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Grumpy Cat
       </td>
-      <td>
+      <td
+        className=""
+      >
         serving moods
       </td>
-      <td>
+      <td
+        className=""
+      >
         siamese
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Smoothie
       </td>
-      <td>
+      <td
+        className=""
+      >
         modeling
       </td>
-      <td>
+      <td
+        className=""
+      >
         orange tabby
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Maru
       </td>
-      <td>
+      <td
+        className=""
+      >
         being a lovable oaf
       </td>
-      <td>
+      <td
+        className=""
+      >
         brown tabby
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Keyboard Cat
       </td>
-      <td>
+      <td
+        className=""
+      >
         piano virtuoso
       </td>
-      <td>
+      <td
+        className=""
+      >
         orange tabby
+      </td>
+    </tr>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
+        Long Cat
+      </td>
+      <td
+        className=""
+      >
+        being loooooooooooooooooooooooooooooooooooooooooooooooooooooong
+      </td>
+      <td
+        className=""
+      >
+        russian white
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`Storyshots Table fixed 1`] = `
+<table
+  className="table"
+>
+  <caption>
+    Famous Internet Cats
+  </caption>
+  <thead
+    className=""
+  >
+    <tr
+      className="d-flex"
+    >
+      <th
+        className="col-3"
+        scope="col"
+      >
+        Name
+      </th>
+      <th
+        className="col-6"
+        scope="col"
+      >
+        Famous For
+      </th>
+      <th
+        className="col-3"
+        scope="col"
+      >
+        <span
+          className="sr-only"
+        />
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr
+      className="d-flex"
+    >
+      <td
+        className="col-3"
+      >
+        Lil Bub
+      </td>
+      <td
+        className="col-6"
+      >
+        weird tongue
+      </td>
+      <td
+        className="col-3"
+      >
+        brown tabby
+      </td>
+    </tr>
+    <tr
+      className="d-flex"
+    >
+      <td
+        className="col-3"
+      >
+        Grumpy Cat
+      </td>
+      <td
+        className="col-6"
+      >
+        serving moods
+      </td>
+      <td
+        className="col-3"
+      >
+        siamese
+      </td>
+    </tr>
+    <tr
+      className="d-flex"
+    >
+      <td
+        className="col-3"
+      >
+        Smoothie
+      </td>
+      <td
+        className="col-6"
+      >
+        modeling
+      </td>
+      <td
+        className="col-3"
+      >
+        orange tabby
+      </td>
+    </tr>
+    <tr
+      className="d-flex"
+    >
+      <td
+        className="col-3"
+      >
+        Maru
+      </td>
+      <td
+        className="col-6"
+      >
+        being a lovable oaf
+      </td>
+      <td
+        className="col-3"
+      >
+        brown tabby
+      </td>
+    </tr>
+    <tr
+      className="d-flex"
+    >
+      <td
+        className="col-3"
+      >
+        Keyboard Cat
+      </td>
+      <td
+        className="col-6"
+      >
+        piano virtuoso
+      </td>
+      <td
+        className="col-3"
+      >
+        orange tabby
+      </td>
+    </tr>
+    <tr
+      className="d-flex"
+    >
+      <td
+        className="col-3"
+      >
+        Long Cat
+      </td>
+      <td
+        className="col-6"
+      >
+        being loooooooooooooooooooooooooooooooooooooooooooooooooooooong
+      </td>
+      <td
+        className="col-3"
+      >
+        russian white
       </td>
     </tr>
   </tbody>
@@ -5002,7 +5217,9 @@ exports[`Storyshots Table responsive 1`] = `
   <thead
     className=""
   >
-    <tr>
+    <tr
+      className=""
+    >
       <th
         className=""
         scope="col"
@@ -5026,59 +5243,118 @@ exports[`Storyshots Table responsive 1`] = `
     </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Lil Bub
       </td>
-      <td>
+      <td
+        className=""
+      >
         weird tongue
       </td>
-      <td>
+      <td
+        className=""
+      >
         brown tabby
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Grumpy Cat
       </td>
-      <td>
+      <td
+        className=""
+      >
         serving moods
       </td>
-      <td>
+      <td
+        className=""
+      >
         siamese
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Smoothie
       </td>
-      <td>
+      <td
+        className=""
+      >
         modeling
       </td>
-      <td>
+      <td
+        className=""
+      >
         orange tabby
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Maru
       </td>
-      <td>
+      <td
+        className=""
+      >
         being a lovable oaf
       </td>
-      <td>
+      <td
+        className=""
+      >
         brown tabby
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Keyboard Cat
       </td>
-      <td>
+      <td
+        className=""
+      >
         piano virtuoso
       </td>
-      <td>
+      <td
+        className=""
+      >
         orange tabby
+      </td>
+    </tr>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
+        Long Cat
+      </td>
+      <td
+        className=""
+      >
+        being loooooooooooooooooooooooooooooooooooooooooooooooooooooong
+      </td>
+      <td
+        className=""
+      >
+        russian white
       </td>
     </tr>
   </tbody>
@@ -5095,7 +5371,9 @@ exports[`Storyshots Table sortable 1`] = `
   <thead
     className=""
   >
-    <tr>
+    <tr
+      className=""
+    >
       <th
         className="sortable"
         scope="col"
@@ -5140,58 +5418,117 @@ exports[`Storyshots Table sortable 1`] = `
     </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Smoothie
       </td>
-      <td>
+      <td
+        className=""
+      >
         modeling
       </td>
-      <td>
+      <td
+        className=""
+      >
         orange tabby
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Maru
       </td>
-      <td>
+      <td
+        className=""
+      >
         being a lovable oaf
       </td>
-      <td>
+      <td
+        className=""
+      >
         brown tabby
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
+        Long Cat
+      </td>
+      <td
+        className=""
+      >
+        being loooooooooooooooooooooooooooooooooooooooooooooooooooooong
+      </td>
+      <td
+        className=""
+      >
+        russian white
+      </td>
+    </tr>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Lil Bub
       </td>
-      <td>
+      <td
+        className=""
+      >
         weird tongue
       </td>
-      <td>
+      <td
+        className=""
+      >
         brown tabby
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Keyboard Cat
       </td>
-      <td>
+      <td
+        className=""
+      >
         piano virtuoso
       </td>
-      <td>
+      <td
+        className=""
+      >
         orange tabby
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Grumpy Cat
       </td>
-      <td>
+      <td
+        className=""
+      >
         serving moods
       </td>
-      <td>
+      <td
+        className=""
+      >
         siamese
       </td>
     </tr>
@@ -5209,7 +5546,9 @@ exports[`Storyshots Table table-striped 1`] = `
   <thead
     className=""
   >
-    <tr>
+    <tr
+      className=""
+    >
       <th
         className=""
         scope="col"
@@ -5233,59 +5572,118 @@ exports[`Storyshots Table table-striped 1`] = `
     </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Lil Bub
       </td>
-      <td>
+      <td
+        className=""
+      >
         weird tongue
       </td>
-      <td>
+      <td
+        className=""
+      >
         brown tabby
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Grumpy Cat
       </td>
-      <td>
+      <td
+        className=""
+      >
         serving moods
       </td>
-      <td>
+      <td
+        className=""
+      >
         siamese
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Smoothie
       </td>
-      <td>
+      <td
+        className=""
+      >
         modeling
       </td>
-      <td>
+      <td
+        className=""
+      >
         orange tabby
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Maru
       </td>
-      <td>
+      <td
+        className=""
+      >
         being a lovable oaf
       </td>
-      <td>
+      <td
+        className=""
+      >
         brown tabby
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Keyboard Cat
       </td>
-      <td>
+      <td
+        className=""
+      >
         piano virtuoso
       </td>
-      <td>
+      <td
+        className=""
+      >
         orange tabby
+      </td>
+    </tr>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
+        Long Cat
+      </td>
+      <td
+        className=""
+      >
+        being loooooooooooooooooooooooooooooooooooooooooooooooooooooong
+      </td>
+      <td
+        className=""
+      >
+        russian white
       </td>
     </tr>
   </tbody>
@@ -5302,7 +5700,9 @@ exports[`Storyshots Table unstyled 1`] = `
   <thead
     className=""
   >
-    <tr>
+    <tr
+      className=""
+    >
       <th
         className=""
         scope="col"
@@ -5326,59 +5726,118 @@ exports[`Storyshots Table unstyled 1`] = `
     </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Lil Bub
       </td>
-      <td>
+      <td
+        className=""
+      >
         weird tongue
       </td>
-      <td>
+      <td
+        className=""
+      >
         brown tabby
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Grumpy Cat
       </td>
-      <td>
+      <td
+        className=""
+      >
         serving moods
       </td>
-      <td>
+      <td
+        className=""
+      >
         siamese
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Smoothie
       </td>
-      <td>
+      <td
+        className=""
+      >
         modeling
       </td>
-      <td>
+      <td
+        className=""
+      >
         orange tabby
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Maru
       </td>
-      <td>
+      <td
+        className=""
+      >
         being a lovable oaf
       </td>
-      <td>
+      <td
+        className=""
+      >
         brown tabby
       </td>
     </tr>
-    <tr>
-      <td>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
         Keyboard Cat
       </td>
-      <td>
+      <td
+        className=""
+      >
         piano virtuoso
       </td>
-      <td>
+      <td
+        className=""
+      >
         orange tabby
+      </td>
+    </tr>
+    <tr
+      className=""
+    >
+      <td
+        className=""
+      >
+        Long Cat
+      </td>
+      <td
+        className=""
+      >
+        being loooooooooooooooooooooooooooooooooooooooooooooooooooooong
+      </td>
+      <td
+        className=""
+      >
+        russian white
       </td>
     </tr>
   </tbody>

--- a/src/Table/README.md
+++ b/src/Table/README.md
@@ -12,6 +12,7 @@ Provides a very basic table component with col-scoped headings displayed in the 
 3. `columnSortable` (boolean; optional) specifies at the column-level whether the column is sortable. If `columnSortable` is `true`, a sort button will be rendered in the column table heading. It is only required if `tableSortable` is set to `true`.
 4. `onSort` (function; conditionally required) specifies what function is called when a sortable column is clicked. It is only required if the column's `columnSortable` is set to `true`.
 5. `hideHeader` (boolean; optional) specifies at the column-level whether the column label is visible. A column that is sortable cannot have its label be hidden.
+6. `width` (string; conditionally required) only if `hasFixedColumnWidths` is set to `true`, the `<td>` elements' `class` attributes will be set to this value. This allows restricting columns to specific widths. See [Bootstrap's grid documentation](https://getbootstrap.com/docs/4.0/layout/grid/) for `col` class names that can be used.
 
 The order of objects in `columns` specifies the order of the columns in the table.
 
@@ -24,16 +25,16 @@ Specifies the key of the column that is sorted by default. It is only required i
 ### `defaultSortDirection` (string; conditionally required)
 Specifies the direction the `defaultSortedColumn` is sorted in by default; it will typically be either 'asc' or 'desc'. It is only required if `tableSortable` is set to `true`.
 
-### `caption` (string or element; optional)
+### `caption` (string or element; optional, default: `null`)
 Specifies a descriptive caption to be applied to the entire table.
 
-### `className` (string array; optional)
+### `className` (string array; optional; default: `[]`)
 Specifies Bootstrap class names to apply to the table. See [Bootstrap's table documentation](https://getbootstrap.com/docs/4.0/content/tables/) for a list of applicable class names.
 
-### `headingClassName` (string array; optional)
+### `headingClassName` (string array; optional; default: `[]`)
 Specifies Bootstrap class names to apply to the table heading. Options are detailed in [Bootstrap's docs](https://getbootstrap.com/docs/4.0/content/tables/#table-head-options).
 
-### `tableSortable` (boolean; optional)
+### `tableSortable` (boolean; optional; default: `false`)
 Specifies whether the table is sortable. This setting supercedes column-level sortability, so if it is `false`, no sortable components will be rendered.
 
 ### `sortButtonsScreenReaderText` (object; conditionally required)
@@ -44,3 +45,16 @@ Specifies the screen reader only text that accompanies the sort buttons for sort
 3. `defaultText`: (string) specifies the screen reader only text for sort buttons that are not engaged.
 
 It is only required if `tableSortable` is set to `true`.
+
+Default:
+
+```javascript
+{
+  asc: 'sort ascending',
+  desc: 'sort descending',
+  defaultText: 'click to sort',
+}
+```
+
+### `hasFixedColumnWidths` (boolean; optional; default: `false`)
+Specifies whether the table's columns have fixed widths. Every element in `columns` must define a `width` if this is `true`.

--- a/src/Table/Table.scss
+++ b/src/Table/Table.scss
@@ -6,3 +6,7 @@
   @extend .p-0;
   font-weight: $font-weight-bold;
 }
+
+.table th, .table td {
+  word-wrap: break-word;
+}

--- a/src/Table/Table.stories.jsx
+++ b/src/Table/Table.stories.jsx
@@ -29,6 +29,11 @@ const catData = [
     color: 'orange tabby',
     famous_for: 'piano virtuoso',
   },
+  {
+    name: 'Long Cat',
+    color: 'russian white',
+    famous_for: 'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
+  },
 ];
 
 const catColumns = [
@@ -37,12 +42,14 @@ const catColumns = [
     key: 'name',
     columnSortable: true,
     onSort: () => {},
+    width: 'col-3',
   },
   {
     label: 'Famous For',
     key: 'famous_for',
     columnSortable: false,
     onSort: () => {},
+    width: 'col-6',
   },
   {
     label: 'Coat Color',
@@ -50,6 +57,7 @@ const catColumns = [
     columnSortable: false,
     hideHeader: true,
     onSort: () => {},
+    width: 'col-3',
   },
 ];
 
@@ -113,4 +121,12 @@ storiesOf('Table', module)
       defaultSortedColumn={catColumns[0].key}
       defaultSortDirection="desc"
     />);
-  });
+  })
+  .add('fixed', () => (
+    <Table
+      data={catData}
+      columns={catColumns}
+      caption="Famous Internet Cats"
+      hasFixedColumnWidths
+    />
+  ));

--- a/src/Table/Table.test.jsx
+++ b/src/Table/Table.test.jsx
@@ -55,6 +55,29 @@ const sortableProps = {
   defaultSortDirection: 'desc',
 };
 
+const fixedColumnProps = {
+  num: { width: 'col-4' },
+  x2: { width: 'col-2' },
+  sq: { width: 'col-3' },
+  i: { width: 'col-3' },
+};
+
+const fixedColumns = props.columns.map(column => ({
+  ...column,
+  ...fixedColumnProps[column.key],
+}));
+
+const fixedProps = {
+  ...props,
+  columns: fixedColumns,
+  hasFixedColumnWidths: true,
+};
+
+const propsWithColWidths = {
+  ...props,
+  columns: fixedColumns,
+};
+
 describe('<Table />', () => {
   describe('renders', () => {
     const wrapper = shallow(<Table {...props} />);
@@ -258,6 +281,48 @@ describe('<Table />', () => {
       expect(x2Spy).toHaveBeenCalledTimes(1);
 
       expect(x2Spy).toBeCalledWith('desc');
+    });
+  });
+  describe('that is fixed', () => {
+    const wrapper = shallow(<Table {...fixedProps} />);
+
+    it('with col width classnames on headings', () => {
+      const tableHeadings = wrapper.find('th');
+
+      expect(tableHeadings).toHaveLength(fixedProps.columns.length);
+      expect(tableHeadings.at(0).hasClass('col-4')).toEqual(true);
+      expect(tableHeadings.at(1).hasClass('col-2')).toEqual(true);
+      expect(tableHeadings.at(2).hasClass('col-3')).toEqual(true);
+    });
+
+    it('with col width classnames on cells', () => {
+      const tableCells = wrapper.find('td');
+
+      expect(tableCells).toHaveLength(fixedProps.columns.length * fixedProps.data.length);
+      expect(tableCells.at(0).hasClass('col-4')).toEqual(true);
+      expect(tableCells.at(1).hasClass('col-2')).toEqual(true);
+      expect(tableCells.at(2).hasClass('col-3')).toEqual(true);
+    });
+  });
+  describe('that is not fixed with col widths', () => {
+    const wrapper = shallow(<Table {...propsWithColWidths} />);
+
+    it('with no col width classnames on headings', () => {
+      const tableHeadings = wrapper.find('th');
+
+      expect(tableHeadings).toHaveLength(fixedProps.columns.length);
+      expect(tableHeadings.at(0).hasClass('col-4')).toEqual(false);
+      expect(tableHeadings.at(1).hasClass('col-2')).toEqual(false);
+      expect(tableHeadings.at(2).hasClass('col-3')).toEqual(false);
+    });
+
+    it('with no col width classnames on cells', () => {
+      const tableCells = wrapper.find('td');
+
+      expect(tableCells).toHaveLength(fixedProps.columns.length * fixedProps.data.length);
+      expect(tableCells.at(0).hasClass('col-4')).toEqual(false);
+      expect(tableCells.at(1).hasClass('col-2')).toEqual(false);
+      expect(tableCells.at(2).hasClass('col-3')).toEqual(false);
     });
   });
 });

--- a/src/Table/index.jsx
+++ b/src/Table/index.jsx
@@ -93,10 +93,13 @@ class Table extends React.Component {
       <thead
         className={classNames(...this.props.headingClassName.map(className => styles[className]))}
       >
-        <tr>
+        <tr className={classNames({ 'd-flex': this.props.hasFixedColumnWidths })}>
           {this.props.columns.map(col => (
             <th
-              className={this.props.tableSortable ? classNames({ sortable: col.columnSortable }) : ''}
+              className={classNames(
+                { sortable: this.props.tableSortable && col.columnSortable },
+                this.props.hasFixedColumnWidths ? col.width : null,
+              )}
               key={col.key}
               scope="col"
             >
@@ -112,9 +115,14 @@ class Table extends React.Component {
     return (
       <tbody>
         {this.props.data.map((row, i) => (
-          <tr key={i}>
-            {this.props.columns.map(col => (
-              <td key={col.key}>{row[col.key]}</td>
+          <tr key={i} className={classNames({ 'd-flex': this.props.hasFixedColumnWidths })}>
+            {this.props.columns.map(({ key, width }) => (
+              <td
+                key={key}
+                className={classNames(this.props.hasFixedColumnWidths ? width : null)}
+              >
+                {row[key]}
+              </td>
             ))}
           </tr>
         ))}
@@ -153,9 +161,11 @@ Table.propTypes = {
     columnSortable: isRequiredIf(PropTypes.bool, props => props.tableSortable),
     onSort: isRequiredIf(PropTypes.func, props => props.columnSortable),
     hideHeader: PropTypes.bool,
+    width: isRequiredIf(PropTypes.string, props => props.hasFixedColumnWidths),
   })).isRequired,
   headingClassName: PropTypes.arrayOf(PropTypes.string),
   tableSortable: PropTypes.bool,
+  hasFixedColumnWidths: PropTypes.bool,
   /* eslint-disable react/require-default-props */
   defaultSortedColumn: isRequiredIf(PropTypes.string, props => props.tableSortable),
   /* eslint-disable react/require-default-props */
@@ -175,6 +185,7 @@ Table.defaultProps = {
   className: [],
   headingClassName: [],
   tableSortable: false,
+  hasFixedColumnWidths: false,
   sortButtonsScreenReaderText: {
     asc: 'sort ascending',
     desc: 'sort descending',


### PR DESCRIPTION
This is a feature that studio-frontend needs so that long filenames will not make the columns jump around jarringly when filtering or paging. I pulled the classnames from this [stackoverflow answer](https://stackoverflow.com/a/37928581/6620612).

FYI @edx/educator-dahlia 