### PR TITLE
fix(modal): handle overflowing content

### DIFF
--- a/src/Modal/Modal.scss
+++ b/src/Modal/Modal.scss
@@ -3,13 +3,27 @@
 @import "~bootstrap/scss/_grid";
 @import "~bootstrap/scss/_utilities";
 
-.modal-open {
-  display: block;
+.modal.show {
+  position: fixed;
+  background-color: transparent;
+  max-height: 100%;
+  width: 100%;
 
   &:focus {
     .modal-dialog {
       box-shadow: $btn-focus-box-shadow;
     }
+  }
+}
+
+.modal.is-ie11 {
+  // fix browser that likes to do things its own way
+  overflow-y: scroll;
+  height: auto;
+
+  .modal-content {
+    height: auto;
+    max-height: none;
   }
 }
 
@@ -19,4 +33,30 @@
   // Fade for backdrop
   &.fade { opacity: 0; }
   &.show { opacity: 1; }
+}
+
+.modal-dialog {
+  height: 100%;
+  margin: auto;
+  padding: $spacer / 2;
+
+  @media (min-width: map-get($grid-breakpoints, 'sm')) {
+    padding: $spacer;
+  }
+}
+
+.modal-content {
+  max-height: 100%;
+}
+
+.modal-header {
+  flex: 0 0 auto;
+}
+
+.modal-body {
+  overflow: auto;
+}
+
+.modal-footer {
+  flex: 0 0 auto;
 }

--- a/src/Modal/Modal.stories.jsx
+++ b/src/Modal/Modal.stories.jsx
@@ -225,4 +225,12 @@ storiesOf('Modal', module)
         parentSelector=".target-div-two"
       />
     </div>
+  ))
+  .add('modal with overflowing content', () => (
+    <Modal
+      open
+      title="Modal title."
+      body={'Overflowing body. '.repeat(600)}
+      onClose={() => {}}
+    />
   ));

--- a/src/Modal/Modal.test.jsx
+++ b/src/Modal/Modal.test.jsx
@@ -127,6 +127,36 @@ describe('<Modal />', () => {
       expect(modalFooter.find('button')).toHaveLength(1);
       expect(wrapper.find('button')).toHaveLength(1);
     });
+
+    it('renders with IE11-specific styling when IE11 is detected', () => {
+      const { MSInputMethodContext } = global;
+      const { documentMode } = global.document;
+
+      // mimic IE11
+      global.MSInputMethodContext = true;
+      global.document.documentMode = true;
+      wrapper = mount(<Modal {...defaultProps} />);
+      const modal = wrapper.find('.modal');
+      expect(modal.hasClass('is-ie11')).toEqual(true);
+
+      global.MSInputMethodContext = MSInputMethodContext;
+      global.document.documentMode = documentMode;
+    });
+
+    it('renders without IE11-specific styling when IE11 is not detected', () => {
+      const { MSInputMethodContext } = global;
+      const { documentMode } = global.document;
+
+      // mimic non-IE11 browser
+      global.MSInputMethodContext = false;
+      global.document.documentMode = false;
+      wrapper = mount(<Modal {...defaultProps} />);
+      const modal = wrapper.find('.modal');
+      expect(modal.hasClass('is-ie11')).toEqual(false);
+
+      global.MSInputMethodContext = MSInputMethodContext;
+      global.document.documentMode = documentMode;
+    });
   });
 
   describe('props received correctly', () => {

--- a/src/Modal/index.jsx
+++ b/src/Modal/index.jsx
@@ -22,6 +22,9 @@ class Modal extends React.Component {
     this.headerId = newId();
     this.el = document.createElement('div');
 
+    // Sets true for IE11, false otherwise: https://stackoverflow.com/a/22082397/6620612
+    this.isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
+
     this.state = {
       open: props.open,
     };
@@ -93,7 +96,7 @@ class Modal extends React.Component {
               {body}
             </div>
           </div>
-          <div className={styles.col}>
+          <div className={styles['col-md-2']}>
             <Icon
               id={newId(`Modal-${variant.status}`)}
               className={[
@@ -183,6 +186,7 @@ class Modal extends React.Component {
               [styles['d-block']]: open,
               [styles.show]: open,
               [styles.fade]: !open,
+              [styles['is-ie11']]: this.isIE11,
             },
           )}
           role="dialog"


### PR DESCRIPTION
This PR fixes a few things:

1. Removes now-unused `.modal-open` styles (the class is now `.show`).
2. When modal body content overflows the screen height, it will now contain it to a scrollable container and still show the modal buttons at the bottom of the screen.
![screenshot-20180510141310-697x616](https://user-images.githubusercontent.com/1505923/39887461-4c33663a-5460-11e8-950b-147951bf17b4.png)
3. In IE11, which has bugs with the flexbox layout which breaks 2, always show a scrollbar when a modal is open which will allow scrolling of the entire modal when it overflows the screen. The scrollbar will be visible even when the modal does not overflow because `overflow: auto` was not working. This should only affect IE11.
![screenshot-20180510141402-649x687](https://user-images.githubusercontent.com/1505923/39887490-5a09157a-5460-11e8-81ff-675639cd0d5d.png)
4. Use `position: fixed` on the `.modal` div so that it does not push contents that are in the DOM after it down the page when it opens (the modal will now display over top of the background elements).
![screenshot-20180510144446-797x403](https://user-images.githubusercontent.com/1505923/39887649-b983d3f0-5460-11e8-9fdd-2fcf7807df3c.png)
![screenshot-20180510144545-779x333](https://user-images.githubusercontent.com/1505923/39887692-dcbd7862-5460-11e8-84a5-091a26e95beb.png)
5. The warning modal variant icon was always showing up on a new line. Specify the icon column as `col-md-2` so that it only collapses to a new row when the screen is smaller than `md`.
![screenshot-20180510144824-619x374](https://user-images.githubusercontent.com/1505923/39887855-3b762020-5461-11e8-9745-d5376d25a726.png)
![screenshot-20180510144736-621x316](https://user-images.githubusercontent.com/1505923/39887812-20ed1f9c-5461-11e8-9133-9a7ab5ce1b11.png)
