### PR TITLE
fix(asinput): allow validationMessage to be an element

### DIFF
--- a/src/asInput/README.md
+++ b/src/asInput/README.md
@@ -37,7 +37,7 @@ Handles all necessary props that are related to Input typed components.
 ### `isValid` (boolean; optional)
 `isValid` specifies whether the current input has validated correctly. Consider updating this from an `onBlur` handler. Only used if `validator` is not specified. The default is true.
 
-### `validationMessage` (string; optional)
+### `validationMessage` (string or element; optional)
 `validationMessage` specifies the message to display when `isValid` is false.  Only used if `validator` is not specified. The default is an empty string.
 
 ### `value` (string or number; optional)

--- a/src/asInput/asInput.test.jsx
+++ b/src/asInput/asInput.test.jsx
@@ -185,6 +185,17 @@ describe('asInput()', () => {
         expect(wrapper.state('validationMessage')).toEqual('Prop');
       });
 
+      it('uses validationMessage as element type', () => {
+        const testMessage = (<span lang="en">Validation Message</span>);
+        const props = {
+          ...baseProps,
+          isValid: false,
+          validationMessage: testMessage,
+        };
+        const wrapper = mount(<InputTestComponent {...props} />);
+        expect(wrapper.state('validationMessage')).toEqual(testMessage);
+      });
+
       it('uses isValid to display validation message', () => {
         const props = {
           ...baseProps,

--- a/src/asInput/index.jsx
+++ b/src/asInput/index.jsx
@@ -25,7 +25,7 @@ export const inputProps = {
   onBlur: PropTypes.func,
   validator: PropTypes.func,
   isValid: PropTypes.bool,
-  validationMessage: PropTypes.string,
+  validationMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   className: PropTypes.arrayOf(PropTypes.string),
   themes: PropTypes.arrayOf(PropTypes.string),
   inline: PropTypes.bool,


### PR DESCRIPTION
More-or-less the same as https://github.com/edx/paragon/pull/133, as noted [here](https://github.com/edx/studio-frontend/pull/158#issuecomment-378643670)