### PR TITLE
fix(status-alert): fix add ability to set close button aria-label

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -18143,6 +18143,34 @@ exports[`Storyshots StatusAlert alert invoked via a button 1`] = `
 </div>
 `;
 
+exports[`Storyshots StatusAlert alert with a custom aria-label on the close button 1`] = `
+<div
+  className="alert fade alert-dismissible alert-info show"
+  hidden={false}
+  role="alert"
+>
+  <button
+    aria-label="Dismiss this very specific information."
+    className="btn close"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+    >
+      ×
+    </span>
+  </button>
+  <div
+    className="alert-dialog"
+  >
+    Some very specific information.
+  </div>
+</div>
+`;
+
 exports[`Storyshots StatusAlert alert with a link 1`] = `
 <div
   className="alert fade alert-dismissible alert-info show"

--- a/src/StatusAlert/StatusAlert.stories.jsx
+++ b/src/StatusAlert/StatusAlert.stories.jsx
@@ -88,6 +88,15 @@ storiesOf('StatusAlert', module)
       open
     />
   ))
+  .add('alert with a custom aria-label on the close button', () => (
+    <StatusAlert
+      alertType="info"
+      dialog="Some very specific information."
+      onClose={() => {}}
+      open
+      closeButtonAriaLabel="Dismiss this very specific information."
+    />
+  ))
   .add('Non-dismissible alert', () => (
     <StatusAlert
       alertType="danger"

--- a/src/StatusAlert/StatusAlert.test.jsx
+++ b/src/StatusAlert/StatusAlert.test.jsx
@@ -34,6 +34,14 @@ describe('<StatusAlert />', () => {
       expect(statusAlertDialog.text()).toEqual(dialog);
       expect(wrapper.find('button')).toHaveLength(0);
     });
+
+    it('renders custom aria-label view', () => {
+      const customLabel = 'Dismiss this alert post-haste!';
+      wrapper = mount(<StatusAlert {...defaultProps} closeButtonAriaLabel={customLabel} />);
+      const button = wrapper.find('button').at(0);
+
+      expect(button.prop('aria-label')).toEqual(customLabel);
+    });
   });
 
   describe('props received correctly', () => {

--- a/src/StatusAlert/index.jsx
+++ b/src/StatusAlert/index.jsx
@@ -64,11 +64,11 @@ class StatusAlert extends React.Component {
   }
 
   renderDismissible() {
-    const { dismissible } = this.props;
+    const { closeButtonAriaLabel, dismissible } = this.props;
 
     return (dismissible) ? (
       <Button
-        aria-label="Close"
+        aria-label={closeButtonAriaLabel}
         inputRef={(input) => { this.xButton = input; }}
         onClick={this.close}
         onKeyDown={this.handleKeyDown}
@@ -110,6 +110,7 @@ StatusAlert.propTypes = {
   dialog: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   dismissible: PropTypes.bool,
   /* eslint-disable react/require-default-props */
+  closeButtonAriaLabel: PropTypes.string,
   onClose: isRequiredIf(PropTypes.func, props => props.dismissible),
   open: PropTypes.bool,
 };
@@ -117,6 +118,7 @@ StatusAlert.propTypes = {
 StatusAlert.defaultProps = {
   alertType: 'warning',
   className: [],
+  closeButtonAriaLabel: 'Close',
   dismissible: true,
   open: false,
 };


### PR DESCRIPTION
This would allow the component to support i18n and enable the addition of context specific labels to the close button (e.g. 'Close the edX Cookie Policy alert.').