### PR TITLE
fix(modal): make portal rendering optional

### DIFF
--- a/src/Modal/Modal.stories.jsx
+++ b/src/Modal/Modal.stories.jsx
@@ -57,7 +57,7 @@ ModalWrapper.propTypes = {
 };
 
 ModalWrapper.defaultProps = {
-  parentSelector: 'body',
+  parentSelector: undefined,
 };
 
 storiesOf('Modal', module)
@@ -198,7 +198,7 @@ storiesOf('Modal', module)
     />
   ))
   .add('modal inside special div', () => (
-    <div>
+    <React.Fragment>
       <div>
         <div className="special-div" />
       </div>
@@ -207,10 +207,10 @@ storiesOf('Modal', module)
         body="I was invoked by a button!"
         parentSelector=".special-div"
       />
-    </div>
+    </React.Fragment>
   ))
   .add('two modals with the same target', () => (
-    <div>
+    <React.Fragment>
       <div>
         <div className="target-div" />
       </div>
@@ -224,10 +224,10 @@ storiesOf('Modal', module)
         body="I target one"
         parentSelector=".target-div"
       />
-    </div>
+    </React.Fragment>
   ))
   .add('two modals with seperate targets', () => (
-    <div>
+    <React.Fragment>
       <div>
         <div className="target-div-one" />
         <div className="target-div-two" />
@@ -242,7 +242,7 @@ storiesOf('Modal', module)
         body="I target two"
         parentSelector=".target-div-two"
       />
-    </div>
+    </React.Fragment>
   ))
   .add('modal with overflowing content', () => (
     <Modal

--- a/src/Modal/README.md
+++ b/src/Modal/README.md
@@ -26,4 +26,4 @@ Provides a basic modal component with customizable title, body, and footer butto
 `renderHeaderCloseButton` specifies whether a close button is rendered in the modal header. It defaults to true.
 
 ### `parentSelector` (string; optional)
-`parentSelector` is the selector for an element in the dom which the modal should be rendered under. It uses querySelector to find the first element that matches that selector, and then creates a react portal to a div underneath the parent element. 
+`parentSelector` is the selector for an element in the dom which the modal should be rendered under. It uses querySelector to find the first element that matches that selector, and then creates a react portal to the parent element. If not specified, then the modal will be rendered where it is defined, not in a portal.

--- a/src/Modal/index.jsx
+++ b/src/Modal/index.jsx
@@ -20,7 +20,6 @@ class Modal extends React.Component {
     this.setCloseButton = this.setCloseButton.bind(this);
 
     this.headerId = newId();
-    this.el = document.createElement('div');
 
     // Sets true for IE11, false otherwise: https://stackoverflow.com/a/22082397/6620612
     this.isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
@@ -34,11 +33,12 @@ class Modal extends React.Component {
     if (this.firstFocusableElement) {
       this.firstFocusableElement.focus();
     }
-    this.parentElement = document.querySelector(this.props.parentSelector);
-    if (this.parentElement === null) {
-      throw new Error(`Modal recieved invalid parentSelector: ${this.props.parentSelector}, no matching element found`);
+    if (this.props.parentSelector) {
+      this.parentElement = document.querySelector(this.props.parentSelector);
+      if (this.parentElement === null) {
+        throw new Error(`Modal recieved invalid parentSelector: ${this.props.parentSelector}, no matching element found`);
+      }
     }
-    this.parentElement.appendChild(this.el);
   }
 
   componentWillReceiveProps({ open }) {
@@ -51,10 +51,6 @@ class Modal extends React.Component {
     if (this.state.open && !prevState.open) {
       this.firstFocusableElement.focus();
     }
-  }
-
-  componentWillUnmount() {
-    ReactDOM.unmountComponentAtNode(this.parentElement);
   }
 
   setFirstFocusableElement(input) {
@@ -168,7 +164,7 @@ class Modal extends React.Component {
     const { renderHeaderCloseButton } = this.props;
 
     return (
-      <div>
+      <React.Fragment>
         <div
           className={classNames({
             [styles['modal-backdrop']]: open,
@@ -224,15 +220,18 @@ class Modal extends React.Component {
             </div>
           </div>
         </div>
-      </div>
+      </React.Fragment>
     );
   }
 
   render() {
-    return ReactDOM.createPortal(
-      this.renderModal(),
-      this.el,
-    );
+    if (this.parentElement) {
+      return ReactDOM.createPortal(
+        this.renderModal(),
+        this.parentElement,
+      );
+    }
+    return this.renderModal();
   }
 }
 
@@ -255,7 +254,7 @@ Modal.propTypes = {
 
 Modal.defaultProps = {
   open: false,
-  parentSelector: 'body',
+  parentSelector: undefined,
   buttons: [],
   closeText: 'Close',
   variant: {},


### PR DESCRIPTION
Yet another modal PR...

Enzyme is having some issues with the `querySelector` call in `Modal`. This is because Enzyme is not a browser so it doesn't actually put anything into a DOM that is selectable with `querySelector`. Generally, it's more idiomatic to pass refs to React components, not selector strings.

Studio-frontend does not need to render the modal in a portal so I decided that it would be best to make the behavior optional. If `parentSelector` is not given, then it will revert to the old way of just rendering the `Modal` where it is defined in the DOM. As far as I know, there's no way to test the portal behavior using `querySelector` with Enzyme (it's currently not tested in Paragon).

This is a breaking change, but users should be able to pass `parentSelector="body"` to get the old default behavior. ~~I still marked this as a `fix` because SFE needs this fix soon and can't wait for `4.0.0`. Are we okay with this? I can't think of an alternative...~~

I also removed some redundant `<div>`s in favor of `<React.Fragment>`s.