### PR TITLE
fix(button): classNames not rendered without spaces

### DIFF
--- a/src/Button/Button.test.jsx
+++ b/src/Button/Button.test.jsx
@@ -10,23 +10,29 @@ const defaultProps = {
 describe('<Button />', () => {
   let wrapper;
   let button;
+  const customClasses = ['custom-class-one', 'custom-class-two'];
 
   beforeEach(() => {
     wrapper = mount(<Button
       {...defaultProps}
+      className={customClasses}
     />);
 
     button = wrapper.find('button');
   });
   it('renders', () => {
     expect(button).toHaveLength(1);
+    expect(button.hasClass(customClasses[0])).toEqual(true);
+    expect(button.hasClass(customClasses[1])).toEqual(true);
   });
+
   it('puts focus on button on click', () => {
     expect(button.matchesElement(document.activeElement)).toEqual(false);
     button.simulate('click');
     button = wrapper.find('button');
     expect(button.at(0).html()).toEqual(document.activeElement.outerHTML);
   });
+
   it('calls onClick prop on click', () => {
     const onClickSpy = jest.fn();
     wrapper.setProps({ onClick: onClickSpy });

--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -63,13 +63,13 @@ class Button extends React.Component {
       <button
         {...other}
         className={classNames([
-          ...className,
+          className,
           styles.btn,
         ], {
           [styles[`btn-${buttonType}`]]: buttonType !== undefined,
         }, {
           [styles.close]: isClose,
-        })}
+        }).trim()}
         onBlur={this.onBlur}
         onClick={this.onClick}
         onKeyDown={this.onKeyDown}


### PR DESCRIPTION
The current implementation renders ```className="custom"``` as ```class="c u s t o m"```. This PR resolves that bug.