### PR TITLE
fix(modal): allow reopening after close

### DIFF
--- a/src/Modal/Modal.test.jsx
+++ b/src/Modal/Modal.test.jsx
@@ -134,6 +134,13 @@ describe('<Modal />', () => {
       wrapper.find('button').at(0).simulate('click');
       expect(spy).toHaveBeenCalledTimes(1);
     });
+    it('reopens after closed', () => {
+      modalOpen(true, wrapper);
+      wrapper.find('button').at(0).simulate('click');
+      modalOpen(false, wrapper);
+      wrapper.setProps({ open: true });
+      modalOpen(true, wrapper);
+    });
   });
   describe('invalid keystrokes do nothing', () => {
     beforeEach(() => {

--- a/src/Modal/index.jsx
+++ b/src/Modal/index.jsx
@@ -31,9 +31,9 @@ class Modal extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.open !== this.props.open) {
-      this.setState({ open: nextProps.open });
+  componentWillReceiveProps({ open }) {
+    if (open !== this.state.open) {
+      this.setState({ open });
     }
   }
 


### PR DESCRIPTION
Modal should re-open if a parent updates its props to `{open: true}`.