### PR TITLE
fix(email-prop-type): upgrade to IE11 compatible version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5449,12 +5449,17 @@
       }
     },
     "email-prop-type": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/email-prop-type/-/email-prop-type-1.1.4.tgz",
-      "integrity": "sha512-NiYia/pDZ7woY3mLRxHdExQQ+eLfOCTTDHLG/v/W/9Yf2M/OwifoO/sszXDA9WQl3aUZqMW2rigI+h7AW0FtgA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/email-prop-type/-/email-prop-type-1.1.5.tgz",
+      "integrity": "sha512-I7RYQE3EGDh3GXdBICtx/zKn21720xxW2UGD4y5Pg8zAFoNjtFdh5fHDrHL/xmICiuobMdpXywfV8/FN1rCdQA==",
       "requires": {
-        "isemail-es5": "3.1.1"
+        "email-validator": "1.1.1"
       }
+    },
+    "email-validator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-1.1.1.tgz",
+      "integrity": "sha512-vkcJJZEb7JXDY883Nx1Lkmb6noM3j1SfSt8L9tVFhZPnPQiFq+Nkd5evc77+tRVS4ChTUSr34voThsglI/ja/A=="
     },
     "emoji-regex": {
       "version": "6.5.1",
@@ -9404,21 +9409,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
-    },
-    "isemail-es5": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isemail-es5/-/isemail-es5-3.1.1.tgz",
-      "integrity": "sha512-ocfNWbNWikQhoEeKS6ArfVouyXHGmjsZzKEX6aCtKcI4ltasAWgMDqcOPE62QMXqmPSV+sYXtY4vsHEgmoazzw==",
-      "requires": {
-        "punycode": "2.1.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
-        }
-      }
     },
     "isexe": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@edx/edx-bootstrap": "^0.4.2",
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.5",
-    "email-prop-type": "^1.1.4",
+    "email-prop-type": "^1.1.5",
     "font-awesome": "^4.7.0",
     "mailto-link": "^1.0.0",
     "prop-types": "^15.5.8",


### PR DESCRIPTION
`email-prop-type@1.1.5`, triggered by [`email-prop-type#22`](https://github.com/jaebradley/email-prop-type/pull/22), was verified to be `IE11`-compliant by @thallada. This updates the `email-prop-type` version in Paragon.

cc: @arizzitano 