### PR TITLE
fix(modal): add prop for wrapperClass

### DIFF
--- a/src/Modal/Modal.test.jsx
+++ b/src/Modal/Modal.test.jsx
@@ -95,6 +95,12 @@ describe('<Modal />', () => {
       expect(wrapper.find('button')).toHaveLength(buttons.length + 2);
     });
 
+    it('renders a custom wrapper class', () => {
+      const customClass = 'my-modal-wrapper';
+      wrapper = mount(<Modal {...defaultProps} wrapperClass={customClass} />);
+      expect(wrapper.childAt(0).hasClass(customClass)).toEqual(true);
+    });
+
     it('renders Warning Variant', () => {
       wrapper = mount(<Modal {...defaultProps} variant={{ status: Variant.status.WARNING }} />);
 

--- a/src/Modal/README.md
+++ b/src/Modal/README.md
@@ -26,4 +26,7 @@ Provides a basic modal component with customizable title, body, and footer butto
 `renderHeaderCloseButton` specifies whether a close button is rendered in the modal header. It defaults to true.
 
 ### `parentSelector` (string; optional)
-`parentSelector` is the selector for an element in the dom which the modal should be rendered under. It uses querySelector to find the first element that matches that selector, and then creates a react portal to a div underneath the parent element. 
+`parentSelector` is the selector for an element in the dom which the modal should be rendered under. It uses querySelector to find the first element that matches that selector, and then creates a react portal to a div underneath the parent element.
+
+### `wrapperClass` (string; optional)
+`wrapperClass` is a class name that can be added to the wrapper div for the modal to enable CSS customization.

--- a/src/Modal/index.jsx
+++ b/src/Modal/index.jsx
@@ -165,10 +165,10 @@ class Modal extends React.Component {
 
   renderModal() {
     const { open } = this.state;
-    const { renderHeaderCloseButton } = this.props;
+    const { renderHeaderCloseButton, wrapperClass } = this.props;
 
     return (
-      <div>
+      <div className={wrapperClass}>
         <div
           className={classNames({
             [styles['modal-backdrop']]: open,
@@ -251,6 +251,7 @@ Modal.propTypes = {
     status: PropTypes.string,
   }),
   renderHeaderCloseButton: PropTypes.bool,
+  wrapperClass: PropTypes.string,
 };
 
 Modal.defaultProps = {
@@ -260,6 +261,7 @@ Modal.defaultProps = {
   closeText: 'Close',
   variant: {},
   renderHeaderCloseButton: true,
+  wrapperClass: '',
 };
 
 


### PR DESCRIPTION
Given recent updates that appends the modal to the document body by default it is not easy to scope modal-specific CSS. This update allows for passing a custom class that will enable CSS scoping.