### PR TITLE
fix(table): fixed: add d-inline to thead & tbody

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -13954,7 +13954,9 @@ exports[`Storyshots Table default heading 1`] = `
       </th>
     </tr>
   </thead>
-  <tbody>
+  <tbody
+    className=""
+  >
     <tr
       className=""
     >
@@ -14081,7 +14083,7 @@ exports[`Storyshots Table fixed 1`] = `
     Famous Internet Cats
   </caption>
   <thead
-    className=""
+    className="d-inline"
   >
     <tr
       className="d-flex"
@@ -14108,7 +14110,9 @@ exports[`Storyshots Table fixed 1`] = `
       </th>
     </tr>
   </thead>
-  <tbody>
+  <tbody
+    className="d-inline"
+  >
     <tr
       className="d-flex"
     >
@@ -14262,7 +14266,9 @@ exports[`Storyshots Table responsive 1`] = `
       </th>
     </tr>
   </thead>
-  <tbody>
+  <tbody
+    className=""
+  >
     <tr
       className=""
     >
@@ -14437,7 +14443,9 @@ exports[`Storyshots Table sortable 1`] = `
       </th>
     </tr>
   </thead>
-  <tbody>
+  <tbody
+    className=""
+  >
     <tr
       className=""
     >
@@ -14591,7 +14599,9 @@ exports[`Storyshots Table table-striped 1`] = `
       </th>
     </tr>
   </thead>
-  <tbody>
+  <tbody
+    className=""
+  >
     <tr
       className=""
     >
@@ -14745,7 +14755,9 @@ exports[`Storyshots Table unstyled 1`] = `
       </th>
     </tr>
   </thead>
-  <tbody>
+  <tbody
+    className=""
+  >
     <tr
       className=""
     >

--- a/src/Table/Table.test.jsx
+++ b/src/Table/Table.test.jsx
@@ -303,6 +303,15 @@ describe('<Table />', () => {
       expect(tableCells.at(1).hasClass('col-2')).toEqual(true);
       expect(tableCells.at(2).hasClass('col-3')).toEqual(true);
     });
+    it('with fixed-related classnames on head, body, and rows', () => {
+      const thead = wrapper.find('thead');
+      const tbody = wrapper.find('tbody');
+      const tr = wrapper.find('tr');
+
+      expect(thead.hasClass('d-inline')).toEqual(true);
+      expect(tbody.hasClass('d-inline')).toEqual(true);
+      expect(tr.at(0).hasClass('d-flex')).toEqual(true);
+    });
   });
   describe('that is not fixed with col widths', () => {
     const wrapper = shallow(<Table {...propsWithColWidths} />);
@@ -323,6 +332,15 @@ describe('<Table />', () => {
       expect(tableCells.at(0).hasClass('col-4')).toEqual(false);
       expect(tableCells.at(1).hasClass('col-2')).toEqual(false);
       expect(tableCells.at(2).hasClass('col-3')).toEqual(false);
+    });
+    it('with no fixed-related classnames on head, body, and rows', () => {
+      const thead = wrapper.find('thead');
+      const tbody = wrapper.find('tbody');
+      const tr = wrapper.find('tr');
+
+      expect(thead.hasClass('d-inline')).toEqual(false);
+      expect(tbody.hasClass('d-inline')).toEqual(false);
+      expect(tr.at(0).hasClass('d-flex')).toEqual(false);
     });
   });
 });

--- a/src/Table/index.jsx
+++ b/src/Table/index.jsx
@@ -91,7 +91,10 @@ class Table extends React.Component {
   getHeadings() {
     return (
       <thead
-        className={classNames(...this.props.headingClassName.map(className => styles[className]))}
+        className={classNames(
+          ...this.props.headingClassName.map(className => styles[className]),
+          { 'd-inline': this.props.hasFixedColumnWidths },
+        )}
       >
         <tr className={classNames({ 'd-flex': this.props.hasFixedColumnWidths })}>
           {this.props.columns.map(col => (
@@ -113,7 +116,7 @@ class Table extends React.Component {
 
   getBody() {
     return (
-      <tbody>
+      <tbody className={classNames({ 'd-inline': this.props.hasFixedColumnWidths })}>
         {this.props.data.map((row, i) => (
           <tr key={i} className={classNames({ 'd-flex': this.props.hasFixedColumnWidths })}>
             {this.props.columns.map(({ key, width }) => (


### PR DESCRIPTION
This is some additional styling that I found out was needed when using `hasFixedColumnWidths` in studio-frontend's table. It doesn't visually change anything in storybook, but `display: inline` prevents the columns from shifting slightly when the cell contents changes in studio-frontend.