### PR TITLE
fix(asinput): allow value of type number or string

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -4709,17 +4709,17 @@ exports[`Storyshots InputText different textual input types 1`] = `
           "",
         ]
       }
-      htmlFor="asInput1"
-      id="label-asInput1"
+      htmlFor="input-search"
+      id="label-input-search"
     >
       Search
     </label>
     <input
-      aria-describedby="error-asInput1"
+      aria-describedby="error-input-search"
       aria-invalid={false}
       className="form-control"
       disabled={false}
-      id="asInput1"
+      id="input-search"
       name="search"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4732,7 +4732,7 @@ exports[`Storyshots InputText different textual input types 1`] = `
     <div
       aria-live="polite"
       className="form-control-feedback"
-      id="error-asInput1"
+      id="error-input-search"
     >
       <span />
     </div>
@@ -4750,17 +4750,17 @@ exports[`Storyshots InputText different textual input types 1`] = `
           "",
         ]
       }
-      htmlFor="asInput1"
-      id="label-asInput1"
+      htmlFor="input-email"
+      id="label-input-email"
     >
       Email
     </label>
     <input
-      aria-describedby="error-asInput1"
+      aria-describedby="error-input-email"
       aria-invalid={false}
       className="form-control"
       disabled={false}
-      id="asInput1"
+      id="input-email"
       name="email"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4773,7 +4773,7 @@ exports[`Storyshots InputText different textual input types 1`] = `
     <div
       aria-live="polite"
       className="form-control-feedback"
-      id="error-asInput1"
+      id="error-input-email"
     >
       <span />
     </div>
@@ -4791,17 +4791,17 @@ exports[`Storyshots InputText different textual input types 1`] = `
           "",
         ]
       }
-      htmlFor="asInput1"
-      id="label-asInput1"
+      htmlFor="input-url"
+      id="label-input-url"
     >
       Url
     </label>
     <input
-      aria-describedby="error-asInput1"
+      aria-describedby="error-input-url"
       aria-invalid={false}
       className="form-control"
       disabled={false}
-      id="asInput1"
+      id="input-url"
       name="url"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4814,7 +4814,7 @@ exports[`Storyshots InputText different textual input types 1`] = `
     <div
       aria-live="polite"
       className="form-control-feedback"
-      id="error-asInput1"
+      id="error-input-url"
     >
       <span />
     </div>
@@ -4832,17 +4832,17 @@ exports[`Storyshots InputText different textual input types 1`] = `
           "",
         ]
       }
-      htmlFor="asInput1"
-      id="label-asInput1"
+      htmlFor="input-tel"
+      id="label-input-tel"
     >
       Telephone
     </label>
     <input
-      aria-describedby="error-asInput1"
+      aria-describedby="error-input-tel"
       aria-invalid={false}
       className="form-control"
       disabled={false}
-      id="asInput1"
+      id="input-tel"
       name="telephone"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4855,7 +4855,7 @@ exports[`Storyshots InputText different textual input types 1`] = `
     <div
       aria-live="polite"
       className="form-control-feedback"
-      id="error-asInput1"
+      id="error-input-tel"
     >
       <span />
     </div>
@@ -4873,17 +4873,17 @@ exports[`Storyshots InputText different textual input types 1`] = `
           "",
         ]
       }
-      htmlFor="asInput1"
-      id="label-asInput1"
+      htmlFor="input-password"
+      id="label-input-password"
     >
       Password
     </label>
     <input
-      aria-describedby="error-asInput1"
+      aria-describedby="error-input-password"
       aria-invalid={false}
       className="form-control"
       disabled={false}
-      id="asInput1"
+      id="input-password"
       name="password"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4896,7 +4896,7 @@ exports[`Storyshots InputText different textual input types 1`] = `
     <div
       aria-live="polite"
       className="form-control-feedback"
-      id="error-asInput1"
+      id="error-input-password"
     >
       <span />
     </div>
