### PR TITLE
fix(asinput): add dangerIconDescription as prop

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -1135,6 +1135,42 @@ exports[`Storyshots CheckBox basic usage 1`] = `
                       <td
                         className="css-1ygfcef"
                       >
+                        dangerIconDescription
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#22a",
+                              "wordBreak": "break-word",
+                            }
+                          }
+                        >
+                          "
+                          
+                          "
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
                         description
                       </td>
                       <td
@@ -2005,6 +2041,42 @@ exports[`Storyshots CheckBox call a function 1`] = `
                         className="css-1ygfcef"
                       >
                         value
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#22a",
+                              "wordBreak": "break-word",
+                            }
+                          }
+                        >
+                          "
+                          
+                          "
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        dangerIconDescription
                       </td>
                       <td
                         className="css-1ygfcef"
@@ -3219,6 +3291,42 @@ exports[`Storyshots CheckBox default checked 1`] = `
                       <td
                         className="css-1ygfcef"
                       >
+                        dangerIconDescription
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#22a",
+                              "wordBreak": "break-word",
+                            }
+                          }
+                        >
+                          "
+                          
+                          "
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
                         description
                       </td>
                       <td
@@ -4069,6 +4177,42 @@ exports[`Storyshots CheckBox disabled 1`] = `
                         className="css-1ygfcef"
                       >
                         value
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#22a",
+                              "wordBreak": "break-word",
+                            }
+                          }
+                        >
+                          "
+                          
+                          "
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        dangerIconDescription
                       </td>
                       <td
                         className="css-1ygfcef"

--- a/src/asInput/README.md
+++ b/src/asInput/README.md
@@ -7,6 +7,9 @@ Handles all necessary props that are related to Input typed components.
 ### `className` (string array; optional)
 `className` specifies Bootstrap class names to apply to the input component. The default is an empty array.
 
+### `dangerIconDescription` (string or element; optional)
+`dangerIconDescription` can be used to provide a screen-reader description of the "exclamation" icon used in the validation message displayed when `isValid` is false and `themes` includes "danger". Only used if `validator` is not specified. The default is an empty string.
+
 ### `description` (string or element; optional)
 `description` can be used to provide a longer description of the component.  It will show up below the input component specified. The default is an empty string.
 
@@ -31,13 +34,36 @@ Handles all necessary props that are related to Input typed components.
 ### `required` (boolean; optional)
 `required` specifies if the component is required. The default type is false.
 
+### `themes` (array of strings; optional)
+`themes` specifies the themes to apply to the input (e.g. "danger"). The default is an empty array.
+
 ### `validator` (function; optional)
-`validator` specifies the function to use for validation logic if the input needs to be validated. Default is undefined.
+`validator` specifies the function to use for validation logic if the input needs to be validated. The function receives the input value as a parameter and it must return an object which will be written to the component's state with `setState`. Default is undefined. E.g.:
+
+```jsx
+<InputText
+  name="username"
+  label="Username"
+  description="The unique name that identifies you throughout the site."
+  validator={(value) => {
+    let feedback = { isValid: true };
+    if (value.length < 3) {
+      feedback = {
+        isValid: false,
+        validationMessage: 'Username must be at least 3 characters in length.',
+        dangerIconDescription: 'Error',
+      };
+    }
+    return feedback;
+  }}
+  themes={['danger']}
+/>
+```
 
 ### `isValid` (boolean; optional)
 `isValid` specifies whether the current input has validated correctly. Consider updating this from an `onBlur` handler. Only used if `validator` is not specified. The default is true.
 
-### `validationMessage` (string; optional)
+### `validationMessage` (string or element; optional)
 `validationMessage` specifies the message to display when `isValid` is false.  Only used if `validator` is not specified. The default is an empty string.
 
 ### `value` (string or number; optional)

--- a/src/asInput/asInput.test.jsx
+++ b/src/asInput/asInput.test.jsx
@@ -169,6 +169,24 @@ describe('asInput()', () => {
         expect(wrapper.state('validationMessage')).toEqual('Spy'); // resetting prop changes nothing
       });
 
+      it('ignores dangerIconDescription prop if validator is defined', () => {
+        const spy = jest.fn();
+        spy.mockReturnValue({ dangerIconDescription: 'Spy' });
+        const props = {
+          ...baseProps,
+          validator: spy,
+          dangerIconDescription: 'Prop',
+        };
+        const wrapper = mount(<InputTestComponent {...props} />);
+        expect(wrapper.state('dangerIconDescription')).toEqual(''); // default is '', ignoring our prop
+
+        wrapper.find('input').simulate('blur'); // trigger validation
+        expect(wrapper.state('dangerIconDescription')).toEqual('Spy'); // validator set Spy, ignoring our prop
+
+        wrapper.setProps({ dangerIconDescription: 'Reset' });
+        expect(wrapper.state('dangerIconDescription')).toEqual('Spy'); // resetting prop changes nothing
+      });
+
       it('uses props if validator becomes undefined', () => {
         const spy = jest.fn();
         spy.mockReturnValue({ validationMessage: 'Spy' });
@@ -177,12 +195,26 @@ describe('asInput()', () => {
           validator: spy,
           isValid: false,
           validationMessage: 'Prop',
+          dangerIconDescription: 'Prop',
         };
         const wrapper = mount(<InputTestComponent {...props} />);
         expect(wrapper.state('validationMessage')).toEqual('');
+        expect(wrapper.state('dangerIconDescription')).toEqual('');
 
         wrapper.setProps({ validator: null });
         expect(wrapper.state('validationMessage')).toEqual('Prop');
+        expect(wrapper.state('dangerIconDescription')).toEqual('Prop');
+      });
+
+      it('uses validationMessage as element type', () => {
+        const testMessage = (<span lang="en">Validation Message</span>);
+        const props = {
+          ...baseProps,
+          isValid: false,
+          validationMessage: testMessage,
+        };
+        const wrapper = mount(<InputTestComponent {...props} />);
+        expect(wrapper.state('validationMessage')).toEqual(testMessage);
       });
 
       it('uses isValid to display validation message', () => {
@@ -197,6 +229,28 @@ describe('asInput()', () => {
 
         wrapper.setProps({ validationMessage: 'New Message' });
         expect(err.text()).toEqual('New Message');
+
+        wrapper.setProps({ isValid: true });
+        expect(err.text()).toEqual('');
+      });
+
+      it('uses isValid to display validation message and danger icon with danger theme', () => {
+        const props = {
+          ...baseProps,
+          themes: ['danger'],
+          isValid: false,
+          validationMessage: 'Nope!',
+          dangerIconDescription: 'Error ',
+        };
+        const wrapper = mount(<InputTestComponent {...props} />);
+        const err = wrapper.find('.form-control-feedback');
+        expect(err.text()).toEqual('Error Nope!');
+
+        wrapper.setProps({ validationMessage: 'New Message' });
+        expect(err.text()).toEqual('Error New Message');
+
+        wrapper.setProps({ dangerIconDescription: 'Danger, Will Robinson! ' });
+        expect(err.text()).toEqual('Danger, Will Robinson! New Message');
 
         wrapper.setProps({ isValid: true });
         expect(err.text()).toEqual('');

--- a/src/asInput/index.jsx
+++ b/src/asInput/index.jsx
@@ -15,6 +15,7 @@ export const inputProps = {
   name: PropTypes.string.isRequired,
   id: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  dangerIconDescription: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   description: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.element,
@@ -25,7 +26,7 @@ export const inputProps = {
   onBlur: PropTypes.func,
   validator: PropTypes.func,
   isValid: PropTypes.bool,
-  validationMessage: PropTypes.string,
+  validationMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   className: PropTypes.arrayOf(PropTypes.string),
   themes: PropTypes.arrayOf(PropTypes.string),
   inline: PropTypes.bool,
@@ -36,6 +37,7 @@ export const defaultProps = {
   onBlur: () => {},
   id: newId('asInput'),
   value: '',
+  dangerIconDescription: '',
   description: undefined,
   disabled: false,
   required: false,
@@ -57,11 +59,13 @@ const asInput = (WrappedComponent, inputType = undefined, labelFirst = true) => 
       const id = this.props.id ? this.props.id : newId('asInput');
       const isValid = this.props.validator ? true : this.props.isValid;
       const validationMessage = this.props.validator ? '' : this.props.validationMessage;
+      const dangerIconDescription = this.props.validator ? '' : this.props.dangerIconDescription;
       this.state = {
         id,
         value: this.props.value,
         isValid,
         validationMessage,
+        dangerIconDescription,
         describedBy: [],
         errorId: `error-${id}`,
         descriptionId: `description-${id}`,
@@ -79,10 +83,15 @@ const asInput = (WrappedComponent, inputType = undefined, labelFirst = true) => 
       if (nextProps.validationMessage !== this.props.validationMessage && !nextProps.validator) {
         updatedState.validationMessage = nextProps.validationMessage;
       }
+      if (nextProps.dangerIconDescription !== this.props.dangerIconDescription &&
+          !nextProps.validator) {
+        updatedState.dangerIconDescription = nextProps.dangerIconDescription;
+      }
       // If validator goes away, revert to props
       if (nextProps.validator !== this.props.validator && !nextProps.validator) {
         updatedState.isValid = nextProps.isValid;
         updatedState.validationMessage = nextProps.validationMessage;
+        updatedState.dangerIconDescription = nextProps.dangerIconDescription;
       }
       if (Object.keys(updatedState).length > 0) {
         this.setState(updatedState);


### PR DESCRIPTION
Also, allow passing `validationMessage` as an element.

These are some additions to the [PR](https://github.com/edx/paragon/pull/196) @mikix merged last week. I only noticed these things after I tried to use `isValid` and `validationMessage` in studio-frontend.