@@ -4914,17 +4914,17 @@ exports[`Storyshots InputText different textual input types 1`] = `
           "",
         ]
       }
-      htmlFor="asInput1"
-      id="label-asInput1"
+      htmlFor="input-number"
+      id="label-input-number"
     >
       Number
     </label>
     <input
-      aria-describedby="error-asInput1"
+      aria-describedby="error-input-number"
       aria-invalid={false}
       className="form-control"
       disabled={false}
-      id="asInput1"
+      id="input-number"
       name="number"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4932,12 +4932,12 @@ exports[`Storyshots InputText different textual input types 1`] = `
       required={false}
       themes={Array []}
       type="number"
-      value="42"
+      value={42}
     />
     <div
       aria-live="polite"
       className="form-control-feedback"
-      id="error-asInput1"
+      id="error-input-number"
     >
       <span />
     </div>
@@ -4955,17 +4955,17 @@ exports[`Storyshots InputText different textual input types 1`] = `
           "",
         ]
       }
-      htmlFor="asInput1"
-      id="label-asInput1"
+      htmlFor="input-datetime-local"
+      id="label-input-datetime-local"
     >
       Date and time
     </label>
     <input
-      aria-describedby="error-asInput1"
+      aria-describedby="error-input-datetime-local"
       aria-invalid={false}
       className="form-control"
       disabled={false}
-      id="asInput1"
+      id="input-datetime-local"
       name="datetime-local"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4978,7 +4978,7 @@ exports[`Storyshots InputText different textual input types 1`] = `
     <div
       aria-live="polite"
       className="form-control-feedback"
-      id="error-asInput1"
+      id="error-input-datetime-local"
     >
       <span />
     </div>
@@ -4996,17 +4996,17 @@ exports[`Storyshots InputText different textual input types 1`] = `
           "",
         ]
       }
-      htmlFor="asInput1"
-      id="label-asInput1"
+      htmlFor="input-date"
+      id="label-input-date"
     >
       Date
     </label>
     <input
-      aria-describedby="error-asInput1"
+      aria-describedby="error-input-date"
       aria-invalid={false}
       className="form-control"
       disabled={false}
-      id="asInput1"
+      id="input-date"
       name="date"
       onBlur={[Function]}
       onChange={[Function]}
@@ -5019,7 +5019,7 @@ exports[`Storyshots InputText different textual input types 1`] = `
     <div
       aria-live="polite"
       className="form-control-feedback"
-      id="error-asInput1"
+      id="error-input-date"
     >
       <span />
     </div>
@@ -5037,17 +5037,17 @@ exports[`Storyshots InputText different textual input types 1`] = `
           "",
         ]
       }
-      htmlFor="asInput1"
-      id="label-asInput1"
+      htmlFor="input-month"
+      id="label-input-month"
     >
       Month
     </label>
     <input
-      aria-describedby="error-asInput1"
+      aria-describedby="error-input-month"
       aria-invalid={false}
       className="form-control"
       disabled={false}
-      id="asInput1"
+      id="input-month"
       name="month"
       onBlur={[Function]}
       onChange={[Function]}
@@ -5060,7 +5060,7 @@ exports[`Storyshots InputText different textual input types 1`] = `
     <div
       aria-live="polite"
       className="form-control-feedback"
-      id="error-asInput1"
+      id="error-input-month"
     >
       <span />
     </div>
@@ -5078,17 +5078,17 @@ exports[`Storyshots InputText different textual input types 1`] = `
           "",
         ]
       }
-      htmlFor="asInput1"
-      id="label-asInput1"
+      htmlFor="input-week"
+      id="label-input-week"
     >
       Week
     </label>
     <input
-      aria-describedby="error-asInput1"
+      aria-describedby="error-input-week"
       aria-invalid={false}
       className="form-control"
       disabled={false}
-      id="asInput1"
+      id="input-week"
       name="week"
       onBlur={[Function]}
       onChange={[Function]}
@@ -5101,7 +5101,7 @@ exports[`Storyshots InputText different textual input types 1`] = `
     <div
       aria-live="polite"
       className="form-control-feedback"
-      id="error-asInput1"
+      id="error-input-week"
     >
       <span />
     </div>
@@ -5119,17 +5119,17 @@ exports[`Storyshots InputText different textual input types 1`] = `
           "",
         ]
       }
-      htmlFor="asInput1"
-      id="label-asInput1"
+      htmlFor="input-time"
+      id="label-input-time"
     >
       Time
     </label>
     <input
-      aria-describedby="error-asInput1"
+      aria-describedby="error-input-time"
       aria-invalid={false}
       className="form-control"
       disabled={false}
-      id="asInput1"
+      id="input-time"
       name="time"
       onBlur={[Function]}
       onChange={[Function]}
@@ -5142,7 +5142,7 @@ exports[`Storyshots InputText different textual input types 1`] = `
     <div
       aria-live="polite"
       className="form-control-feedback"
-      id="error-asInput1"
+      id="error-input-time"
     >
       <span />
     </div>
@@ -5160,17 +5160,17 @@ exports[`Storyshots InputText different textual input types 1`] = `
           "",
         ]
       }
-      htmlFor="asInput1"
-      id="label-asInput1"
+      htmlFor="input-color"
+      id="label-input-color"
     >
       Color
     </label>
     <input
-      aria-describedby="error-asInput1"
+      aria-describedby="error-input-color"
       aria-invalid={false}
       className="form-control"
       disabled={false}
-      id="asInput1"
+      id="input-color"
       name="color"
       onBlur={[Function]}
       onChange={[Function]}
@@ -5183,7 +5183,7 @@ exports[`Storyshots InputText different textual input types 1`] = `
     <div
       aria-live="polite"
       className="form-control-feedback"
-      id="error-asInput1"
+      id="error-input-color"
     >
       <span />
     </div>

--- a/src/InputText/InputText.stories.jsx
+++ b/src/InputText/InputText.stories.jsx
@@ -101,72 +101,84 @@ storiesOf('InputText', module)
         label="Search"
         value="what is paragon"
         type="search"
+        id="input-search"
       />
       <InputText
         name="email"
         label="Email"
         value="paragon@edx.org"
         type="email"
+        id="input-email"
       />
       <InputText
         name="url"
         label="Url"
         value="https://edx.github.io/paragon"
         type="url"
+        id="input-url"
       />
       <InputText
         name="telephone"
         label="Telephone"
         value="1-(555)-555-5555"
         type="tel"
+        id="input-tel"
       />
       <InputText
         name="password"
         label="Password"
         value="hunter2"
         type="password"
+        id="input-password"
       />
       <InputText
         name="number"
         label="Number"
-        value="42"
+        value={42}
         type="number"
+        id="input-number"
       />
       <InputText
         name="datetime-local"
         label="Date and time"
         value="2017-04-27T13:45:00"
         type="datetime-local"
+        id="input-datetime-local"
       />
       <InputText
         name="date"
         label="Date"
         value="2017-04-27"
         type="date"
+        id="input-date"
       />
       <InputText
         name="month"
         label="Month"
         value="2017-04"
         type="month"
+        id="input-month"
       />
       <InputText
         name="week"
         label="Week"
         value="2017-W33"
         type="week"
+        id="input-week"
       />
       <InputText
         name="time"
         label="Time"
         value="13:45:00"
         type="time"
+        id="input-time"
       />
       <InputText
         name="color"
         label="Color"
         value="#BF472C"
         type="color"
+        id="input-color"
       />
     </form>
   ))

--- a/src/asInput/README.md
+++ b/src/asInput/README.md
@@ -40,5 +40,5 @@ Handles all necessary props that are related to Input typed components.
 ### `validationMessage` (string; optional)
 `validationMessage` specifies the message to display when `isValid` is false.  Only used if `validator` is not specified. The default is an empty string.
 
-### `value` (string; optional)
+### `value` (string or number; optional)
 `value` specifies the value for the value property within the component. The default is an empty string.

--- a/src/asInput/index.jsx
+++ b/src/asInput/index.jsx
@@ -14,7 +14,7 @@ export const inputProps = {
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   name: PropTypes.string.isRequired,
   id: PropTypes.string,
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   description: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.element,


### PR DESCRIPTION
Input elements of type "number" have a Number value. React accepts a string or a number.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#Value

FYI: @MichaelRoytman I think that this will resolve the console errors we are seeing in studio-frontend.