### PR TITLE
feat(pagination): add Pagination and Responsive components

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -6464,7 +6464,7 @@ exports[`Storyshots Dropdown basic usage 1`] = `
           <button
             aria-expanded={false}
             aria-haspopup="true"
-            className="dropdown-toggle btn btn-light"
+            className="btn dropdown-toggle btn-light"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -38718,6 +38718,3985 @@ exports[`Storyshots MailtoLink with subject and body 1`] = `
 </div>
 `;
 
+exports[`Storyshots Pagination basic usage 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": 0,
+      "display": "flex",
+      "justifyContent": "center",
+      "left": 0,
+      "overflow": "auto",
+      "position": "fixed",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+      }
+    }
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <nav
+          aria-label="pagination navigation"
+          className=""
+        >
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            aria-relevant="text"
+            className="sr-only"
+          >
+            Page 1, Current Page, of 20
+          </div>
+          <ul
+            className="pagination"
+          >
+            <li
+              className="page-item disabled"
+            >
+              <button
+                aria-label="Previous"
+                className="btn previous page-link"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                tabIndex="-1"
+                type="button"
+              >
+                <div>
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-chevron-left mr-2"
+                      id="pagination-34"
+                    />
+                  </div>
+                  Previous
+                </div>
+              </button>
+            </li>
+            <li
+              className="page-item"
+            >
+              <button
+                aria-label="Next, Page 2"
+                className="btn next page-link"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                tabIndex={undefined}
+                type="button"
+              >
+                <div>
+                  Next
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-chevron-right ml-2"
+                      id="pagination-36"
+                    />
+                  </div>
+                </div>
+              </button>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <button
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#28c",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+      <div
+        style={
+          Object {
+            "background": "white",
+            "bottom": 0,
+            "display": "none",
+            "left": 0,
+            "overflow": "auto",
+            "padding": "0 40px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+            "zIndex": 99999,
+          }
+        }
+      >
+        <button
+          onClick={[Function]}
+          style={
+            Object {
+              "background": "#28c",
+              "border": "none",
+              "borderRadius": "0 0 0 5px",
+              "color": "#fff",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "sans-serif",
+              "fontSize": "12px",
+              "padding": "5px 15px",
+              "position": "fixed",
+              "right": 0,
+              "top": 0,
+            }
+          }
+          type="button"
+        >
+          ×
+        </button>
+        <div
+          style={undefined}
+        >
+          <div
+            style={
+              Object {
+                "WebkitFontSmoothing": "antialiased",
+                "backgroundColor": "#fff",
+                "border": "1px solid #eee",
+                "borderRadius": "2px",
+                "boxShadow": "0px 2px 3px rgba(0, 0, 0, 0.05)",
+                "color": "#444",
+                "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+                "fontSize": "15px",
+                "fontWeight": 300,
+                "lineHeight": 1.45,
+                "marginBottom": "20px",
+                "marginTop": "20px",
+                "padding": "20px 40px 40px",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "borderBottom": "1px solid #eee",
+                  "marginBottom": 10,
+                  "paddingTop": 10,
+                }
+              }
+            >
+              <h1
+                style={
+                  Object {
+                    "fontSize": "35px",
+                    "margin": 0,
+                    "padding": 0,
+                  }
+                }
+              >
+                Pagination
+              </h1>
+              <h2
+                style={
+                  Object {
+                    "fontSize": "22px",
+                    "fontWeight": 400,
+                    "margin": "0 0 10px 0",
+                    "padding": 0,
+                  }
+                }
+              >
+                basic usage
+              </h2>
+            </div>
+            
+            <div>
+              <h1
+                style={
+                  Object {
+                    "borderBottom": "1px solid #EEE",
+                    "fontSize": "25px",
+                    "margin": "20px 0 0 0",
+                    "padding": "0 0 5px 0",
+                  }
+                }
+              >
+                Story Source
+              </h1>
+              <pre
+                className="css-4akams"
+              >
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "paddingLeft": 18,
+                        "paddingRight": 3,
+                      }
+                    }
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#777",
+                        }
+                      }
+                    >
+                      &lt;
+                      Pagination
+                    </span>
+                    <span>
+                      <span>
+                         
+                        <span
+                          style={Object {}}
+                        >
+                          paginationLabel
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              pagination navigation
+                              "
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span>
+                         
+                        <span
+                          style={Object {}}
+                        >
+                          pageCount
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#a11",
+                                  }
+                                }
+                              >
+                                20
+                              </span>
+                              }
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span>
+                         
+                        <span
+                          style={Object {}}
+                        >
+                          onPageSelect
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                page-selected()
+                              </span>
+                              }
+                            </span>
+                          </span>
+                        </span>
+                         
+                      </span>
+                    </span>
+                    <span
+                      style={
+                        Object {
+                          "color": "#777",
+                        }
+                      }
+                    >
+                      /&gt;
+                    </span>
+                  </div>
+                </div>
+                <button
+                  className="css-gydez8"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="css-kv47nt"
+                  >
+                    <div
+                      style={
+                        Object {
+                          "marginBottom": 6,
+                        }
+                      }
+                    >
+                      Copied!
+                    </div>
+                    <div>
+                      Copy
+                    </div>
+                  </div>
+                </button>
+              </pre>
+            </div>
+            <div>
+              <h1
+                style={
+                  Object {
+                    "borderBottom": "1px solid #EEE",
+                    "fontSize": "25px",
+                    "margin": "20px 0 0 0",
+                    "padding": "0 0 5px 0",
+                  }
+                }
+              >
+                Prop Types
+              </h1>
+              <div>
+                <h2
+                  style={
+                    Object {
+                      "margin": "20px 0 0 0",
+                    }
+                  }
+                >
+                  "
+                  Pagination
+                  " Component
+                </h2>
+                <table
+                  className="css-1ytzlk7"
+                >
+                  <thead>
+                    <tr>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        property
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        propType
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        required
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        default
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        description
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        onPageSelect
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        pageCount
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        paginationLabel
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        buttonLabels
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            {
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              previous
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Previous
+                              "
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              next
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Next
+                              "
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              page
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Page
+                              "
+                            </span>
+                            , 
+                            …
+                            }
+                          </span>
+                          }
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        className
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#22a",
+                              "wordBreak": "break-word",
+                            }
+                          }
+                        >
+                          "
+                          
+                          "
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        currentPage
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#a11",
+                              }
+                            }
+                          >
+                            1
+                          </span>
+                          }
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        maxPagesDisplayed
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#a11",
+                              }
+                            }
+                          >
+                            7
+                          </span>
+                          }
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Pagination with custom element labels 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": 0,
+      "display": "flex",
+      "justifyContent": "center",
+      "left": 0,
+      "overflow": "auto",
+      "position": "fixed",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+      }
+    }
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <nav
+          aria-label="pagination navigation"
+          className=""
+        >
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            aria-relevant="text"
+            className="sr-only"
+          >
+            Página 1, Página actual, de 20
+          </div>
+          <ul
+            className="pagination"
+          >
+            <li
+              className="page-item disabled"
+            >
+              <button
+                aria-label="Anterior"
+                className="btn previous page-link"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                tabIndex="-1"
+                type="button"
+              >
+                <div>
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-chevron-left mr-2"
+                      id="pagination-47"
+                    />
+                  </div>
+                  <span>
+                    Anterior
+                  </span>
+                </div>
+              </button>
+            </li>
+            <li
+              className="page-item"
+            >
+              <button
+                aria-label="Siguiente, Página 2"
+                className="btn next page-link"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                tabIndex={undefined}
+                type="button"
+              >
+                <div>
+                  <span>
+                    Siguiente
+                  </span>
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-chevron-right ml-2"
+                      id="pagination-49"
+                    />
+                  </div>
+                </div>
+              </button>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <button
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#28c",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+      <div
+        style={
+          Object {
+            "background": "white",
+            "bottom": 0,
+            "display": "none",
+            "left": 0,
+            "overflow": "auto",
+            "padding": "0 40px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+            "zIndex": 99999,
+          }
+        }
+      >
+        <button
+          onClick={[Function]}
+          style={
+            Object {
+              "background": "#28c",
+              "border": "none",
+              "borderRadius": "0 0 0 5px",
+              "color": "#fff",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "sans-serif",
+              "fontSize": "12px",
+              "padding": "5px 15px",
+              "position": "fixed",
+              "right": 0,
+              "top": 0,
+            }
+          }
+          type="button"
+        >
+          ×
+        </button>
+        <div
+          style={undefined}
+        >
+          <div
+            style={
+              Object {
+                "WebkitFontSmoothing": "antialiased",
+                "backgroundColor": "#fff",
+                "border": "1px solid #eee",
+                "borderRadius": "2px",
+                "boxShadow": "0px 2px 3px rgba(0, 0, 0, 0.05)",
+                "color": "#444",
+                "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+                "fontSize": "15px",
+                "fontWeight": 300,
+                "lineHeight": 1.45,
+                "marginBottom": "20px",
+                "marginTop": "20px",
+                "padding": "20px 40px 40px",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "borderBottom": "1px solid #eee",
+                  "marginBottom": 10,
+                  "paddingTop": 10,
+                }
+              }
+            >
+              <h1
+                style={
+                  Object {
+                    "fontSize": "35px",
+                    "margin": 0,
+                    "padding": 0,
+                  }
+                }
+              >
+                Pagination
+              </h1>
+              <h2
+                style={
+                  Object {
+                    "fontSize": "22px",
+                    "fontWeight": 400,
+                    "margin": "0 0 10px 0",
+                    "padding": 0,
+                  }
+                }
+              >
+                with custom element labels
+              </h2>
+            </div>
+            
+            <div>
+              <h1
+                style={
+                  Object {
+                    "borderBottom": "1px solid #EEE",
+                    "fontSize": "25px",
+                    "margin": "20px 0 0 0",
+                    "padding": "0 0 5px 0",
+                  }
+                }
+              >
+                Story Source
+              </h1>
+              <pre
+                className="css-4akams"
+              >
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "paddingLeft": 18,
+                        "paddingRight": 3,
+                      }
+                    }
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#777",
+                        }
+                      }
+                    >
+                      &lt;
+                      Pagination
+                    </span>
+                    <span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
+                          paginationLabel
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              pagination navigation
+                              "
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
+                          pageCount
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#a11",
+                                  }
+                                }
+                              >
+                                20
+                              </span>
+                              }
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
+                          onPageSelect
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                page-selected()
+                              </span>
+                              }
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
+                          buttonLabels
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  previous
+                                </span>
+                                : 
+                                <span>
+                                  {
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    &lt;span /&gt;
+                                  </span>
+                                  }
+                                </span>
+                                , 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  next
+                                </span>
+                                : 
+                                <span>
+                                  {
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    &lt;span /&gt;
+                                  </span>
+                                  }
+                                </span>
+                                , 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  page
+                                </span>
+                                : 
+                                <span>
+                                  {
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    &lt;span /&gt;
+                                  </span>
+                                  }
+                                </span>
+                                , 
+                                …
+                                }
+                              </span>
+                              }
+                            </span>
+                          </span>
+                        </span>
+                        <br />
+                      </span>
+                    </span>
+                    <span
+                      style={
+                        Object {
+                          "color": "#777",
+                        }
+                      }
+                    >
+                      /&gt;
+                    </span>
+                  </div>
+                </div>
+                <button
+                  className="css-gydez8"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="css-kv47nt"
+                  >
+                    <div
+                      style={
+                        Object {
+                          "marginBottom": 6,
+                        }
+                      }
+                    >
+                      Copied!
+                    </div>
+                    <div>
+                      Copy
+                    </div>
+                  </div>
+                </button>
+              </pre>
+            </div>
+            <div>
+              <h1
+                style={
+                  Object {
+                    "borderBottom": "1px solid #EEE",
+                    "fontSize": "25px",
+                    "margin": "20px 0 0 0",
+                    "padding": "0 0 5px 0",
+                  }
+                }
+              >
+                Prop Types
+              </h1>
+              <div>
+                <h2
+                  style={
+                    Object {
+                      "margin": "20px 0 0 0",
+                    }
+                  }
+                >
+                  "
+                  Pagination
+                  " Component
+                </h2>
+                <table
+                  className="css-1ytzlk7"
+                >
+                  <thead>
+                    <tr>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        property
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        propType
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        required
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        default
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        description
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        onPageSelect
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        pageCount
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        paginationLabel
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        buttonLabels
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            {
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              previous
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Previous
+                              "
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              next
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Next
+                              "
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              page
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Page
+                              "
+                            </span>
+                            , 
+                            …
+                            }
+                          </span>
+                          }
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        className
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#22a",
+                              "wordBreak": "break-word",
+                            }
+                          }
+                        >
+                          "
+                          
+                          "
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        currentPage
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#a11",
+                              }
+                            }
+                          >
+                            1
+                          </span>
+                          }
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        maxPagesDisplayed
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#a11",
+                              }
+                            }
+                          >
+                            7
+                          </span>
+                          }
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Pagination with custom string labels 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": 0,
+      "display": "flex",
+      "justifyContent": "center",
+      "left": 0,
+      "overflow": "auto",
+      "position": "fixed",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+      }
+    }
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <nav
+          aria-label="pagination navigation"
+          className=""
+        >
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            aria-relevant="text"
+            className="sr-only"
+          >
+            Página 1, Página actual, de 20
+          </div>
+          <ul
+            className="pagination"
+          >
+            <li
+              className="page-item disabled"
+            >
+              <button
+                aria-label="Anterior"
+                className="btn previous page-link"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                tabIndex="-1"
+                type="button"
+              >
+                <div>
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-chevron-left mr-2"
+                      id="pagination-44"
+                    />
+                  </div>
+                  Anterior
+                </div>
+              </button>
+            </li>
+            <li
+              className="page-item"
+            >
+              <button
+                aria-label="Siguiente, Página 2"
+                className="btn next page-link"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                tabIndex={undefined}
+                type="button"
+              >
+                <div>
+                  Siguiente
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-chevron-right ml-2"
+                      id="pagination-46"
+                    />
+                  </div>
+                </div>
+              </button>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <button
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#28c",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+      <div
+        style={
+          Object {
+            "background": "white",
+            "bottom": 0,
+            "display": "none",
+            "left": 0,
+            "overflow": "auto",
+            "padding": "0 40px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+            "zIndex": 99999,
+          }
+        }
+      >
+        <button
+          onClick={[Function]}
+          style={
+            Object {
+              "background": "#28c",
+              "border": "none",
+              "borderRadius": "0 0 0 5px",
+              "color": "#fff",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "sans-serif",
+              "fontSize": "12px",
+              "padding": "5px 15px",
+              "position": "fixed",
+              "right": 0,
+              "top": 0,
+            }
+          }
+          type="button"
+        >
+          ×
+        </button>
+        <div
+          style={undefined}
+        >
+          <div
+            style={
+              Object {
+                "WebkitFontSmoothing": "antialiased",
+                "backgroundColor": "#fff",
+                "border": "1px solid #eee",
+                "borderRadius": "2px",
+                "boxShadow": "0px 2px 3px rgba(0, 0, 0, 0.05)",
+                "color": "#444",
+                "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+                "fontSize": "15px",
+                "fontWeight": 300,
+                "lineHeight": 1.45,
+                "marginBottom": "20px",
+                "marginTop": "20px",
+                "padding": "20px 40px 40px",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "borderBottom": "1px solid #eee",
+                  "marginBottom": 10,
+                  "paddingTop": 10,
+                }
+              }
+            >
+              <h1
+                style={
+                  Object {
+                    "fontSize": "35px",
+                    "margin": 0,
+                    "padding": 0,
+                  }
+                }
+              >
+                Pagination
+              </h1>
+              <h2
+                style={
+                  Object {
+                    "fontSize": "22px",
+                    "fontWeight": 400,
+                    "margin": "0 0 10px 0",
+                    "padding": 0,
+                  }
+                }
+              >
+                with custom string labels
+              </h2>
+            </div>
+            
+            <div>
+              <h1
+                style={
+                  Object {
+                    "borderBottom": "1px solid #EEE",
+                    "fontSize": "25px",
+                    "margin": "20px 0 0 0",
+                    "padding": "0 0 5px 0",
+                  }
+                }
+              >
+                Story Source
+              </h1>
+              <pre
+                className="css-4akams"
+              >
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "paddingLeft": 18,
+                        "paddingRight": 3,
+                      }
+                    }
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#777",
+                        }
+                      }
+                    >
+                      &lt;
+                      Pagination
+                    </span>
+                    <span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
+                          paginationLabel
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              pagination navigation
+                              "
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
+                          pageCount
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#a11",
+                                  }
+                                }
+                              >
+                                20
+                              </span>
+                              }
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
+                          onPageSelect
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                page-selected()
+                              </span>
+                              }
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
+                          buttonLabels
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  previous
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  "
+                                  Anterior
+                                  "
+                                </span>
+                                , 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  next
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  "
+                                  Siguiente
+                                  "
+                                </span>
+                                , 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  page
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  "
+                                  Página
+                                  "
+                                </span>
+                                , 
+                                …
+                                }
+                              </span>
+                              }
+                            </span>
+                          </span>
+                        </span>
+                        <br />
+                      </span>
+                    </span>
+                    <span
+                      style={
+                        Object {
+                          "color": "#777",
+                        }
+                      }
+                    >
+                      /&gt;
+                    </span>
+                  </div>
+                </div>
+                <button
+                  className="css-gydez8"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="css-kv47nt"
+                  >
+                    <div
+                      style={
+                        Object {
+                          "marginBottom": 6,
+                        }
+                      }
+                    >
+                      Copied!
+                    </div>
+                    <div>
+                      Copy
+                    </div>
+                  </div>
+                </button>
+              </pre>
+            </div>
+            <div>
+              <h1
+                style={
+                  Object {
+                    "borderBottom": "1px solid #EEE",
+                    "fontSize": "25px",
+                    "margin": "20px 0 0 0",
+                    "padding": "0 0 5px 0",
+                  }
+                }
+              >
+                Prop Types
+              </h1>
+              <div>
+                <h2
+                  style={
+                    Object {
+                      "margin": "20px 0 0 0",
+                    }
+                  }
+                >
+                  "
+                  Pagination
+                  " Component
+                </h2>
+                <table
+                  className="css-1ytzlk7"
+                >
+                  <thead>
+                    <tr>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        property
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        propType
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        required
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        default
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        description
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        onPageSelect
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        pageCount
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        paginationLabel
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        buttonLabels
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            {
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              previous
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Previous
+                              "
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              next
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Next
+                              "
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              page
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Page
+                              "
+                            </span>
+                            , 
+                            …
+                            }
+                          </span>
+                          }
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        className
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#22a",
+                              "wordBreak": "break-word",
+                            }
+                          }
+                        >
+                          "
+                          
+                          "
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        currentPage
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#a11",
+                              }
+                            }
+                          >
+                            1
+                          </span>
+                          }
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        maxPagesDisplayed
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#a11",
+                              }
+                            }
+                          >
+                            7
+                          </span>
+                          }
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Pagination with initial page selected 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": 0,
+      "display": "flex",
+      "justifyContent": "center",
+      "left": 0,
+      "overflow": "auto",
+      "position": "fixed",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+      }
+    }
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <nav
+          aria-label="pagination navigation"
+          className=""
+        >
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            aria-relevant="text"
+            className="sr-only"
+          >
+            Page 15, Current Page, of 20
+          </div>
+          <ul
+            className="pagination"
+          >
+            <li
+              className="page-item"
+            >
+              <button
+                aria-label="Previous, Page 14"
+                className="btn previous page-link"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                tabIndex={undefined}
+                type="button"
+              >
+                <div>
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-chevron-left mr-2"
+                      id="pagination-37"
+                    />
+                  </div>
+                  Previous
+                </div>
+              </button>
+            </li>
+            <li
+              className="page-item"
+            >
+              <button
+                aria-label="Next, Page 16"
+                className="btn next page-link"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                tabIndex={undefined}
+                type="button"
+              >
+                <div>
+                  Next
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-chevron-right ml-2"
+                      id="pagination-40"
+                    />
+                  </div>
+                </div>
+              </button>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <button
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#28c",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+      <div
+        style={
+          Object {
+            "background": "white",
+            "bottom": 0,
+            "display": "none",
+            "left": 0,
+            "overflow": "auto",
+            "padding": "0 40px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+            "zIndex": 99999,
+          }
+        }
+      >
+        <button
+          onClick={[Function]}
+          style={
+            Object {
+              "background": "#28c",
+              "border": "none",
+              "borderRadius": "0 0 0 5px",
+              "color": "#fff",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "sans-serif",
+              "fontSize": "12px",
+              "padding": "5px 15px",
+              "position": "fixed",
+              "right": 0,
+              "top": 0,
+            }
+          }
+          type="button"
+        >
+          ×
+        </button>
+        <div
+          style={undefined}
+        >
+          <div
+            style={
+              Object {
+                "WebkitFontSmoothing": "antialiased",
+                "backgroundColor": "#fff",
+                "border": "1px solid #eee",
+                "borderRadius": "2px",
+                "boxShadow": "0px 2px 3px rgba(0, 0, 0, 0.05)",
+                "color": "#444",
+                "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+                "fontSize": "15px",
+                "fontWeight": 300,
+                "lineHeight": 1.45,
+                "marginBottom": "20px",
+                "marginTop": "20px",
+                "padding": "20px 40px 40px",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "borderBottom": "1px solid #eee",
+                  "marginBottom": 10,
+                  "paddingTop": 10,
+                }
+              }
+            >
+              <h1
+                style={
+                  Object {
+                    "fontSize": "35px",
+                    "margin": 0,
+                    "padding": 0,
+                  }
+                }
+              >
+                Pagination
+              </h1>
+              <h2
+                style={
+                  Object {
+                    "fontSize": "22px",
+                    "fontWeight": 400,
+                    "margin": "0 0 10px 0",
+                    "padding": 0,
+                  }
+                }
+              >
+                with initial page selected
+              </h2>
+            </div>
+            
+            <div>
+              <h1
+                style={
+                  Object {
+                    "borderBottom": "1px solid #EEE",
+                    "fontSize": "25px",
+                    "margin": "20px 0 0 0",
+                    "padding": "0 0 5px 0",
+                  }
+                }
+              >
+                Story Source
+              </h1>
+              <pre
+                className="css-4akams"
+              >
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "paddingLeft": 18,
+                        "paddingRight": 3,
+                      }
+                    }
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#777",
+                        }
+                      }
+                    >
+                      &lt;
+                      Pagination
+                    </span>
+                    <span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
+                          paginationLabel
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              pagination navigation
+                              "
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
+                          pageCount
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#a11",
+                                  }
+                                }
+                              >
+                                20
+                              </span>
+                              }
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
+                          currentPage
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#a11",
+                                  }
+                                }
+                              >
+                                15
+                              </span>
+                              }
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
+                          onPageSelect
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                page-selected()
+                              </span>
+                              }
+                            </span>
+                          </span>
+                        </span>
+                        <br />
+                      </span>
+                    </span>
+                    <span
+                      style={
+                        Object {
+                          "color": "#777",
+                        }
+                      }
+                    >
+                      /&gt;
+                    </span>
+                  </div>
+                </div>
+                <button
+                  className="css-gydez8"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="css-kv47nt"
+                  >
+                    <div
+                      style={
+                        Object {
+                          "marginBottom": 6,
+                        }
+                      }
+                    >
+                      Copied!
+                    </div>
+                    <div>
+                      Copy
+                    </div>
+                  </div>
+                </button>
+              </pre>
+            </div>
+            <div>
+              <h1
+                style={
+                  Object {
+                    "borderBottom": "1px solid #EEE",
+                    "fontSize": "25px",
+                    "margin": "20px 0 0 0",
+                    "padding": "0 0 5px 0",
+                  }
+                }
+              >
+                Prop Types
+              </h1>
+              <div>
+                <h2
+                  style={
+                    Object {
+                      "margin": "20px 0 0 0",
+                    }
+                  }
+                >
+                  "
+                  Pagination
+                  " Component
+                </h2>
+                <table
+                  className="css-1ytzlk7"
+                >
+                  <thead>
+                    <tr>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        property
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        propType
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        required
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        default
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        description
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        onPageSelect
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        pageCount
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        paginationLabel
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        buttonLabels
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            {
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              previous
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Previous
+                              "
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              next
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Next
+                              "
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              page
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Page
+                              "
+                            </span>
+                            , 
+                            …
+                            }
+                          </span>
+                          }
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        className
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#22a",
+                              "wordBreak": "break-word",
+                            }
+                          }
+                        >
+                          "
+                          
+                          "
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        currentPage
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#a11",
+                              }
+                            }
+                          >
+                            1
+                          </span>
+                          }
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        maxPagesDisplayed
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#a11",
+                              }
+                            }
+                          >
+                            7
+                          </span>
+                          }
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Pagination with max pages displayed 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": 0,
+      "display": "flex",
+      "justifyContent": "center",
+      "left": 0,
+      "overflow": "auto",
+      "position": "fixed",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+      }
+    }
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <nav
+          aria-label="pagination navigation"
+          className=""
+        >
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            aria-relevant="text"
+            className="sr-only"
+          >
+            Page 1, Current Page, of 20
+          </div>
+          <ul
+            className="pagination"
+          >
+            <li
+              className="page-item disabled"
+            >
+              <button
+                aria-label="Previous"
+                className="btn previous page-link"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                tabIndex="-1"
+                type="button"
+              >
+                <div>
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-chevron-left mr-2"
+                      id="pagination-41"
+                    />
+                  </div>
+                  Previous
+                </div>
+              </button>
+            </li>
+            <li
+              className="page-item"
+            >
+              <button
+                aria-label="Next, Page 2"
+                className="btn next page-link"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                tabIndex={undefined}
+                type="button"
+              >
+                <div>
+                  Next
+                  <div>
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-chevron-right ml-2"
+                      id="pagination-43"
+                    />
+                  </div>
+                </div>
+              </button>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <button
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#28c",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+      <div
+        style={
+          Object {
+            "background": "white",
+            "bottom": 0,
+            "display": "none",
+            "left": 0,
+            "overflow": "auto",
+            "padding": "0 40px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+            "zIndex": 99999,
+          }
+        }
+      >
+        <button
+          onClick={[Function]}
+          style={
+            Object {
+              "background": "#28c",
+              "border": "none",
+              "borderRadius": "0 0 0 5px",
+              "color": "#fff",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "sans-serif",
+              "fontSize": "12px",
+              "padding": "5px 15px",
+              "position": "fixed",
+              "right": 0,
+              "top": 0,
+            }
+          }
+          type="button"
+        >
+          ×
+        </button>
+        <div
+          style={undefined}
+        >
+          <div
+            style={
+              Object {
+                "WebkitFontSmoothing": "antialiased",
+                "backgroundColor": "#fff",
+                "border": "1px solid #eee",
+                "borderRadius": "2px",
+                "boxShadow": "0px 2px 3px rgba(0, 0, 0, 0.05)",
+                "color": "#444",
+                "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+                "fontSize": "15px",
+                "fontWeight": 300,
+                "lineHeight": 1.45,
+                "marginBottom": "20px",
+                "marginTop": "20px",
+                "padding": "20px 40px 40px",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "borderBottom": "1px solid #eee",
+                  "marginBottom": 10,
+                  "paddingTop": 10,
+                }
+              }
+            >
+              <h1
+                style={
+                  Object {
+                    "fontSize": "35px",
+                    "margin": 0,
+                    "padding": 0,
+                  }
+                }
+              >
+                Pagination
+              </h1>
+              <h2
+                style={
+                  Object {
+                    "fontSize": "22px",
+                    "fontWeight": 400,
+                    "margin": "0 0 10px 0",
+                    "padding": 0,
+                  }
+                }
+              >
+                with max pages displayed
+              </h2>
+            </div>
+            
+            <div>
+              <h1
+                style={
+                  Object {
+                    "borderBottom": "1px solid #EEE",
+                    "fontSize": "25px",
+                    "margin": "20px 0 0 0",
+                    "padding": "0 0 5px 0",
+                  }
+                }
+              >
+                Story Source
+              </h1>
+              <pre
+                className="css-4akams"
+              >
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "paddingLeft": 18,
+                        "paddingRight": 3,
+                      }
+                    }
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#777",
+                        }
+                      }
+                    >
+                      &lt;
+                      Pagination
+                    </span>
+                    <span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
+                          paginationLabel
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              pagination navigation
+                              "
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
+                          pageCount
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#a11",
+                                  }
+                                }
+                              >
+                                20
+                              </span>
+                              }
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
+                          onPageSelect
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                page-selected()
+                              </span>
+                              }
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
+                          maxPagesDisplayed
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#a11",
+                                  }
+                                }
+                              >
+                                9
+                              </span>
+                              }
+                            </span>
+                          </span>
+                        </span>
+                        <br />
+                      </span>
+                    </span>
+                    <span
+                      style={
+                        Object {
+                          "color": "#777",
+                        }
+                      }
+                    >
+                      /&gt;
+                    </span>
+                  </div>
+                </div>
+                <button
+                  className="css-gydez8"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="css-kv47nt"
+                  >
+                    <div
+                      style={
+                        Object {
+                          "marginBottom": 6,
+                        }
+                      }
+                    >
+                      Copied!
+                    </div>
+                    <div>
+                      Copy
+                    </div>
+                  </div>
+                </button>
+              </pre>
+            </div>
+            <div>
+              <h1
+                style={
+                  Object {
+                    "borderBottom": "1px solid #EEE",
+                    "fontSize": "25px",
+                    "margin": "20px 0 0 0",
+                    "padding": "0 0 5px 0",
+                  }
+                }
+              >
+                Prop Types
+              </h1>
+              <div>
+                <h2
+                  style={
+                    Object {
+                      "margin": "20px 0 0 0",
+                    }
+                  }
+                >
+                  "
+                  Pagination
+                  " Component
+                </h2>
+                <table
+                  className="css-1ytzlk7"
+                >
+                  <thead>
+                    <tr>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        property
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        propType
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        required
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        default
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        description
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        onPageSelect
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        pageCount
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        paginationLabel
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        buttonLabels
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            {
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              previous
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Previous
+                              "
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              next
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Next
+                              "
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              page
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Page
+                              "
+                            </span>
+                            , 
+                            …
+                            }
+                          </span>
+                          }
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        className
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#22a",
+                              "wordBreak": "break-word",
+                            }
+                          }
+                        >
+                          "
+                          
+                          "
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        currentPage
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#a11",
+                              }
+                            }
+                          >
+                            1
+                          </span>
+                          }
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        maxPagesDisplayed
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#a11",
+                              }
+                            }
+                          >
+                            7
+                          </span>
+                          }
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Paragon Welcome 1`] = `
 <div
   className="css-jail"
@@ -41821,8 +45800,8 @@ exports[`Storyshots SearchField basic usage 1`] = `
           >
             <label
               className=""
-              htmlFor="asInput34"
-              id="label-asInput34"
+              htmlFor="asInput50"
+              id="label-asInput50"
             >
               Search:
             </label>
@@ -41833,12 +45812,12 @@ exports[`Storyshots SearchField basic usage 1`] = `
                 className="input-group-prepend"
               />
               <input
-                aria-describedby="error-asInput34"
+                aria-describedby="error-asInput50"
                 aria-invalid={false}
                 autoComplete="off"
                 className="form-control is-invalid-nodanger search-field__input search-field__no-clear-btn"
                 disabled={false}
-                id="asInput34"
+                id="asInput50"
                 name="search"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -41853,7 +45832,7 @@ exports[`Storyshots SearchField basic usage 1`] = `
                 className="input-group-append"
               >
                 <button
-                  className="search-field__search-btn btn"
+                  className="btn search-field__search-btn"
                   disabled={true}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -41878,7 +45857,7 @@ exports[`Storyshots SearchField basic usage 1`] = `
             <div
               aria-live="polite"
               className="invalid-feedback invalid-feedback-nodanger"
-              id="error-asInput34"
+              id="error-asInput50"
             >
               <span />
             </div>
@@ -42540,8 +46519,8 @@ exports[`Storyshots SearchField with callbacks 1`] = `
           >
             <label
               className=""
-              htmlFor="asInput38"
-              id="label-asInput38"
+              htmlFor="asInput54"
+              id="label-asInput54"
             >
               Search:
             </label>
@@ -42552,12 +46531,12 @@ exports[`Storyshots SearchField with callbacks 1`] = `
                 className="input-group-prepend"
               />
               <input
-                aria-describedby="error-asInput38"
+                aria-describedby="error-asInput54"
                 aria-invalid={false}
                 autoComplete="off"
                 className="form-control is-invalid-nodanger search-field__input search-field__no-clear-btn"
                 disabled={false}
-                id="asInput38"
+                id="asInput54"
                 name="search"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -42572,7 +46551,7 @@ exports[`Storyshots SearchField with callbacks 1`] = `
                 className="input-group-append"
               >
                 <button
-                  className="search-field__search-btn btn"
+                  className="btn search-field__search-btn"
                   disabled={true}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -42597,7 +46576,7 @@ exports[`Storyshots SearchField with callbacks 1`] = `
             <div
               aria-live="polite"
               className="invalid-feedback invalid-feedback-nodanger"
-              id="error-asInput38"
+              id="error-asInput54"
             >
               <span />
             </div>
@@ -43355,8 +47334,8 @@ exports[`Storyshots SearchField with custom label and screenreader text 1`] = `
           >
             <label
               className=""
-              htmlFor="asInput39"
-              id="label-asInput39"
+              htmlFor="asInput55"
+              id="label-asInput55"
             >
               Buscar:
             </label>
@@ -43367,12 +47346,12 @@ exports[`Storyshots SearchField with custom label and screenreader text 1`] = `
                 className="input-group-prepend"
               />
               <input
-                aria-describedby="error-asInput39"
+                aria-describedby="error-asInput55"
                 aria-invalid={false}
                 autoComplete="off"
                 className="form-control is-invalid-nodanger search-field__input search-field__no-clear-btn"
                 disabled={false}
-                id="asInput39"
+                id="asInput55"
                 name="search"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -43387,7 +47366,7 @@ exports[`Storyshots SearchField with custom label and screenreader text 1`] = `
                 className="input-group-append"
               >
                 <button
-                  className="search-field__search-btn btn"
+                  className="btn search-field__search-btn"
                   disabled={true}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -43412,7 +47391,7 @@ exports[`Storyshots SearchField with custom label and screenreader text 1`] = `
             <div
               aria-live="polite"
               className="invalid-feedback invalid-feedback-nodanger"
-              id="error-asInput39"
+              id="error-asInput55"
             >
               <span />
             </div>
@@ -44175,8 +48154,8 @@ exports[`Storyshots SearchField with placeholder 1`] = `
           >
             <label
               className=""
-              htmlFor="asInput35"
-              id="label-asInput35"
+              htmlFor="asInput51"
+              id="label-asInput51"
             >
               Search:
             </label>
@@ -44187,12 +48166,12 @@ exports[`Storyshots SearchField with placeholder 1`] = `
                 className="input-group-prepend"
               />
               <input
-                aria-describedby="error-asInput35"
+                aria-describedby="error-asInput51"
                 aria-invalid={false}
                 autoComplete="off"
                 className="form-control is-invalid-nodanger search-field__input search-field__no-clear-btn"
                 disabled={false}
-                id="asInput35"
+                id="asInput51"
                 name="search"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -44207,7 +48186,7 @@ exports[`Storyshots SearchField with placeholder 1`] = `
                 className="input-group-append"
               >
                 <button
-                  className="search-field__search-btn btn"
+                  className="btn search-field__search-btn"
                   disabled={true}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -44232,7 +48211,7 @@ exports[`Storyshots SearchField with placeholder 1`] = `
             <div
               aria-live="polite"
               className="invalid-feedback invalid-feedback-nodanger"
-              id="error-asInput35"
+              id="error-asInput51"
             >
               <span />
             </div>
@@ -44921,8 +48900,8 @@ exports[`Storyshots SearchField with value 1`] = `
           >
             <label
               className=""
-              htmlFor="asInput37"
-              id="label-asInput37"
+              htmlFor="asInput53"
+              id="label-asInput53"
             >
               Search:
             </label>
@@ -44933,12 +48912,12 @@ exports[`Storyshots SearchField with value 1`] = `
                 className="input-group-prepend"
               />
               <input
-                aria-describedby="error-asInput37"
+                aria-describedby="error-asInput53"
                 aria-invalid={false}
                 autoComplete="off"
                 className="form-control is-invalid-nodanger search-field__input"
                 disabled={false}
-                id="asInput37"
+                id="asInput53"
                 name="search"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -44953,7 +48932,7 @@ exports[`Storyshots SearchField with value 1`] = `
                 className="input-group-append"
               >
                 <button
-                  className="search-field__clear-btn ml-1 btn"
+                  className="btn search-field__clear-btn ml-1"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -44964,7 +48943,7 @@ exports[`Storyshots SearchField with value 1`] = `
                       <span
                         aria-hidden={true}
                         className="fa fa-times"
-                        id="icon-SearchField36"
+                        id="icon-SearchField52"
                       />
                       <span
                         className="sr-only"
@@ -44975,7 +48954,7 @@ exports[`Storyshots SearchField with value 1`] = `
                   </small>
                 </button>
                 <button
-                  className="search-field__search-btn border-left btn"
+                  className="btn search-field__search-btn border-left"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -45000,7 +48979,7 @@ exports[`Storyshots SearchField with value 1`] = `
             <div
               aria-live="polite"
               className="invalid-feedback invalid-feedback-nodanger"
-              id="error-asInput37"
+              id="error-asInput53"
             >
               <span />
             </div>
@@ -55137,7 +59116,7 @@ exports[`Storyshots Table sortable 1`] = `
                 scope="col"
               >
                 <button
-                  className="btn-header btn"
+                  className="btn btn-header"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -59574,10 +63553,10 @@ exports[`Storyshots Tabs basic usage 1`] = `
           >
             <li
               className="nav-item"
-              id="tab-label-tabInterface40-0"
+              id="tab-label-tabInterface56-0"
             >
               <a
-                aria-controls="tab-panel-tabInterface40-0"
+                aria-controls="tab-panel-tabInterface56-0"
                 aria-selected={true}
                 className="nav-link active"
                 onClick={[Function]}
@@ -59589,10 +63568,10 @@ exports[`Storyshots Tabs basic usage 1`] = `
             </li>
             <li
               className="nav-item"
-              id="tab-label-tabInterface40-1"
+              id="tab-label-tabInterface56-1"
             >
               <a
-                aria-controls="tab-panel-tabInterface40-1"
+                aria-controls="tab-panel-tabInterface56-1"
                 aria-selected={false}
                 className="nav-link"
                 onClick={[Function]}
@@ -59604,10 +63583,10 @@ exports[`Storyshots Tabs basic usage 1`] = `
             </li>
             <li
               className="nav-item"
-              id="tab-label-tabInterface40-2"
+              id="tab-label-tabInterface56-2"
             >
               <a
-                aria-controls="tab-panel-tabInterface40-2"
+                aria-controls="tab-panel-tabInterface56-2"
                 aria-selected={false}
                 className="nav-link"
                 onClick={[Function]}
@@ -59623,9 +63602,9 @@ exports[`Storyshots Tabs basic usage 1`] = `
           >
             <div
               aria-hidden={false}
-              aria-labelledby="tab-label-tabInterface40-0"
+              aria-labelledby="tab-label-tabInterface56-0"
               className="tab-pane active"
-              id="tab-panel-tabInterface40-0"
+              id="tab-panel-tabInterface56-0"
               role="tabpanel"
             >
               <div>
@@ -59634,9 +63613,9 @@ exports[`Storyshots Tabs basic usage 1`] = `
             </div>
             <div
               aria-hidden={true}
-              aria-labelledby="tab-label-tabInterface40-1"
+              aria-labelledby="tab-label-tabInterface56-1"
               className="tab-pane"
-              id="tab-panel-tabInterface40-1"
+              id="tab-panel-tabInterface56-1"
               role="tabpanel"
             >
               <div>
@@ -59645,9 +63624,9 @@ exports[`Storyshots Tabs basic usage 1`] = `
             </div>
             <div
               aria-hidden={true}
-              aria-labelledby="tab-label-tabInterface40-2"
+              aria-labelledby="tab-label-tabInterface56-2"
               className="tab-pane"
-              id="tab-panel-tabInterface40-2"
+              id="tab-panel-tabInterface56-2"
               role="tabpanel"
             >
               <div>
@@ -60298,8 +64277,8 @@ exports[`Storyshots Textarea label as element 1`] = `
         >
           <label
             className=""
-            htmlFor="asInput44"
-            id="label-asInput44"
+            htmlFor="asInput60"
+            id="label-asInput60"
           >
             <span
               lang="en"
@@ -60308,11 +64287,11 @@ exports[`Storyshots Textarea label as element 1`] = `
             </span>
           </label>
           <textarea
-            aria-describedby="error-asInput44"
+            aria-describedby="error-asInput60"
             aria-invalid={false}
             className="form-control is-invalid-nodanger"
             disabled={false}
-            id="asInput44"
+            id="asInput60"
             name="username"
             onBlur={[Function]}
             onChange={[Function]}
@@ -60328,7 +64307,7 @@ exports[`Storyshots Textarea label as element 1`] = `
           <div
             aria-live="polite"
             className="invalid-feedback invalid-feedback-nodanger"
-            id="error-asInput44"
+            id="error-asInput60"
           >
             <span />
           </div>
@@ -61329,17 +65308,17 @@ exports[`Storyshots Textarea minimal usage 1`] = `
         >
           <label
             className=""
-            htmlFor="asInput41"
-            id="label-asInput41"
+            htmlFor="asInput57"
+            id="label-asInput57"
           >
             First Name
           </label>
           <textarea
-            aria-describedby="error-asInput41"
+            aria-describedby="error-asInput57"
             aria-invalid={false}
             className="form-control is-invalid-nodanger"
             disabled={false}
-            id="asInput41"
+            id="asInput57"
             name="name"
             onBlur={[Function]}
             onChange={[Function]}
@@ -61355,7 +65334,7 @@ exports[`Storyshots Textarea minimal usage 1`] = `
           <div
             aria-live="polite"
             className="invalid-feedback invalid-feedback-nodanger"
-            id="error-asInput41"
+            id="error-asInput57"
           >
             <span />
           </div>
@@ -62355,17 +66334,17 @@ exports[`Storyshots Textarea scrollable 1`] = `
         >
           <label
             className=""
-            htmlFor="asInput42"
-            id="label-asInput42"
+            htmlFor="asInput58"
+            id="label-asInput58"
           >
             Information
           </label>
           <textarea
-            aria-describedby="error-asInput42"
+            aria-describedby="error-asInput58"
             aria-invalid={false}
             className="form-control is-invalid-nodanger"
             disabled={false}
-            id="asInput42"
+            id="asInput58"
             name="name"
             onBlur={[Function]}
             onChange={[Function]}
@@ -62381,7 +66360,7 @@ exports[`Storyshots Textarea scrollable 1`] = `
           <div
             aria-live="polite"
             className="invalid-feedback invalid-feedback-nodanger"
-            id="error-asInput42"
+            id="error-asInput58"
           >
             <span />
           </div>
@@ -63381,17 +67360,17 @@ exports[`Storyshots Textarea validation 1`] = `
         >
           <label
             className=""
-            htmlFor="asInput43"
-            id="label-asInput43"
+            htmlFor="asInput59"
+            id="label-asInput59"
           >
             Username
           </label>
           <textarea
-            aria-describedby="error-asInput43 description-asInput43"
+            aria-describedby="error-asInput59 description-asInput59"
             aria-invalid={false}
             className="form-control is-invalid-nodanger"
             disabled={false}
-            id="asInput43"
+            id="asInput59"
             name="username"
             onBlur={[Function]}
             onChange={[Function]}
@@ -63407,13 +67386,13 @@ exports[`Storyshots Textarea validation 1`] = `
           <div
             aria-live="polite"
             className="invalid-feedback invalid-feedback-nodanger"
-            id="error-asInput43"
+            id="error-asInput59"
           >
             <span />
           </div>
           <small
             className="form-text"
-            id="description-asInput43"
+            id="description-asInput59"
           >
             The unique name that identifies you throughout the site.
           </small>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
       }
     },
     "@commitlint/cli": {
@@ -21,7 +21,7 @@
       "integrity": "sha512-zFbw1GHSA3SmcGVDRc0nbm//U7jg9kzG5lGhg/bkYf7CcMpiWgTTcRjPSZea8tLl5Yh/A00RcTl+wBFdniOmPw==",
       "dev": true,
       "requires": {
-        "@commitlint/core": "6.0.2",
+        "@commitlint/core": "^6.0.2",
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.0",
         "get-stdin": "5.0.1",
@@ -36,17 +36,17 @@
           "integrity": "sha512-dNp0mC4gIxL3zh6s7Yx86tQX0bZ/wNbuclsYYkIpT0J3OXraXEUrGj2Z5nUaTwRa0cfVVSV9gndjY2Ej4KRtKg==",
           "dev": true,
           "requires": {
-            "@commitlint/execute-rule": "6.0.2",
-            "@commitlint/is-ignored": "6.0.2",
-            "@commitlint/parse": "6.0.2",
-            "@commitlint/resolve-extends": "6.0.2",
-            "@commitlint/rules": "6.0.2",
-            "@commitlint/top-level": "6.0.2",
-            "@marionebl/sander": "0.6.1",
-            "babel-runtime": "6.26.0",
-            "chalk": "2.3.0",
-            "cosmiconfig": "3.1.0",
-            "git-raw-commits": "1.3.0",
+            "@commitlint/execute-rule": "^6.0.2",
+            "@commitlint/is-ignored": "^6.0.2",
+            "@commitlint/parse": "^6.0.2",
+            "@commitlint/resolve-extends": "^6.0.2",
+            "@commitlint/rules": "^6.0.2",
+            "@commitlint/top-level": "^6.0.2",
+            "@marionebl/sander": "^0.6.0",
+            "babel-runtime": "^6.23.0",
+            "chalk": "^2.0.1",
+            "cosmiconfig": "^3.0.1",
+            "git-raw-commits": "^1.3.0",
             "lodash.merge": "4.6.0",
             "lodash.mergewith": "4.6.0",
             "lodash.pick": "4.4.0",
@@ -62,7 +62,7 @@
       "integrity": "sha512-GStYfrN0qGa9ZIGSmfloZW6xDfuToVrWhjgEyfOIR0dMeiXj8IuLmWqFaqzyh6yz2ooZJPuxYhvnpMuH+Ad/2w==",
       "dev": true,
       "requires": {
-        "@commitlint/config-angular-type-enum": "6.0.2"
+        "@commitlint/config-angular-type-enum": "^6.0.2"
       }
     },
     "@commitlint/config-angular-type-enum": {
@@ -114,8 +114,8 @@
       "integrity": "sha512-c+Zm0LjCrDO116BXS3WBrTgtbgLFcTwiYeF7mKFmzcMs+kdvKfUzw08skl42g/4lU9lZWyesNUWd2vNAmXtiSg==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "1.6.0",
-        "conventional-commits-parser": "2.1.0"
+        "conventional-changelog-angular": "^1.3.3",
+        "conventional-commits-parser": "^2.1.0"
       }
     },
     "@commitlint/prompt": {
@@ -124,17 +124,17 @@
       "integrity": "sha512-Iu8/EGqgVIaOr4u6ix4RBScaMH6PFdPRhuZ0Hj8xThgehUNvflGt/FnsfagHKb+LTcRO/9xoAVHETUMg9cLeJA==",
       "dev": true,
       "requires": {
-        "@commitlint/core": "6.0.2",
-        "babel-runtime": "6.26.0",
-        "chalk": "2.3.0",
+        "@commitlint/core": "^6.0.2",
+        "babel-runtime": "^6.23.0",
+        "chalk": "^2.0.0",
         "lodash.camelcase": "4.3.0",
         "lodash.kebabcase": "4.1.1",
         "lodash.snakecase": "4.1.1",
         "lodash.startcase": "4.4.0",
         "lodash.topairs": "4.3.0",
         "lodash.upperfirst": "4.3.1",
-        "throat": "4.1.0",
-        "vorpal": "1.12.0"
+        "throat": "^4.1.0",
+        "vorpal": "^1.10.0"
       },
       "dependencies": {
         "@commitlint/core": {
@@ -143,17 +143,17 @@
           "integrity": "sha512-dNp0mC4gIxL3zh6s7Yx86tQX0bZ/wNbuclsYYkIpT0J3OXraXEUrGj2Z5nUaTwRa0cfVVSV9gndjY2Ej4KRtKg==",
           "dev": true,
           "requires": {
-            "@commitlint/execute-rule": "6.0.2",
-            "@commitlint/is-ignored": "6.0.2",
-            "@commitlint/parse": "6.0.2",
-            "@commitlint/resolve-extends": "6.0.2",
-            "@commitlint/rules": "6.0.2",
-            "@commitlint/top-level": "6.0.2",
-            "@marionebl/sander": "0.6.1",
-            "babel-runtime": "6.26.0",
-            "chalk": "2.3.0",
-            "cosmiconfig": "3.1.0",
-            "git-raw-commits": "1.3.0",
+            "@commitlint/execute-rule": "^6.0.2",
+            "@commitlint/is-ignored": "^6.0.2",
+            "@commitlint/parse": "^6.0.2",
+            "@commitlint/resolve-extends": "^6.0.2",
+            "@commitlint/rules": "^6.0.2",
+            "@commitlint/top-level": "^6.0.2",
+            "@marionebl/sander": "^0.6.0",
+            "babel-runtime": "^6.23.0",
+            "chalk": "^2.0.1",
+            "cosmiconfig": "^3.0.1",
+            "git-raw-commits": "^1.3.0",
             "lodash.merge": "4.6.0",
             "lodash.mergewith": "4.6.0",
             "lodash.pick": "4.4.0",
@@ -169,7 +169,7 @@
       "integrity": "sha512-P83HgJdNtT5pRs+9jpq7WP3luFHel0aPMb2EBEDiQx6alV41Q5Wt3yg6R+xvN4/SipjTPlEBaIeA1npMNoSudw==",
       "dev": true,
       "requires": {
-        "@commitlint/prompt": "6.0.2",
+        "@commitlint/prompt": "^6.0.2",
         "execa": "0.9.0",
         "meow": "3.7.0"
       },
@@ -180,13 +180,13 @@
           "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         }
       }
@@ -200,9 +200,9 @@
         "babel-runtime": "6.26.0",
         "lodash.merge": "4.6.0",
         "lodash.omit": "4.5.0",
-        "require-uncached": "1.0.3",
-        "resolve-from": "4.0.0",
-        "resolve-global": "0.1.0"
+        "require-uncached": "^1.0.3",
+        "resolve-from": "^4.0.0",
+        "resolve-global": "^0.1.0"
       }
     },
     "@commitlint/rules": {
@@ -211,10 +211,10 @@
       "integrity": "sha512-lvlKf9WDdRed1uSz87PoxI26yyGdXxPyYniUnEfm3K7grWdnNVFbz8nkuI3iX6V9K6XVZBzbohans+jvQbKlYw==",
       "dev": true,
       "requires": {
-        "@commitlint/ensure": "6.0.2",
-        "@commitlint/message": "6.0.2",
-        "@commitlint/to-lines": "6.0.2",
-        "babel-runtime": "6.26.0"
+        "@commitlint/ensure": "^6.0.2",
+        "@commitlint/message": "^6.0.2",
+        "@commitlint/to-lines": "^6.0.2",
+        "babel-runtime": "^6.23.0"
       }
     },
     "@commitlint/to-lines": {
@@ -229,7 +229,7 @@
       "integrity": "sha512-aou9SdSrU+cl/XtrOj/fFKv6sf7Tc6z+r/N4ajOG4sxri3zzDkunF9AkNkSKEmioFLhFcpDIbip8+IS/fa9Nmw==",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "@edx/edx-bootstrap": {
@@ -238,8 +238,8 @@
       "integrity": "sha512-ZVoGAqWo9NtPKoNRgOgiW+Qr83TyZ+CWiKFpTmqaG3fm0qBgysnYYRooh1pyaJPedgFw2ljGrAAHYpn94R3pfw==",
       "requires": {
         "bootstrap": "4.0.0",
-        "jquery": "3.3.1",
-        "popper.js": "1.14.1"
+        "jquery": "^3.2.1",
+        "popper.js": "^1.12.6"
       }
     },
     "@marionebl/sander": {
@@ -248,9 +248,9 @@
       "integrity": "sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.3",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -259,8 +259,8 @@
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
-        "call-me-maybe": "1.0.1",
-        "glob-to-regexp": "0.3.0"
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
       }
     },
     "@octokit/rest": {
@@ -269,14 +269,14 @@
       "integrity": "sha512-KcqG0zjnjzUqn7wczz/fKiueNpTLiAI7erhUG6bXWAsYKJJlqnwYonFSXrMW/nmes5y+qOk4uSyHBh1mdRXdVQ==",
       "dev": true,
       "requires": {
-        "before-after-hook": "1.1.0",
-        "btoa-lite": "1.0.0",
-        "debug": "3.1.0",
-        "http-proxy-agent": "2.1.0",
-        "https-proxy-agent": "2.2.1",
-        "lodash": "4.17.4",
-        "node-fetch": "2.1.2",
-        "url-template": "2.0.8"
+        "before-after-hook": "^1.1.0",
+        "btoa-lite": "^1.0.0",
+        "debug": "^3.1.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.0",
+        "lodash": "^4.17.4",
+        "node-fetch": "^2.1.1",
+        "url-template": "^2.0.8"
       },
       "dependencies": {
         "debug": {
@@ -302,11 +302,11 @@
       "integrity": "sha512-4GLFDmp8Up+f4GQGPIzLVd8X9a3yqbZjl761sEdfCH4e5FkEO3I9XRlTEfKSueeCt5OA1lZBb9IHGpZ6Ot0+BQ==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "3.0.6",
-        "conventional-commits-parser": "2.1.0",
-        "debug": "3.1.0",
-        "import-from": "2.1.0",
-        "lodash": "4.17.4"
+        "conventional-changelog-angular": "^3.0.0",
+        "conventional-commits-parser": "^2.0.0",
+        "debug": "^3.1.0",
+        "import-from": "^2.1.0",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "conventional-changelog-angular": {
@@ -315,8 +315,8 @@
           "integrity": "sha512-jWuwQEOn/jcPZ5ZQbAlKnrMAW00uT8BTac/ex1S2lDhqg5D4Qr3rGzyGmK/ZCSmVopE9BOcFkt3+ubEGqfpT9w==",
           "dev": true,
           "requires": {
-            "compare-func": "1.3.2",
-            "q": "1.5.1"
+            "compare-func": "^1.3.1",
+            "q": "^1.5.1"
           }
         },
         "debug": {
@@ -342,20 +342,20 @@
       "integrity": "sha512-iaoHp8sDTgE0dFK4l9UwtjP/GmxHN9r8Hxi8fJNXOtC6tYU8JJqbvQHek4N7flNNbx74Drgga+Sc1eShlhE3Ng==",
       "dev": true,
       "requires": {
-        "@octokit/rest": "15.2.6",
-        "@semantic-release/error": "2.2.0",
-        "aggregate-error": "1.0.0",
-        "bottleneck": "2.3.0",
-        "debug": "3.1.0",
-        "fs-extra": "5.0.0",
-        "globby": "8.0.1",
-        "issue-parser": "1.0.3",
-        "lodash": "4.17.4",
-        "mime": "2.3.1",
-        "p-filter": "1.0.0",
-        "p-retry": "1.0.0",
-        "parse-github-url": "1.0.2",
-        "url-join": "4.0.0"
+        "@octokit/rest": "^15.2.0",
+        "@semantic-release/error": "^2.2.0",
+        "aggregate-error": "^1.0.0",
+        "bottleneck": "^2.0.1",
+        "debug": "^3.1.0",
+        "fs-extra": "^5.0.0",
+        "globby": "^8.0.0",
+        "issue-parser": "^1.0.2",
+        "lodash": "^4.17.4",
+        "mime": "^2.0.3",
+        "p-filter": "^1.0.0",
+        "p-retry": "^1.0.0",
+        "parse-github-url": "^1.0.1",
+        "url-join": "^4.0.0"
       },
       "dependencies": {
         "debug": {
@@ -373,13 +373,13 @@
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "dir-glob": "2.0.0",
-            "fast-glob": "2.2.0",
-            "glob": "7.1.2",
-            "ignore": "3.3.7",
-            "pify": "3.0.0",
-            "slash": "1.0.0"
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
           }
         },
         "mime": {
@@ -408,15 +408,15 @@
       "integrity": "sha512-Kkl5nwRGw0yRg6B4qr8LIi+BkcdK3tJ67ziTzo65SZLEpuV8NLVsm7OAiOMK34rOL3Utkno+BA3AGTg7fhm/nw==",
       "dev": true,
       "requires": {
-        "@semantic-release/error": "2.2.0",
-        "aggregate-error": "1.0.0",
-        "execa": "0.10.0",
-        "fs-extra": "5.0.0",
-        "lodash": "4.17.4",
-        "nerf-dart": "1.0.0",
-        "normalize-url": "2.0.1",
-        "read-pkg": "3.0.0",
-        "registry-auth-token": "3.3.1"
+        "@semantic-release/error": "^2.2.0",
+        "aggregate-error": "^1.0.0",
+        "execa": "^0.10.0",
+        "fs-extra": "^5.0.0",
+        "lodash": "^4.17.4",
+        "nerf-dart": "^1.0.0",
+        "normalize-url": "^2.0.1",
+        "read-pkg": "^3.0.0",
+        "registry-auth-token": "^3.3.1"
       },
       "dependencies": {
         "load-json-file": {
@@ -425,10 +425,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "normalize-url": {
@@ -437,9 +437,9 @@
           "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
           "dev": true,
           "requires": {
-            "prepend-http": "2.0.0",
-            "query-string": "5.1.1",
-            "sort-keys": "2.0.0"
+            "prepend-http": "^2.0.0",
+            "query-string": "^5.0.1",
+            "sort-keys": "^2.0.0"
           }
         },
         "parse-json": {
@@ -448,8 +448,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.1"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -458,7 +458,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -479,9 +479,9 @@
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
           "requires": {
-            "decode-uri-component": "0.2.0",
-            "object-assign": "4.1.1",
-            "strict-uri-encode": "1.1.0"
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
           }
         },
         "read-pkg": {
@@ -490,9 +490,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "sort-keys": {
@@ -501,7 +501,7 @@
           "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
           "dev": true,
           "requires": {
-            "is-plain-obj": "1.1.0"
+            "is-plain-obj": "^1.0.0"
           }
         },
         "strip-bom": {
@@ -518,15 +518,15 @@
       "integrity": "sha512-8eigxfGSy36+mv4rUIbGZAGZkUVZYNXOyRpcG+ZHSeGTqG6hu9uUxmzkfQ2hvK3zSxqrzKPg3MxnhvZL1Qqmrg==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "3.0.6",
-        "conventional-changelog-writer": "3.0.9",
-        "conventional-commits-parser": "2.1.7",
-        "debug": "3.1.0",
-        "get-stream": "3.0.0",
-        "git-url-parse": "9.0.0",
-        "import-from": "2.1.0",
-        "into-stream": "3.1.0",
-        "lodash": "4.17.4"
+        "conventional-changelog-angular": "^3.0.6",
+        "conventional-changelog-writer": "^3.0.9",
+        "conventional-commits-parser": "^2.1.7",
+        "debug": "^3.1.0",
+        "get-stream": "^3.0.0",
+        "git-url-parse": "^9.0.0",
+        "import-from": "^2.1.0",
+        "into-stream": "^3.1.0",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "camelcase": {
@@ -541,9 +541,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "map-obj": "2.0.0",
-            "quick-lru": "1.1.0"
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
           }
         },
         "conventional-changelog-angular": {
@@ -552,8 +552,8 @@
           "integrity": "sha512-jWuwQEOn/jcPZ5ZQbAlKnrMAW00uT8BTac/ex1S2lDhqg5D4Qr3rGzyGmK/ZCSmVopE9BOcFkt3+ubEGqfpT9w==",
           "dev": true,
           "requires": {
-            "compare-func": "1.3.2",
-            "q": "1.5.1"
+            "compare-func": "^1.3.1",
+            "q": "^1.5.1"
           }
         },
         "conventional-commits-parser": {
@@ -562,13 +562,13 @@
           "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.2",
-            "is-text-path": "1.0.1",
-            "lodash": "4.17.4",
-            "meow": "4.0.0",
-            "split2": "2.2.0",
-            "through2": "2.0.3",
-            "trim-off-newlines": "1.0.1"
+            "JSONStream": "^1.0.4",
+            "is-text-path": "^1.0.0",
+            "lodash": "^4.2.1",
+            "meow": "^4.0.0",
+            "split2": "^2.0.0",
+            "through2": "^2.0.0",
+            "trim-off-newlines": "^1.0.0"
           }
         },
         "debug": {
@@ -586,8 +586,8 @@
           "integrity": "sha512-zks1jS4ocMA/9WUx3C0nGIj/wBQjjIuktQ4KqKTyStMdEtnnFbZ4ZVKCvNeHwKh1COk/8sZaVTyvYj3paHI9Fg==",
           "dev": true,
           "requires": {
-            "git-up": "2.0.10",
-            "parse-domain": "2.0.0"
+            "git-up": "^2.0.0",
+            "parse-domain": "^2.0.0"
           }
         },
         "indent-string": {
@@ -602,10 +602,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "map-obj": {
@@ -620,15 +620,15 @@
           "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.4.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
           }
         },
         "minimist": {
@@ -643,8 +643,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.1"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -653,7 +653,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -668,9 +668,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -679,8 +679,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "redent": {
@@ -689,8 +689,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "3.2.0",
-            "strip-indent": "2.0.0"
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -725,9 +725,9 @@
       "integrity": "sha512-Riia+CbQ2NTx6fO92vZ2dmjNPVv778V0P9F6X0JvvD/rJ1uvPK6Z05Co7gkTL1VY32QoxpYCudpgsd4jwt4laA==",
       "dev": true,
       "requires": {
-        "@storybook/components": "3.3.13",
-        "axe-core": "2.6.1",
-        "prop-types": "15.6.0"
+        "@storybook/components": "^3.3.13",
+        "axe-core": "^2.6.0",
+        "prop-types": "^15.6.0"
       },
       "dependencies": {
         "@storybook/components": {
@@ -736,9 +736,9 @@
           "integrity": "sha512-htNVEUfW//Xw9RfXtNExDnVEJaHVIA4U08tsfKHOaCkeA3urpPkSZD9+4SCLixw2IYodbolbFWphaqBk1yrQDw==",
           "dev": true,
           "requires": {
-            "glamor": "2.20.40",
-            "glamorous": "4.11.4",
-            "prop-types": "15.6.0"
+            "glamor": "^2.20.40",
+            "glamorous": "^4.11.2",
+            "prop-types": "^15.6.0"
           }
         }
       }
@@ -749,12 +749,12 @@
       "integrity": "sha512-0WWzGYnnW9juWrBLE9sNE2dlewuaNYbb5Jyw9YYBt1nkk+a/A16yneJ1yxUlRHOuKcXs+DZYRaI/8SlGrY9Kmg==",
       "dev": true,
       "requires": {
-        "deep-equal": "1.0.1",
-        "global": "4.3.2",
-        "make-error": "1.3.2",
-        "prop-types": "15.6.0",
-        "react-inspector": "2.2.2",
-        "uuid": "3.1.0"
+        "deep-equal": "^1.0.1",
+        "global": "^4.3.2",
+        "make-error": "^1.3.2",
+        "prop-types": "^15.6.0",
+        "react-inspector": "^2.2.2",
+        "uuid": "^3.1.0"
       }
     },
     "@storybook/addon-centered": {
@@ -763,7 +763,7 @@
       "integrity": "sha512-jntSqn7KzijWDX0MbqZI/6cLOOU9f7WCAmvldfiUFUoXLSslse6tvfsjGrS6s0xaTk1Ss1sDui2LMmn1pLfq8w==",
       "dev": true,
       "requires": {
-        "global": "4.3.2"
+        "global": "^4.3.2"
       }
     },
     "@storybook/addon-console": {
@@ -772,7 +772,7 @@
       "integrity": "sha1-kxOmXwQ5K1JGmOAc7qpIAfXQeyA=",
       "dev": true,
       "requires": {
-        "global": "4.3.2"
+        "global": "^4.3.2"
       }
     },
     "@storybook/addon-info": {
@@ -783,15 +783,15 @@
       "requires": {
         "@storybook/client-logger": "3.4.2",
         "@storybook/components": "3.4.2",
-        "babel-runtime": "6.26.0",
-        "glamor": "2.20.40",
-        "glamorous": "4.12.4",
-        "global": "4.3.2",
-        "marksy": "6.0.3",
-        "nested-object-assign": "1.0.2",
-        "prop-types": "15.6.1",
-        "react-addons-create-fragment": "15.6.2",
-        "util-deprecate": "1.0.2"
+        "babel-runtime": "^6.26.0",
+        "glamor": "^2.20.40",
+        "glamorous": "^4.12.1",
+        "global": "^4.3.2",
+        "marksy": "^6.0.3",
+        "nested-object-assign": "^1.0.1",
+        "prop-types": "^15.6.1",
+        "react-addons-create-fragment": "^15.5.3",
+        "util-deprecate": "^1.0.2"
       },
       "dependencies": {
         "@storybook/client-logger": {
@@ -806,9 +806,9 @@
           "integrity": "sha512-KtbgMINfl6h/bTFyQndDVHq4plG06L5Wr9SnDaRo+ZLUloD07MMuCeTw/O6Bs3KH7tfkBXbKOgc5m5HbjIQDpg==",
           "dev": true,
           "requires": {
-            "glamor": "2.20.40",
-            "glamorous": "4.12.4",
-            "prop-types": "15.6.1"
+            "glamor": "^2.20.40",
+            "glamorous": "^4.12.1",
+            "prop-types": "^15.6.1"
           }
         },
         "glamorous": {
@@ -817,14 +817,14 @@
           "integrity": "sha512-9XjKfMnVJlohSa6ZYrrOz/ZW1xu3JK6zjRTCTkLLJowlmEU7zt9uvIZeUHiYEkr8qDfhhSDDOYZrMiknz0r1Iw==",
           "dev": true,
           "requires": {
-            "brcast": "3.0.1",
-            "csstype": "2.3.0",
-            "fast-memoize": "2.2.8",
-            "html-tag-names": "1.1.2",
-            "is-function": "1.0.1",
-            "is-plain-object": "2.0.4",
-            "react-html-attributes": "1.4.2",
-            "svg-tag-names": "1.1.1"
+            "brcast": "^3.0.0",
+            "csstype": "^2.2.0",
+            "fast-memoize": "^2.2.7",
+            "html-tag-names": "^1.1.1",
+            "is-function": "^1.0.1",
+            "is-plain-object": "^2.0.4",
+            "react-html-attributes": "^1.4.2",
+            "svg-tag-names": "^1.1.0"
           }
         },
         "prop-types": {
@@ -833,9 +833,9 @@
           "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
           "dev": true,
           "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
+            "fbjs": "^0.8.16",
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
           }
         },
         "react-html-attributes": {
@@ -844,7 +844,7 @@
           "integrity": "sha1-DSzPE0/Hmy01Q4N9wVkdMre5A/k=",
           "dev": true,
           "requires": {
-            "html-element-attributes": "1.3.0"
+            "html-element-attributes": "^1.0.0"
           }
         }
       }
@@ -855,9 +855,9 @@
       "integrity": "sha512-aab+Rfbpjm5EQ+aQLtxRV1xlba4Usvuu214yP/Mrw3ll1PnlUkq6iASOXE7oT301QZmztGxy8oyGHzfAXxZ8lw==",
       "dev": true,
       "requires": {
-        "@storybook/components": "3.3.10",
-        "global": "4.3.2",
-        "prop-types": "15.6.0"
+        "@storybook/components": "^3.3.10",
+        "global": "^4.3.2",
+        "prop-types": "^15.5.10"
       }
     },
     "@storybook/addon-options": {
@@ -872,13 +872,13 @@
       "integrity": "sha512-/83gj4VxVKGU5Jf5tK6oczr0tnhYMG336UwoQPVySVrFhMbnslpAW80QNcs2/+EWsZOA7YfNbRnnUwrVPsAgfw==",
       "dev": true,
       "requires": {
-        "@storybook/channels": "3.3.10",
-        "babel-runtime": "6.26.0",
-        "glob": "7.1.2",
-        "global": "4.3.2",
-        "jest-specific-snapshot": "0.3.0",
-        "prop-types": "15.6.0",
-        "read-pkg-up": "3.0.0"
+        "@storybook/channels": "^3.3.10",
+        "babel-runtime": "^6.26.0",
+        "glob": "^7.1.2",
+        "global": "^4.3.2",
+        "jest-specific-snapshot": "^0.3.0",
+        "prop-types": "^15.6.0",
+        "read-pkg-up": "^3.0.0"
       },
       "dependencies": {
         "@storybook/channels": {
@@ -893,10 +893,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "parse-json": {
@@ -905,8 +905,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.1"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -915,7 +915,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -930,9 +930,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -941,8 +941,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "strip-bom": {
@@ -965,9 +965,9 @@
       "integrity": "sha512-89H+UoYIXkXdXkkc6Gb/qkxFod/G0rQDhOMtrDYN8LuikZ11OwhACjRLZ0F8g44o/64dkMzn0t/6qHUX5WTPHw==",
       "dev": true,
       "requires": {
-        "@storybook/channels": "3.3.10",
-        "global": "4.3.2",
-        "json-stringify-safe": "5.0.1"
+        "@storybook/channels": "^3.3.10",
+        "global": "^4.3.2",
+        "json-stringify-safe": "^5.0.1"
       }
     },
     "@storybook/channels": {
@@ -988,9 +988,9 @@
       "integrity": "sha512-4M30s2BZoLmp5IqaOQ7U2M29FACI6ioi74fMps06aUYIWWmY8a7w2hKpo3+DxXtytZUxRyrIUcEfGpALK/dfmw==",
       "dev": true,
       "requires": {
-        "glamor": "2.20.40",
-        "glamorous": "4.11.4",
-        "prop-types": "15.6.0"
+        "glamor": "^2.20.40",
+        "glamorous": "^4.11.2",
+        "prop-types": "^15.6.0"
       }
     },
     "@storybook/mantra-core": {
@@ -999,9 +999,9 @@
       "integrity": "sha512-GD4OYJ8GsayVhIg306sfgcKDk9j8YfuSKIAWvdB/g7IDlw0pDgueONALVEEE2XWJtCwcsUyDtCYzXFgCBWLEjA==",
       "dev": true,
       "requires": {
-        "@storybook/react-komposer": "2.0.3",
-        "@storybook/react-simple-di": "1.3.0",
-        "babel-runtime": "6.26.0"
+        "@storybook/react-komposer": "^2.0.1",
+        "@storybook/react-simple-di": "^1.2.1",
+        "babel-runtime": "6.x.x"
       }
     },
     "@storybook/node-logger": {
@@ -1010,8 +1010,8 @@
       "integrity": "sha512-SRuv0JpeBBHjgkZKz+fiSnphD2xYu/+qBdKODmPU1stqE93XM49fxThe8aF+bjgxd2be9tUAEJQNvvIiyBvIOA==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "npmlog": "4.1.2"
+        "chalk": "^2.3.0",
+        "npmlog": "^4.1.2"
       }
     },
     "@storybook/react": {
@@ -1020,63 +1020,63 @@
       "integrity": "sha512-AaSnR5/d9ZPLNIlRB1e3Q3i2W9/5Nlu/+oRkNgAkGpo+jM9INOeS2uIPAXSIqmTXxF5Lstc2GVtXvVtmoMivCg==",
       "dev": true,
       "requires": {
-        "@storybook/addon-actions": "3.3.10",
-        "@storybook/addon-links": "3.3.10",
-        "@storybook/addons": "3.3.10",
-        "@storybook/channel-postmessage": "3.3.10",
-        "@storybook/client-logger": "3.3.10",
-        "@storybook/node-logger": "3.3.10",
-        "@storybook/ui": "3.3.10",
-        "airbnb-js-shims": "1.6.0",
-        "autoprefixer": "7.2.5",
-        "babel-loader": "7.1.2",
-        "babel-plugin-react-docgen": "1.8.2",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "babel-plugin-transform-runtime": "6.23.0",
-        "babel-preset-env": "1.6.1",
-        "babel-preset-minify": "0.2.0",
-        "babel-preset-react": "6.24.1",
-        "babel-preset-react-app": "3.1.1",
-        "babel-preset-stage-0": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "case-sensitive-paths-webpack-plugin": "2.1.1",
-        "chalk": "2.3.0",
-        "commander": "2.12.2",
-        "common-tags": "1.7.2",
-        "configstore": "3.1.1",
-        "core-js": "2.5.3",
-        "css-loader": "0.28.9",
-        "dotenv-webpack": "1.5.4",
-        "express": "4.16.2",
-        "file-loader": "1.1.6",
-        "find-cache-dir": "1.0.0",
-        "glamor": "2.20.40",
-        "glamorous": "4.11.4",
-        "global": "4.3.2",
-        "html-loader": "0.5.5",
-        "html-webpack-plugin": "2.30.1",
-        "json-loader": "0.5.7",
-        "json-stringify-safe": "5.0.1",
-        "json5": "0.5.1",
-        "lodash.flattendeep": "4.4.0",
-        "markdown-loader": "2.0.2",
-        "npmlog": "4.1.2",
-        "postcss-flexbugs-fixes": "3.3.0",
-        "postcss-loader": "2.0.10",
-        "prop-types": "15.6.0",
-        "qs": "6.5.1",
-        "redux": "3.7.2",
-        "request": "2.83.0",
-        "serve-favicon": "2.4.5",
-        "shelljs": "0.7.8",
-        "style-loader": "0.19.1",
-        "uglifyjs-webpack-plugin": "1.1.6",
-        "url-loader": "0.6.2",
-        "util-deprecate": "1.0.2",
-        "uuid": "3.1.0",
-        "webpack": "3.10.0",
-        "webpack-dev-middleware": "1.12.2",
-        "webpack-hot-middleware": "2.21.0"
+        "@storybook/addon-actions": "^3.3.10",
+        "@storybook/addon-links": "^3.3.10",
+        "@storybook/addons": "^3.3.10",
+        "@storybook/channel-postmessage": "^3.3.10",
+        "@storybook/client-logger": "^3.3.10",
+        "@storybook/node-logger": "^3.3.10",
+        "@storybook/ui": "^3.3.10",
+        "airbnb-js-shims": "^1.4.0",
+        "autoprefixer": "^7.2.3",
+        "babel-loader": "^7.1.2",
+        "babel-plugin-react-docgen": "^1.8.0",
+        "babel-plugin-transform-regenerator": "^6.26.0",
+        "babel-plugin-transform-runtime": "^6.23.0",
+        "babel-preset-env": "^1.6.1",
+        "babel-preset-minify": "^0.2.0",
+        "babel-preset-react": "^6.24.1",
+        "babel-preset-react-app": "^3.1.0",
+        "babel-preset-stage-0": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "case-sensitive-paths-webpack-plugin": "^2.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.2",
+        "common-tags": "^1.6.0",
+        "configstore": "^3.1.1",
+        "core-js": "^2.5.3",
+        "css-loader": "^0.28.8",
+        "dotenv-webpack": "^1.5.4",
+        "express": "^4.16.2",
+        "file-loader": "^1.1.6",
+        "find-cache-dir": "^1.0.0",
+        "glamor": "^2.20.40",
+        "glamorous": "^4.11.2",
+        "global": "^4.3.2",
+        "html-loader": "^0.5.4",
+        "html-webpack-plugin": "^2.30.1",
+        "json-loader": "^0.5.7",
+        "json-stringify-safe": "^5.0.1",
+        "json5": "^0.5.1",
+        "lodash.flattendeep": "^4.4.0",
+        "markdown-loader": "^2.0.1",
+        "npmlog": "^4.1.2",
+        "postcss-flexbugs-fixes": "^3.2.0",
+        "postcss-loader": "^2.0.9",
+        "prop-types": "^15.6.0",
+        "qs": "^6.5.1",
+        "redux": "^3.7.2",
+        "request": "^2.83.0",
+        "serve-favicon": "^2.4.5",
+        "shelljs": "^0.7.8",
+        "style-loader": "^0.19.1",
+        "uglifyjs-webpack-plugin": "^1.1.6",
+        "url-loader": "^0.6.2",
+        "util-deprecate": "^1.0.2",
+        "uuid": "^3.1.0",
+        "webpack": "^3.10.0",
+        "webpack-dev-middleware": "^1.12.2",
+        "webpack-hot-middleware": "^2.21.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1091,20 +1091,20 @@
           "integrity": "sha512-r3dgelMm/mkPz5Y7m9SeiGE46i2VsEU/OYbez+1llfxtv8b2y5/b5StaeEvPK3S5tlNQI+tDW/xDIhKJoZgDtw==",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "css-selector-tokenizer": "0.7.0",
-            "cssnano": "3.10.0",
-            "icss-utils": "2.1.0",
-            "loader-utils": "1.1.0",
-            "lodash.camelcase": "4.3.0",
-            "object-assign": "4.1.1",
-            "postcss": "5.2.18",
-            "postcss-modules-extract-imports": "1.2.0",
-            "postcss-modules-local-by-default": "1.2.0",
-            "postcss-modules-scope": "1.1.0",
-            "postcss-modules-values": "1.3.0",
-            "postcss-value-parser": "3.3.0",
-            "source-list-map": "2.0.0"
+            "babel-code-frame": "^6.26.0",
+            "css-selector-tokenizer": "^0.7.0",
+            "cssnano": "^3.10.0",
+            "icss-utils": "^2.1.0",
+            "loader-utils": "^1.0.2",
+            "lodash.camelcase": "^4.3.0",
+            "object-assign": "^4.1.1",
+            "postcss": "^5.0.6",
+            "postcss-modules-extract-imports": "^1.2.0",
+            "postcss-modules-local-by-default": "^1.2.0",
+            "postcss-modules-scope": "^1.1.0",
+            "postcss-modules-values": "^1.3.0",
+            "postcss-value-parser": "^3.3.0",
+            "source-list-map": "^2.0.0"
           }
         },
         "has-flag": {
@@ -1119,10 +1119,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           },
           "dependencies": {
             "chalk": {
@@ -1131,11 +1131,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -1154,7 +1154,7 @@
           "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
           "dev": true,
           "requires": {
-            "postcss": "6.0.16"
+            "postcss": "^6.0.1"
           },
           "dependencies": {
             "has-flag": {
@@ -1169,9 +1169,9 @@
               "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
               "dev": true,
               "requires": {
-                "chalk": "2.3.0",
-                "source-map": "0.6.1",
-                "supports-color": "5.1.0"
+                "chalk": "^2.3.0",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.1.0"
               }
             },
             "source-map": {
@@ -1186,7 +1186,7 @@
               "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
               "dev": true,
               "requires": {
-                "has-flag": "2.0.0"
+                "has-flag": "^2.0.0"
               }
             }
           }
@@ -1197,8 +1197,8 @@
           "integrity": "sha512-sgv/iF/T4/SewJkaVpldKC4WjSkz0JsOh2eKtxCPpCO1oR05+7MOF+H476HVRbLArkgA7j5TRJJ4p2jdFkUGQQ==",
           "dev": true,
           "requires": {
-            "ajv": "5.5.2",
-            "ajv-keywords": "2.1.1"
+            "ajv": "^5.0.0",
+            "ajv-keywords": "^2.1.0"
           }
         },
         "style-loader": {
@@ -1207,8 +1207,8 @@
           "integrity": "sha512-IRE+ijgojrygQi3rsqT0U4dd+UcPCqcVvauZpCnQrGAlEe+FUIyrK93bUDScamesjP08JlQNsFJU+KmPedP5Og==",
           "dev": true,
           "requires": {
-            "loader-utils": "1.1.0",
-            "schema-utils": "0.3.0"
+            "loader-utils": "^1.0.2",
+            "schema-utils": "^0.3.0"
           },
           "dependencies": {
             "schema-utils": {
@@ -1217,7 +1217,7 @@
               "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
               "dev": true,
               "requires": {
-                "ajv": "5.5.2"
+                "ajv": "^5.0.0"
               }
             }
           }
@@ -1228,7 +1228,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         },
         "uglify-es": {
@@ -1237,8 +1237,8 @@
           "integrity": "sha512-j8li0jWcAN6yBuAVYFZEFyYINZAm4WEdMwkA6qXFi4TLrze3Mp0Le7QjW6LR9HQjQJ2zRa9VgnFLs3PatijWOw==",
           "dev": true,
           "requires": {
-            "commander": "2.13.0",
-            "source-map": "0.6.1"
+            "commander": "~2.13.0",
+            "source-map": "~0.6.1"
           },
           "dependencies": {
             "commander": {
@@ -1261,14 +1261,14 @@
           "integrity": "sha512-VUja+7rYbznEvUaeb8IxOCTUrq4BCb1ml0vffa+mfwKtrAwlqnU0ENF14DtYltV1cxd/HSuK51CCA/D/8kMQVw==",
           "dev": true,
           "requires": {
-            "cacache": "10.0.1",
-            "find-cache-dir": "1.0.0",
-            "schema-utils": "0.4.3",
-            "serialize-javascript": "1.4.0",
-            "source-map": "0.6.1",
-            "uglify-es": "3.3.8",
-            "webpack-sources": "1.1.0",
-            "worker-farm": "1.5.2"
+            "cacache": "^10.0.1",
+            "find-cache-dir": "^1.0.0",
+            "schema-utils": "^0.4.2",
+            "serialize-javascript": "^1.4.0",
+            "source-map": "^0.6.1",
+            "uglify-es": "^3.3.4",
+            "webpack-sources": "^1.1.0",
+            "worker-farm": "^1.5.2"
           },
           "dependencies": {
             "source-map": {
@@ -1287,11 +1287,11 @@
       "integrity": "sha512-DjL/XwZLNx79Rc1y0dyjxme64eUSJeJvajCN587sVDsVZIgsPlDWwmaohOCkPhR8HNGrY89qoeFZZxFslT203w==",
       "dev": true,
       "requires": {
-        "@storybook/react-stubber": "1.0.1",
-        "babel-runtime": "6.26.0",
-        "hoist-non-react-statics": "1.2.0",
-        "lodash.pick": "4.4.0",
-        "shallowequal": "0.2.2"
+        "@storybook/react-stubber": "^1.0.0",
+        "babel-runtime": "^6.11.6",
+        "hoist-non-react-statics": "^1.2.0",
+        "lodash.pick": "^4.4.0",
+        "shallowequal": "^0.2.2"
       }
     },
     "@storybook/react-simple-di": {
@@ -1300,10 +1300,10 @@
       "integrity": "sha512-RH6gPQaYMs/VzQX2dgbZU8DQMKFXVOv1ruohHjjNPys4q+YdqMFMDe5jOP1AUE3j9g01x0eW7bVjRawSpl++Ew==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "create-react-class": "15.6.2",
-        "hoist-non-react-statics": "1.2.0",
-        "prop-types": "15.6.0"
+        "babel-runtime": "6.x.x",
+        "create-react-class": "^15.6.2",
+        "hoist-non-react-statics": "1.x.x",
+        "prop-types": "^15.6.0"
       }
     },
     "@storybook/react-stubber": {
@@ -1312,7 +1312,7 @@
       "integrity": "sha512-k+CHH+vA8bQfCmzBTtJsPkITFgD+C/w19KuByZ9WeEvNUFtnDaCqfP+Vp3/OR+3IAfAXYYOWolqPLxNPcEqEjw==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.5.0"
       }
     },
     "@storybook/storybook-deployer": {
@@ -1321,10 +1321,10 @@
       "integrity": "sha512-islhy4R8i8sxdLD71X2Wy1wo5ZgsDCVqHVN91+1lB+zAOweLTi1aQm2dcRh+me65jAopkJdFjmbiQ2TVgjAo2w==",
       "dev": true,
       "requires": {
-        "git-url-parse": "8.1.0",
-        "parse-repo": "1.0.4",
-        "shelljs": "0.8.1",
-        "yargs": "11.0.0"
+        "git-url-parse": "^8.1.0",
+        "parse-repo": "^1.0.4",
+        "shelljs": "^0.8.1",
+        "yargs": "^11.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1345,9 +1345,9 @@
           "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -1362,9 +1362,9 @@
           "integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
           "dev": true,
           "requires": {
-            "glob": "7.1.2",
-            "interpret": "1.1.0",
-            "rechoir": "0.6.2"
+            "glob": "^7.0.0",
+            "interpret": "^1.0.0",
+            "rechoir": "^0.6.2"
           }
         },
         "string-width": {
@@ -1373,8 +1373,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -1383,7 +1383,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "yargs": {
@@ -1392,18 +1392,18 @@
           "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
           "dev": true,
           "requires": {
-            "cliui": "4.0.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
           }
         },
         "yargs-parser": {
@@ -1412,7 +1412,7 @@
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -1423,29 +1423,29 @@
       "integrity": "sha512-MiosMkpozvFdn3f13qtNJ04y7tw7yHwumYae2P8Mb1z93tiXLWY2lSRPiAsifpOfn4cmCNgLHcKbcXr9G3d9CA==",
       "dev": true,
       "requires": {
-        "@storybook/components": "3.3.10",
-        "@storybook/mantra-core": "1.7.2",
-        "@storybook/react-komposer": "2.0.3",
-        "babel-runtime": "6.26.0",
-        "deep-equal": "1.0.1",
-        "events": "1.1.1",
-        "fuse.js": "3.2.0",
-        "global": "4.3.2",
-        "json-stringify-safe": "5.0.1",
-        "keycode": "2.1.9",
-        "lodash.debounce": "4.0.8",
-        "lodash.pick": "4.4.0",
-        "lodash.sortby": "4.7.0",
-        "podda": "1.2.2",
-        "prop-types": "15.6.0",
-        "qs": "6.5.1",
-        "react-fuzzy": "0.5.1",
-        "react-icons": "2.2.7",
-        "react-inspector": "2.2.2",
-        "react-modal": "3.1.11",
-        "react-split-pane": "0.1.74",
-        "react-treebeard": "2.1.0",
-        "redux": "3.7.2"
+        "@storybook/components": "^3.3.10",
+        "@storybook/mantra-core": "^1.7.2",
+        "@storybook/react-komposer": "^2.0.3",
+        "babel-runtime": "^6.26.0",
+        "deep-equal": "^1.0.1",
+        "events": "^1.1.1",
+        "fuse.js": "^3.2.0",
+        "global": "^4.3.2",
+        "json-stringify-safe": "^5.0.1",
+        "keycode": "^2.1.9",
+        "lodash.debounce": "^4.0.8",
+        "lodash.pick": "^4.4.0",
+        "lodash.sortby": "^4.7.0",
+        "podda": "^1.2.2",
+        "prop-types": "^15.6.0",
+        "qs": "^6.5.1",
+        "react-fuzzy": "^0.5.1",
+        "react-icons": "^2.2.7",
+        "react-inspector": "^2.2.2",
+        "react-modal": "^3.1.10",
+        "react-split-pane": "^0.1.74",
+        "react-treebeard": "^2.1.0",
+        "redux": "^3.7.2"
       }
     },
     "@types/inline-style-prefixer": {
@@ -1472,8 +1472,8 @@
       "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "dev": true,
       "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "abab": {
@@ -1494,7 +1494,7 @@
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.17",
+        "mime-types": "~2.1.16",
         "negotiator": "0.6.1"
       }
     },
@@ -1510,7 +1510,7 @@
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.3"
       },
       "dependencies": {
         "acorn": {
@@ -1527,7 +1527,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -1544,7 +1544,7 @@
       "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
       "dev": true,
       "requires": {
-        "es6-promisify": "5.0.0"
+        "es6-promisify": "^5.0.0"
       }
     },
     "aggregate-error": {
@@ -1553,8 +1553,8 @@
       "integrity": "sha1-iINE2tAiCnLjr1CQYRf0h3GSX6w=",
       "dev": true,
       "requires": {
-        "clean-stack": "1.3.0",
-        "indent-string": "3.2.0"
+        "clean-stack": "^1.0.0",
+        "indent-string": "^3.0.0"
       },
       "dependencies": {
         "indent-string": {
@@ -1571,21 +1571,21 @@
       "integrity": "sha512-yrlKswsUUYR8KTalUzi92O3MNq7grj60pP1z4Txu1LTTtsu2ACblLgaYxgzS99FQ0BZUFKPZyX2CboPdDcuETQ==",
       "dev": true,
       "requires": {
-        "array-includes": "3.0.3",
-        "array.prototype.flat": "1.2.1",
-        "array.prototype.flatmap": "1.2.1",
-        "array.prototype.flatten": "1.2.1",
-        "es5-shim": "4.5.10",
-        "es6-shim": "0.35.3",
-        "function.prototype.name": "1.1.0",
-        "object.entries": "1.0.4",
-        "object.getownpropertydescriptors": "2.0.3",
-        "object.values": "1.0.4",
-        "promise.prototype.finally": "3.1.0",
-        "string.prototype.matchall": "3.0.0",
-        "string.prototype.padend": "3.0.0",
-        "string.prototype.padstart": "3.0.0",
-        "symbol.prototype.description": "1.0.0"
+        "array-includes": "^3.0.3",
+        "array.prototype.flat": "^1.2.1",
+        "array.prototype.flatmap": "^1.2.1",
+        "array.prototype.flatten": "^1.2.1",
+        "es5-shim": "^4.5.10",
+        "es6-shim": "^0.35.3",
+        "function.prototype.name": "^1.1.0",
+        "object.entries": "^1.0.4",
+        "object.getownpropertydescriptors": "^2.0.3",
+        "object.values": "^1.0.4",
+        "promise.prototype.finally": "^3.1.0",
+        "string.prototype.matchall": "^3.0.0",
+        "string.prototype.padend": "^3.0.0",
+        "string.prototype.padstart": "^3.0.0",
+        "symbol.prototype.description": "^1.0.0"
       },
       "dependencies": {
         "function.prototype.name": {
@@ -1594,9 +1594,9 @@
           "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
           "dev": true,
           "requires": {
-            "define-properties": "1.1.2",
-            "function-bind": "1.1.1",
-            "is-callable": "1.1.3"
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "is-callable": "^1.1.3"
           }
         }
       }
@@ -1606,15 +1606,15 @@
       "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.10.0.tgz",
       "integrity": "sha512-M7kDqFO6kFNGV0fHPZaBx672m0jwbpCdbrtW2lcevCEuPB2sKCY3IPa030K/N1iJLEGwCNk4NSag65XBEulwhg==",
       "requires": {
-        "array.prototype.find": "2.0.4",
-        "function.prototype.name": "1.1.0",
-        "has": "1.0.1",
-        "is-regex": "1.0.4",
-        "object-is": "1.0.1",
-        "object.assign": "4.1.0",
-        "object.entries": "1.0.4",
-        "prop-types": "15.6.1",
-        "prop-types-exact": "1.1.2"
+        "array.prototype.find": "^2.0.4",
+        "function.prototype.name": "^1.1.0",
+        "has": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4",
+        "prop-types": "^15.6.1",
+        "prop-types-exact": "^1.1.2"
       },
       "dependencies": {
         "function.prototype.name": {
@@ -1622,9 +1622,9 @@
           "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
           "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
           "requires": {
-            "define-properties": "1.1.2",
-            "function-bind": "1.1.1",
-            "is-callable": "1.1.3"
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "is-callable": "^1.1.3"
           }
         },
         "object.assign": {
@@ -1632,10 +1632,10 @@
           "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
           "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
           "requires": {
-            "define-properties": "1.1.2",
-            "function-bind": "1.1.1",
-            "has-symbols": "1.0.0",
-            "object-keys": "1.0.11"
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "object-keys": "^1.0.11"
           }
         },
         "prop-types": {
@@ -1643,9 +1643,9 @@
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
           "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
           "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
+            "fbjs": "^0.8.16",
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
           }
         }
       }
@@ -1656,10 +1656,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -1674,9 +1674,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "alphanum-sort": {
@@ -1703,7 +1703,7 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1724,8 +1724,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -1734,7 +1734,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -1761,9 +1761,8 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-      "dev": true,
       "requires": {
-        "color-convert": "1.9.1"
+        "color-convert": "^1.9.0"
       }
     },
     "ansicolors": {
@@ -1778,8 +1777,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "append-transform": {
@@ -1788,7 +1787,7 @@
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
       "dev": true,
       "requires": {
-        "default-require-extensions": "1.0.0"
+        "default-require-extensions": "^1.0.0"
       }
     },
     "aproba": {
@@ -1803,8 +1802,8 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -1813,7 +1812,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "argv-formatter": {
@@ -1829,7 +1828,7 @@
       "dev": true,
       "requires": {
         "ast-types-flow": "0.0.7",
-        "commander": "2.12.2"
+        "commander": "^2.11.0"
       }
     },
     "arr-diff": {
@@ -1838,7 +1837,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -1889,8 +1888,8 @@
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "array-union": {
@@ -1899,14 +1898,13 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array-unique": {
       "version": "0.2.1",
@@ -1919,8 +1917,8 @@
       "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
       "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "array.prototype.flat": {
@@ -1929,9 +1927,9 @@
       "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.10.0",
+        "function-bind": "^1.1.1"
       }
     },
     "array.prototype.flatmap": {
@@ -1940,9 +1938,9 @@
       "integrity": "sha512-i18e2APdsiezkcqDyZor78Pbfjfds3S94dG6dgIV2ZASJaUf1N0dz2tGdrmwrmlZuNUgxH+wz6Z0zYVH2c5xzQ==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.10.0",
+        "function-bind": "^1.1.1"
       }
     },
     "array.prototype.flatten": {
@@ -1951,9 +1949,9 @@
       "integrity": "sha512-3GhsA78XgK//wQKbhUe6L93kknekGlTRY0kvYcpuSi0aa9rVrMr/okeIIv/XSpN8fZ5iUM+bWifhf2/7CYKtIg==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.10.0",
+        "function-bind": "^1.1.1"
       }
     },
     "arrify": {
@@ -1979,9 +1977,9 @@
       "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -2034,7 +2032,7 @@
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.14.0"
       }
     },
     "async-each": {
@@ -2067,12 +2065,12 @@
       "integrity": "sha512-XqHfo8Ht0VU+T5P+eWEVoXza456KJ4l62BPewu3vpNf3LP9s2+zYXkXBznzYby4XeECXgG3N4i+hGvOhXErZmA==",
       "dev": true,
       "requires": {
-        "browserslist": "2.11.3",
-        "caniuse-lite": "1.0.30000792",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "6.0.16",
-        "postcss-value-parser": "3.3.0"
+        "browserslist": "^2.11.1",
+        "caniuse-lite": "^1.0.30000791",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^6.0.16",
+        "postcss-value-parser": "^3.2.3"
       },
       "dependencies": {
         "browserslist": {
@@ -2081,8 +2079,8 @@
           "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30000792",
-            "electron-to-chromium": "1.3.31"
+            "caniuse-lite": "^1.0.30000792",
+            "electron-to-chromium": "^1.3.30"
           }
         },
         "caniuse-lite": {
@@ -2103,9 +2101,9 @@
           "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
-            "source-map": "0.6.1",
-            "supports-color": "5.1.0"
+            "chalk": "^2.3.0",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.1.0"
           }
         },
         "source-map": {
@@ -2120,7 +2118,7 @@
           "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -2158,21 +2156,21 @@
       "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-polyfill": "6.26.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "chokidar": "1.7.0",
-        "commander": "2.12.2",
-        "convert-source-map": "1.5.1",
-        "fs-readdir-recursive": "1.1.0",
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "output-file-sync": "1.1.2",
-        "path-is-absolute": "1.0.1",
-        "slash": "1.0.0",
-        "source-map": "0.5.7",
-        "v8flags": "2.1.1"
+        "babel-core": "^6.26.0",
+        "babel-polyfill": "^6.26.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "chokidar": "^1.6.1",
+        "commander": "^2.11.0",
+        "convert-source-map": "^1.5.0",
+        "fs-readdir-recursive": "^1.0.0",
+        "glob": "^7.1.2",
+        "lodash": "^4.17.4",
+        "output-file-sync": "^1.1.2",
+        "path-is-absolute": "^1.0.1",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.6",
+        "v8flags": "^2.1.1"
       }
     },
     "babel-code-frame": {
@@ -2181,9 +2179,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2198,11 +2196,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -2219,25 +2217,25 @@
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "debug": "^2.6.8",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.7",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.6"
       }
     },
     "babel-generator": {
@@ -2246,14 +2244,14 @@
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.6",
+        "trim-right": "^1.0.1"
       }
     },
     "babel-helper-bindify-decorators": {
@@ -2262,9 +2260,9 @@
       "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -2273,9 +2271,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-builder-react-jsx": {
@@ -2284,9 +2282,9 @@
       "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "esutils": "2.0.2"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "esutils": "^2.0.2"
       }
     },
     "babel-helper-call-delegate": {
@@ -2295,10 +2293,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -2307,10 +2305,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-evaluate-path": {
@@ -2325,9 +2323,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-explode-class": {
@@ -2336,10 +2334,10 @@
       "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
       "dev": true,
       "requires": {
-        "babel-helper-bindify-decorators": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-bindify-decorators": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-flip-expressions": {
@@ -2354,11 +2352,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -2367,8 +2365,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -2377,8 +2375,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-is-nodes-equiv": {
@@ -2405,8 +2403,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -2415,9 +2413,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -2426,11 +2424,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-remove-or-void": {
@@ -2445,12 +2443,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-to-multiple-sequence-expressions": {
@@ -2465,8 +2463,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-jest": {
@@ -2475,8 +2473,8 @@
       "integrity": "sha1-Djg6KqazU14ZfbKSlXCiGCvQhOg=",
       "dev": true,
       "requires": {
-        "babel-plugin-istanbul": "4.1.6",
-        "babel-preset-jest": "23.0.0"
+        "babel-plugin-istanbul": "^4.1.6",
+        "babel-preset-jest": "^23.0.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -2497,10 +2495,10 @@
           "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
           "dev": true,
           "requires": {
-            "babel-plugin-syntax-object-rest-spread": "6.13.0",
-            "find-up": "2.1.0",
-            "istanbul-lib-instrument": "1.10.1",
-            "test-exclude": "4.2.1"
+            "babel-plugin-syntax-object-rest-spread": "^6.13.0",
+            "find-up": "^2.1.0",
+            "istanbul-lib-instrument": "^1.10.1",
+            "test-exclude": "^4.2.1"
           }
         },
         "braces": {
@@ -2509,16 +2507,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.1",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -2527,7 +2525,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -2538,13 +2536,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -2553,7 +2551,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -2562,7 +2560,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-descriptor": {
@@ -2571,9 +2569,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -2590,14 +2588,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -2606,7 +2604,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -2615,7 +2613,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -2626,10 +2624,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -2638,7 +2636,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -2649,7 +2647,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2658,7 +2656,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -2669,7 +2667,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2678,7 +2676,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -2689,7 +2687,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2698,7 +2696,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -2715,13 +2713,13 @@
           "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
           "dev": true,
           "requires": {
-            "babel-generator": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "istanbul-lib-coverage": "1.2.0",
-            "semver": "5.4.1"
+            "babel-generator": "^6.18.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.18.0",
+            "babel-types": "^6.18.0",
+            "babylon": "^6.18.0",
+            "istanbul-lib-coverage": "^1.2.0",
+            "semver": "^5.3.0"
           }
         },
         "kind-of": {
@@ -2736,19 +2734,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         },
         "test-exclude": {
@@ -2757,11 +2755,11 @@
           "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
           "dev": true,
           "requires": {
-            "arrify": "1.0.1",
-            "micromatch": "3.1.10",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "require-main-filename": "1.0.1"
+            "arrify": "^1.0.1",
+            "micromatch": "^3.1.8",
+            "object-assign": "^4.1.0",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
           }
         }
       }
@@ -2772,9 +2770,9 @@
       "integrity": "sha512-jRwlFbINAeyDStqK6Dd5YuY0k5YuzQUvlz2ZamuXrXmxav3pNqe9vfJ402+2G+OmlJSXxCOpB6Uz0INM7RQe2A==",
       "dev": true,
       "requires": {
-        "find-cache-dir": "1.0.0",
-        "loader-utils": "1.1.0",
-        "mkdirp": "0.5.1"
+        "find-cache-dir": "^1.0.0",
+        "loader-utils": "^1.0.2",
+        "mkdirp": "^0.5.1"
       }
     },
     "babel-messages": {
@@ -2783,7 +2781,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -2792,7 +2790,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-dynamic-import-node": {
@@ -2801,9 +2799,9 @@
       "integrity": "sha512-tTfZbM9Ecwj3GK50mnPrUpinTwA4xXmDiQGCk/aBYbvl1+X8YqldK86wZ1owVJ4u3mrKbRlXMma80J18qwiaTQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -2812,9 +2810,9 @@
       "integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "istanbul-lib-instrument": "1.9.1",
-        "test-exclude": "4.1.1"
+        "find-up": "^2.1.0",
+        "istanbul-lib-instrument": "^1.7.5",
+        "test-exclude": "^4.1.1"
       }
     },
     "babel-plugin-jest-hoist": {
@@ -2829,7 +2827,7 @@
       "integrity": "sha512-4i+8ntaS8gwVUcOz5y+zE+55OVOl2nTbmHV51D4wAIiKcRI8U5K//ip1GHfhsgk/NJrrHK7h97Oy5jpqt0Iixg==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "0.2.0"
+        "babel-helper-evaluate-path": "^0.2.0"
       }
     },
     "babel-plugin-minify-constant-folding": {
@@ -2838,7 +2836,7 @@
       "integrity": "sha512-B3ffQBEUQ8ydlIkYv2MkZtTCbV7FAkWAV7NkyhcXlGpD10PaCxNGQ/B9oguXGowR1m16Q5nGhvNn8Pkn1MO6Hw==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "0.2.0"
+        "babel-helper-evaluate-path": "^0.2.0"
       }
     },
     "babel-plugin-minify-dead-code-elimination": {
@@ -2847,10 +2845,10 @@
       "integrity": "sha512-zE7y3pRyzA4zK5nBou0kTcwUTSQ/AiFrynt1cIEYN7vcO2gS9ZFZoI0aO9JYLUdct5fsC1vfB35408yrzTyVfg==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "0.2.0",
-        "babel-helper-mark-eval-scopes": "0.2.0",
-        "babel-helper-remove-or-void": "0.2.0",
-        "lodash.some": "4.6.0"
+        "babel-helper-evaluate-path": "^0.2.0",
+        "babel-helper-mark-eval-scopes": "^0.2.0",
+        "babel-helper-remove-or-void": "^0.2.0",
+        "lodash.some": "^4.6.0"
       }
     },
     "babel-plugin-minify-flip-comparisons": {
@@ -2859,7 +2857,7 @@
       "integrity": "sha512-QOqXSEmD/LhT3LpM1WCyzAGcQZYYKJF7oOHvS6QbpomHenydrV53DMdPX2mK01icBExKZcJAHF209wvDBa+CSg==",
       "dev": true,
       "requires": {
-        "babel-helper-is-void-0": "0.2.0"
+        "babel-helper-is-void-0": "^0.2.0"
       }
     },
     "babel-plugin-minify-guarded-expressions": {
@@ -2868,7 +2866,7 @@
       "integrity": "sha512-5+NSPdRQ9mnrHaA+zFj+D5OzmSiv90EX5zGH6cWQgR/OUqmCHSDqgTRPFvOctgpo8MJyO7Rt7ajs2UfLnlAwYg==",
       "dev": true,
       "requires": {
-        "babel-helper-flip-expressions": "0.2.0"
+        "babel-helper-flip-expressions": "^0.2.0"
       }
     },
     "babel-plugin-minify-infinity": {
@@ -2883,7 +2881,7 @@
       "integrity": "sha512-Gixuak1/CO7VCdjn15/8Bxe/QsAtDG4zPbnsNoe1mIJGCIH/kcmSjFhMlGJtXDQZd6EKzeMfA5WmX9+jvGRefw==",
       "dev": true,
       "requires": {
-        "babel-helper-mark-eval-scopes": "0.2.0"
+        "babel-helper-mark-eval-scopes": "^0.2.0"
       }
     },
     "babel-plugin-minify-numeric-literals": {
@@ -2904,9 +2902,9 @@
       "integrity": "sha512-Mj3Mwy2zVosMfXDWXZrQH5/uMAyfJdmDQ1NVqit+ArbHC3LlXVzptuyC1JxTyai/wgFvjLaichm/7vSUshkWqw==",
       "dev": true,
       "requires": {
-        "babel-helper-flip-expressions": "0.2.0",
-        "babel-helper-is-nodes-equiv": "0.0.1",
-        "babel-helper-to-multiple-sequence-expressions": "0.2.0"
+        "babel-helper-flip-expressions": "^0.2.0",
+        "babel-helper-is-nodes-equiv": "^0.0.1",
+        "babel-helper-to-multiple-sequence-expressions": "^0.2.0"
       }
     },
     "babel-plugin-minify-type-constructors": {
@@ -2915,7 +2913,7 @@
       "integrity": "sha512-NiOvvA9Pq6bki6nP4BayXwT5GZadw7DJFDDzHmkpnOQpENWe8RtHtKZM44MG1R6EQ5XxgbLdsdhswIzTkFlO5g==",
       "dev": true,
       "requires": {
-        "babel-helper-is-void-0": "0.2.0"
+        "babel-helper-is-void-0": "^0.2.0"
       }
     },
     "babel-plugin-react-docgen": {
@@ -2924,9 +2922,9 @@
       "integrity": "sha512-201wzLbDeeZri6p+KREqspsFA8rNV6SiVx65jiPC6lhM7TUTNcbEoacFHbB6ou8ONsQT3phTqLpd5Nl02mZaqw==",
       "dev": true,
       "requires": {
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4",
-        "react-docgen": "2.20.0"
+        "babel-types": "^6.24.1",
+        "lodash": "^4.17.0",
+        "react-docgen": "^2.20.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -3019,9 +3017,9 @@
       "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-generators": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-generators": "^6.5.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-async-to-generator": {
@@ -3030,9 +3028,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-class-constructor-call": {
@@ -3041,9 +3039,9 @@
       "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-class-constructor-call": "6.18.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-syntax-class-constructor-call": "^6.18.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -3052,10 +3050,10 @@
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-plugin-syntax-class-properties": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-decorators": {
@@ -3064,11 +3062,11 @@
       "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-class": "6.24.1",
-        "babel-plugin-syntax-decorators": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-class": "^6.24.1",
+        "babel-plugin-syntax-decorators": "^6.13.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-do-expressions": {
@@ -3077,8 +3075,8 @@
       "integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-do-expressions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-do-expressions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -3087,7 +3085,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -3096,7 +3094,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -3105,11 +3103,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -3118,15 +3116,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -3135,8 +3133,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -3145,7 +3143,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -3154,8 +3152,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -3164,7 +3162,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -3173,9 +3171,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -3184,7 +3182,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -3193,9 +3191,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -3204,10 +3202,10 @@
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -3216,9 +3214,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -3227,9 +3225,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -3238,8 +3236,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -3248,12 +3246,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -3262,8 +3260,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -3272,7 +3270,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -3281,9 +3279,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -3292,7 +3290,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -3301,7 +3299,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -3310,9 +3308,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -3321,9 +3319,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-export-extensions": {
@@ -3332,8 +3330,8 @@
       "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-export-extensions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-export-extensions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-flow-strip-types": {
@@ -3342,8 +3340,8 @@
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-flow": "^6.18.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-function-bind": {
@@ -3352,8 +3350,8 @@
       "integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-function-bind": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-function-bind": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-inline-consecutive-adds": {
@@ -3386,8 +3384,8 @@
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
       }
     },
     "babel-plugin-transform-property-literals": {
@@ -3396,7 +3394,7 @@
       "integrity": "sha512-MmiQsQ5AcIaRZMJD0zY5C4H3xuHm06/nWgtOsz7AXV44VEIXIlPiJ39IFYJ4Qx67/fEm8zJAedzR8t+B7d10Bg==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "babel-plugin-transform-react-constant-elements": {
@@ -3405,7 +3403,7 @@
       "integrity": "sha1-LxGb9NLN1F65uqrldAU8YE9hR90=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-display-name": {
@@ -3414,7 +3412,7 @@
       "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-jsx": {
@@ -3423,9 +3421,9 @@
       "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-react-jsx": "6.26.0",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-react-jsx": "^6.24.1",
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-jsx-self": {
@@ -3434,8 +3432,8 @@
       "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-jsx-source": {
@@ -3444,8 +3442,8 @@
       "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -3454,7 +3452,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-regexp-constructors": {
@@ -3481,7 +3479,7 @@
       "integrity": "sha512-O8v57tPMHkp89kA4ZfQEYds/pzgvz/QYerBJjIuL5/Jc7RnvMVRA5gJY9zFKP7WayW8WOSBV4vh8Y8FJRio+ow==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "0.2.0"
+        "babel-helper-evaluate-path": "^0.2.0"
       }
     },
     "babel-plugin-transform-runtime": {
@@ -3490,7 +3488,7 @@
       "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-simplify-comparison-operators": {
@@ -3505,8 +3503,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-undefined-to-void": {
@@ -3520,9 +3518,9 @@
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
       }
     },
     "babel-preset-env": {
@@ -3531,36 +3529,36 @@
       "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.10.0",
-        "invariant": "2.2.2",
-        "semver": "5.4.1"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^2.1.2",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
       }
     },
     "babel-preset-flow": {
@@ -3569,7 +3567,7 @@
       "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-flow-strip-types": "6.22.0"
+        "babel-plugin-transform-flow-strip-types": "^6.22.0"
       }
     },
     "babel-preset-jest": {
@@ -3578,8 +3576,8 @@
       "integrity": "sha1-Sd4DA/G2h13K1hY+qn64Mw1Ugk0=",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "23.0.0",
-        "babel-plugin-syntax-object-rest-spread": "6.13.0"
+        "babel-plugin-jest-hoist": "^23.0.0",
+        "babel-plugin-syntax-object-rest-spread": "^6.13.0"
       }
     },
     "babel-preset-minify": {
@@ -3588,29 +3586,29 @@
       "integrity": "sha512-mR8Q44RmMzm18bM2Lqd9uiPopzk5GDCtVuquNbLFmX6lOKnqWoenaNBxnWW0UhBFC75lEHTIgNGCbnsRI0pJVw==",
       "dev": true,
       "requires": {
-        "babel-plugin-minify-builtins": "0.2.0",
-        "babel-plugin-minify-constant-folding": "0.2.0",
-        "babel-plugin-minify-dead-code-elimination": "0.2.0",
-        "babel-plugin-minify-flip-comparisons": "0.2.0",
-        "babel-plugin-minify-guarded-expressions": "0.2.0",
-        "babel-plugin-minify-infinity": "0.2.0",
-        "babel-plugin-minify-mangle-names": "0.2.0",
-        "babel-plugin-minify-numeric-literals": "0.2.0",
-        "babel-plugin-minify-replace": "0.2.0",
-        "babel-plugin-minify-simplify": "0.2.0",
-        "babel-plugin-minify-type-constructors": "0.2.0",
-        "babel-plugin-transform-inline-consecutive-adds": "0.2.0",
-        "babel-plugin-transform-member-expression-literals": "6.8.5",
-        "babel-plugin-transform-merge-sibling-variables": "6.8.6",
-        "babel-plugin-transform-minify-booleans": "6.8.3",
-        "babel-plugin-transform-property-literals": "6.8.5",
-        "babel-plugin-transform-regexp-constructors": "0.2.0",
-        "babel-plugin-transform-remove-console": "6.8.5",
-        "babel-plugin-transform-remove-debugger": "6.8.5",
-        "babel-plugin-transform-remove-undefined": "0.2.0",
-        "babel-plugin-transform-simplify-comparison-operators": "6.8.5",
-        "babel-plugin-transform-undefined-to-void": "6.8.3",
-        "lodash.isplainobject": "4.0.6"
+        "babel-plugin-minify-builtins": "^0.2.0",
+        "babel-plugin-minify-constant-folding": "^0.2.0",
+        "babel-plugin-minify-dead-code-elimination": "^0.2.0",
+        "babel-plugin-minify-flip-comparisons": "^0.2.0",
+        "babel-plugin-minify-guarded-expressions": "^0.2.0",
+        "babel-plugin-minify-infinity": "^0.2.0",
+        "babel-plugin-minify-mangle-names": "^0.2.0",
+        "babel-plugin-minify-numeric-literals": "^0.2.0",
+        "babel-plugin-minify-replace": "^0.2.0",
+        "babel-plugin-minify-simplify": "^0.2.0",
+        "babel-plugin-minify-type-constructors": "^0.2.0",
+        "babel-plugin-transform-inline-consecutive-adds": "^0.2.0",
+        "babel-plugin-transform-member-expression-literals": "^6.8.5",
+        "babel-plugin-transform-merge-sibling-variables": "^6.8.6",
+        "babel-plugin-transform-minify-booleans": "^6.8.3",
+        "babel-plugin-transform-property-literals": "^6.8.5",
+        "babel-plugin-transform-regexp-constructors": "^0.2.0",
+        "babel-plugin-transform-remove-console": "^6.8.5",
+        "babel-plugin-transform-remove-debugger": "^6.8.5",
+        "babel-plugin-transform-remove-undefined": "^0.2.0",
+        "babel-plugin-transform-simplify-comparison-operators": "^6.8.5",
+        "babel-plugin-transform-undefined-to-void": "^6.8.3",
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "babel-preset-react": {
@@ -3619,12 +3617,12 @@
       "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-plugin-transform-react-display-name": "6.25.0",
-        "babel-plugin-transform-react-jsx": "6.24.1",
-        "babel-plugin-transform-react-jsx-self": "6.22.0",
-        "babel-plugin-transform-react-jsx-source": "6.22.0",
-        "babel-preset-flow": "6.23.0"
+        "babel-plugin-syntax-jsx": "^6.3.13",
+        "babel-plugin-transform-react-display-name": "^6.23.0",
+        "babel-plugin-transform-react-jsx": "^6.24.1",
+        "babel-plugin-transform-react-jsx-self": "^6.22.0",
+        "babel-plugin-transform-react-jsx-source": "^6.22.0",
+        "babel-preset-flow": "^6.23.0"
       }
     },
     "babel-preset-react-app": {
@@ -3654,9 +3652,9 @@
       "integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-do-expressions": "6.22.0",
-        "babel-plugin-transform-function-bind": "6.22.0",
-        "babel-preset-stage-1": "6.24.1"
+        "babel-plugin-transform-do-expressions": "^6.22.0",
+        "babel-plugin-transform-function-bind": "^6.22.0",
+        "babel-preset-stage-1": "^6.24.1"
       }
     },
     "babel-preset-stage-1": {
@@ -3665,9 +3663,9 @@
       "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-class-constructor-call": "6.24.1",
-        "babel-plugin-transform-export-extensions": "6.22.0",
-        "babel-preset-stage-2": "6.24.1"
+        "babel-plugin-transform-class-constructor-call": "^6.24.1",
+        "babel-plugin-transform-export-extensions": "^6.22.0",
+        "babel-preset-stage-2": "^6.24.1"
       }
     },
     "babel-preset-stage-2": {
@@ -3676,10 +3674,10 @@
       "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
-        "babel-plugin-transform-class-properties": "6.24.1",
-        "babel-plugin-transform-decorators": "6.24.1",
-        "babel-preset-stage-3": "6.24.1"
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-plugin-transform-class-properties": "^6.24.1",
+        "babel-plugin-transform-decorators": "^6.24.1",
+        "babel-preset-stage-3": "^6.24.1"
       }
     },
     "babel-preset-stage-3": {
@@ -3688,11 +3686,11 @@
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-generator-functions": "6.24.1",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-object-rest-spread": "6.26.0"
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-generator-functions": "^6.24.1",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+        "babel-plugin-transform-object-rest-spread": "^6.22.0"
       }
     },
     "babel-register": {
@@ -3701,13 +3699,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       }
     },
     "babel-runtime": {
@@ -3715,8 +3713,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -3738,11 +3736,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -3751,15 +3749,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -3768,10 +3766,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -3792,13 +3790,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -3807,7 +3805,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         }
       }
@@ -3831,7 +3829,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "before-after-hook": {
@@ -3865,7 +3863,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "bluebird": {
@@ -3887,15 +3885,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "http-errors": "1.6.2",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.15"
+        "type-is": "~1.6.15"
       }
     },
     "bonjour": {
@@ -3904,12 +3902,12 @@
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "dev": true,
       "requires": {
-        "array-flatten": "2.1.1",
-        "deep-equal": "1.0.1",
-        "dns-equal": "1.0.0",
-        "dns-txt": "2.0.2",
-        "multicast-dns": "6.2.3",
-        "multicast-dns-service-types": "1.1.0"
+        "array-flatten": "^2.1.0",
+        "deep-equal": "^1.0.1",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
       },
       "dependencies": {
         "array-flatten": {
@@ -3932,7 +3930,7 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "bootstrap": {
@@ -3958,13 +3956,13 @@
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "2.3.0",
-        "cli-boxes": "1.0.0",
-        "string-width": "2.1.1",
-        "term-size": "1.2.0",
-        "widest-line": "2.0.0"
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3991,8 +3989,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -4001,7 +3999,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -4012,7 +4010,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -4022,9 +4020,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "brcast": {
@@ -4068,12 +4066,12 @@
       "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -4082,9 +4080,9 @@
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.1.1",
-        "browserify-des": "1.0.0",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -4093,9 +4091,9 @@
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "browserify-rsa": {
@@ -4104,8 +4102,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.5"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -4114,13 +4112,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.0"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -4129,7 +4127,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "1.0.6"
+        "pako": "~1.0.5"
       }
     },
     "browserslist": {
@@ -4138,8 +4136,8 @@
       "integrity": "sha512-WyvzSLsuAVPOjbljXnyeWl14Ae+ukAT8MUuagKVzIDvwBxl4UAwD1xqtyQs2eWYPGUKMeC3Ol62goqYuKqTTcw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000784",
-        "electron-to-chromium": "1.3.29"
+        "caniuse-lite": "^1.0.30000780",
+        "electron-to-chromium": "^1.3.28"
       }
     },
     "bser": {
@@ -4148,7 +4146,7 @@
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "dev": true,
       "requires": {
-        "node-int64": "0.4.0"
+        "node-int64": "^0.4.0"
       }
     },
     "btoa-lite": {
@@ -4163,9 +4161,9 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.1",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-indexof": {
@@ -4204,19 +4202,19 @@
       "integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
-        "chownr": "1.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "lru-cache": "4.1.1",
-        "mississippi": "1.3.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "promise-inflight": "1.0.1",
-        "rimraf": "2.6.2",
-        "ssri": "5.0.0",
-        "unique-filename": "1.1.0",
-        "y18n": "3.2.1"
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^5.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
       },
       "dependencies": {
         "ssri": {
@@ -4225,7 +4223,7 @@
           "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.1.0"
           }
         }
       }
@@ -4236,15 +4234,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "cacheable-request": {
@@ -4274,9 +4272,9 @@
           "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
           "dev": true,
           "requires": {
-            "prepend-http": "2.0.0",
-            "query-string": "5.1.1",
-            "sort-keys": "2.0.0"
+            "prepend-http": "^2.0.0",
+            "query-string": "^5.0.1",
+            "sort-keys": "^2.0.0"
           }
         },
         "prepend-http": {
@@ -4291,9 +4289,9 @@
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
           "requires": {
-            "decode-uri-component": "0.2.0",
-            "object-assign": "4.1.1",
-            "strict-uri-encode": "1.1.0"
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
           }
         },
         "sort-keys": {
@@ -4302,7 +4300,7 @@
           "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
           "dev": true,
           "requires": {
-            "is-plain-obj": "1.1.0"
+            "is-plain-obj": "^1.0.0"
           }
         }
       }
@@ -4319,7 +4317,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -4334,8 +4332,8 @@
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
       }
     },
     "camelcase": {
@@ -4350,8 +4348,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       }
     },
     "caniuse-api": {
@@ -4360,10 +4358,10 @@
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "dev": true,
       "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000784",
-        "lodash.memoize": "4.1.2",
-        "lodash.uniq": "4.5.0"
+        "browserslist": "^1.3.6",
+        "caniuse-db": "^1.0.30000529",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
       },
       "dependencies": {
         "browserslist": {
@@ -4372,8 +4370,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000784",
-            "electron-to-chromium": "1.3.29"
+            "caniuse-db": "^1.0.30000639",
+            "electron-to-chromium": "^1.2.7"
           }
         }
       }
@@ -4396,16 +4394,16 @@
       "integrity": "sha512-kX9HeZNnPzceo4696pR1yLUkFRdQhrSfT85N9o5+xWqXAcU85v65DG5vWNE2OxKDDzexOD7G7FcPGm4/GGMriA==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
-        "chalk": "1.1.3",
-        "cli-table2": "0.2.0",
-        "fast-levenshtein": "2.0.6",
-        "lodash.camelcase": "4.3.0",
-        "lodash.kebabcase": "4.1.1",
-        "micromist": "1.0.2",
-        "prettyjson": "1.2.1",
-        "tabtab": "2.2.2",
-        "winston": "2.4.1"
+        "bluebird": "^3.4.7",
+        "chalk": "^1.1.3",
+        "cli-table2": "^0.2.0",
+        "fast-levenshtein": "^2.0.6",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "micromist": "^1.0.1",
+        "prettyjson": "^1.2.1",
+        "tabtab": "^2.2.2",
+        "winston": "^2.3.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4420,11 +4418,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -4447,8 +4445,8 @@
       "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
       "dev": true,
       "requires": {
-        "ansicolors": "0.2.1",
-        "redeyed": "1.0.1"
+        "ansicolors": "~0.2.1",
+        "redeyed": "~1.0.0"
       }
     },
     "case-sensitive-paths-webpack-plugin": {
@@ -4484,8 +4482,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chain-function": {
@@ -4498,11 +4496,10 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
       "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-      "dev": true,
       "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "4.5.0"
+        "ansi-styles": "^3.1.0",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^4.0.0"
       }
     },
     "chardet": {
@@ -4517,12 +4514,12 @@
       "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
       "dev": true,
       "requires": {
-        "css-select": "1.2.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.9.2",
-        "lodash": "4.17.4",
-        "parse5": "3.0.3"
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
       }
     },
     "chokidar": {
@@ -4531,15 +4528,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "chownr": {
@@ -4560,8 +4557,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "circular-json": {
@@ -4576,7 +4573,7 @@
       "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.1.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4591,11 +4588,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -4612,10 +4609,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -4624,7 +4621,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -4633,7 +4630,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4642,7 +4639,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -4653,7 +4650,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4662,7 +4659,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -4673,9 +4670,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -4697,7 +4694,7 @@
       "integrity": "sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "0.5.x"
       }
     },
     "clean-stack": {
@@ -4718,7 +4715,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-table": {
@@ -4744,9 +4741,9 @@
       "integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
       "dev": true,
       "requires": {
-        "colors": "1.1.2",
-        "lodash": "3.10.1",
-        "string-width": "1.0.2"
+        "colors": "^1.1.2",
+        "lodash": "^3.10.1",
+        "string-width": "^1.0.1"
       },
       "dependencies": {
         "lodash": {
@@ -4770,9 +4767,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "good-listener": "1.2.2",
-        "select": "1.1.2",
-        "tiny-emitter": "2.0.2"
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
       }
     },
     "cliui": {
@@ -4781,8 +4778,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       }
     },
@@ -4798,10 +4795,10 @@
       "integrity": "sha1-NIxhrpzb4O3+BT2R/0zFIdeQ7eg=",
       "dev": true,
       "requires": {
-        "for-own": "1.0.0",
-        "is-plain-object": "2.0.4",
-        "kind-of": "3.2.2",
-        "shallow-clone": "0.1.2"
+        "for-own": "^1.0.0",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^3.2.2",
+        "shallow-clone": "^0.1.2"
       },
       "dependencies": {
         "for-own": {
@@ -4810,7 +4807,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "1.0.2"
+            "for-in": "^1.0.1"
           }
         }
       }
@@ -4821,7 +4818,7 @@
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dev": true,
       "requires": {
-        "mimic-response": "1.0.0"
+        "mimic-response": "^1.0.0"
       }
     },
     "co": {
@@ -4836,7 +4833,7 @@
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.1.2"
       }
     },
     "code-point-at": {
@@ -4851,8 +4848,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color": {
@@ -4861,25 +4858,23 @@
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "dev": true,
       "requires": {
-        "clone": "1.0.3",
-        "color-convert": "1.9.1",
-        "color-string": "0.3.0"
+        "clone": "^1.0.2",
+        "color-convert": "^1.3.0",
+        "color-string": "^0.3.0"
       }
     },
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "0.3.0",
@@ -4887,7 +4882,7 @@
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.0.0"
       }
     },
     "colormin": {
@@ -4896,9 +4891,9 @@
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
       "dev": true,
       "requires": {
-        "color": "0.11.4",
+        "color": "^0.11.0",
         "css-color-names": "0.0.4",
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "colors": {
@@ -4913,7 +4908,7 @@
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -4928,7 +4923,7 @@
       "integrity": "sha512-joj9ZlUOjCrwdbmiLqafeUSgkUM74NqhLsZtSqDmhKudaIY197zTrb8JMl31fMnCUuxwFT23eC/oWvrZzDLRJQ==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.26.0"
       }
     },
     "commondir": {
@@ -4943,8 +4938,8 @@
       "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
       "dev": true,
       "requires": {
-        "array-ify": "1.0.0",
-        "dot-prop": "3.0.0"
+        "array-ify": "^1.0.0",
+        "dot-prop": "^3.0.0"
       }
     },
     "component-emitter": {
@@ -4959,7 +4954,7 @@
       "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
       "dev": true,
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": ">= 1.33.0 < 2"
       },
       "dependencies": {
         "mime-db": {
@@ -4976,13 +4971,13 @@
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "~1.3.4",
         "bytes": "3.0.0",
-        "compressible": "2.0.13",
+        "compressible": "~2.0.13",
         "debug": "2.6.9",
-        "on-headers": "1.0.1",
+        "on-headers": "~1.0.1",
         "safe-buffer": "5.1.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       }
     },
     "concat-map": {
@@ -4997,9 +4992,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "configstore": {
@@ -5008,12 +5003,12 @@
       "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
       "dev": true,
       "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       },
       "dependencies": {
         "dot-prop": {
@@ -5022,7 +5017,7 @@
           "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
           "dev": true,
           "requires": {
-            "is-obj": "1.0.1"
+            "is-obj": "^1.0.0"
           }
         }
       }
@@ -5039,7 +5034,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "console-control-strings": {
@@ -5084,8 +5079,8 @@
       "integrity": "sha1-CiagcfLJ/PzyuGugz79uYwG3W/o=",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "q": "1.5.1"
+        "compare-func": "^1.3.1",
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-writer": {
@@ -5094,16 +5089,16 @@
       "integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "conventional-commits-filter": "1.1.6",
-        "dateformat": "3.0.3",
-        "handlebars": "4.0.11",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.4",
-        "meow": "4.0.0",
-        "semver": "5.5.0",
-        "split": "1.0.1",
-        "through2": "2.0.3"
+        "compare-func": "^1.3.1",
+        "conventional-commits-filter": "^1.1.6",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.0.2",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "semver": "^5.5.0",
+        "split": "^1.0.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -5118,9 +5113,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "map-obj": "2.0.0",
-            "quick-lru": "1.1.0"
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
           }
         },
         "indent-string": {
@@ -5135,10 +5130,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "map-obj": {
@@ -5153,15 +5148,15 @@
           "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.4.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
           }
         },
         "minimist": {
@@ -5176,8 +5171,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.1"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -5186,7 +5181,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -5201,9 +5196,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -5212,8 +5207,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "redent": {
@@ -5222,8 +5217,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "3.2.0",
-            "strip-indent": "2.0.0"
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
           }
         },
         "semver": {
@@ -5258,8 +5253,8 @@
       "integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
       "dev": true,
       "requires": {
-        "is-subset": "0.1.1",
-        "modify-values": "1.0.1"
+        "is-subset": "^0.1.1",
+        "modify-values": "^1.0.0"
       }
     },
     "conventional-commits-parser": {
@@ -5268,13 +5263,13 @@
       "integrity": "sha512-8MD05yN0Zb6aRsZnFX1ET+8rHWfWJk+my7ANCJZBU2mhz7TSB1fk2vZhkrwVy/PCllcTYAP/1T1NiWQ7Z01mKw==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
-        "is-text-path": "1.0.1",
-        "lodash": "4.17.4",
-        "meow": "3.7.0",
-        "split2": "2.2.0",
-        "through2": "2.0.3",
-        "trim-off-newlines": "1.0.1"
+        "JSONStream": "^1.0.4",
+        "is-text-path": "^1.0.0",
+        "lodash": "^4.2.1",
+        "meow": "^3.3.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0",
+        "trim-off-newlines": "^1.0.0"
       }
     },
     "convert-source-map": {
@@ -5301,12 +5296,12 @@
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "fs-write-stream-atomic": "1.0.10",
-        "iferr": "0.1.5",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
       }
     },
     "copy-descriptor": {
@@ -5323,8 +5318,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "3.1.0",
@@ -5332,10 +5326,10 @@
       "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
       "dev": true,
       "requires": {
-        "is-directory": "0.3.1",
-        "js-yaml": "3.10.0",
-        "parse-json": "3.0.0",
-        "require-from-string": "2.0.1"
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.9.0",
+        "parse-json": "^3.0.0",
+        "require-from-string": "^2.0.1"
       },
       "dependencies": {
         "parse-json": {
@@ -5344,7 +5338,7 @@
           "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.3.1"
           }
         }
       }
@@ -5355,11 +5349,11 @@
       "integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
       "dev": true,
       "requires": {
-        "js-yaml": "3.10.0",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.5",
-        "minimist": "1.2.0",
-        "request": "2.83.0"
+        "js-yaml": "^3.6.1",
+        "lcov-parse": "^0.0.10",
+        "log-driver": "^1.2.5",
+        "minimist": "^1.2.0",
+        "request": "^2.79.0"
       },
       "dependencies": {
         "minimist": {
@@ -5376,8 +5370,8 @@
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-error-class": {
@@ -5386,7 +5380,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "create-hash": {
@@ -5395,10 +5389,10 @@
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "sha.js": "2.4.9"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -5407,12 +5401,12 @@
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.9"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "create-react-class": {
@@ -5421,9 +5415,9 @@
       "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "cross-spawn": {
@@ -5432,9 +5426,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -5443,7 +5437,7 @@
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -5452,7 +5446,7 @@
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -5463,17 +5457,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.0",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.0",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "diffie-hellman": "5.0.2",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.14",
-        "public-encrypt": "4.0.0",
-        "randombytes": "2.0.5",
-        "randomfill": "1.0.3"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "crypto-random-string": {
@@ -5494,7 +5488,7 @@
       "integrity": "sha512-yuWmPMD9FLi50Xf3k8W8oO3WM1eVnxEGCldCLyfusQ+CgivFk0s23yst4ooW6tfxMuSa03S6uUEga9UhX6GRrA==",
       "dev": true,
       "requires": {
-        "hyphenate-style-name": "1.0.2"
+        "hyphenate-style-name": "^1.0.2"
       }
     },
     "css-loader": {
@@ -5503,20 +5497,20 @@
       "integrity": "sha512-GxMpax8a/VgcfRrVy0gXD6yLd5ePYbXX/5zGgTVYp4wXtJklS8Z2VaUArJgc//f6/Dzil7BaJObdSv8eKKCPgg==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "css-selector-tokenizer": "0.7.0",
-        "cssnano": "3.10.0",
-        "icss-utils": "2.1.0",
-        "loader-utils": "1.1.0",
-        "lodash.camelcase": "4.3.0",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.18",
-        "postcss-modules-extract-imports": "1.1.0",
-        "postcss-modules-local-by-default": "1.2.0",
-        "postcss-modules-scope": "1.1.0",
-        "postcss-modules-values": "1.3.0",
-        "postcss-value-parser": "3.3.0",
-        "source-list-map": "2.0.0"
+        "babel-code-frame": "^6.11.0",
+        "css-selector-tokenizer": "^0.7.0",
+        "cssnano": ">=2.6.1 <4",
+        "icss-utils": "^2.1.0",
+        "loader-utils": "^1.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.6",
+        "postcss-modules-extract-imports": "^1.0.0",
+        "postcss-modules-local-by-default": "^1.0.1",
+        "postcss-modules-scope": "^1.0.0",
+        "postcss-modules-values": "^1.1.0",
+        "postcss-value-parser": "^3.3.0",
+        "source-list-map": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5531,11 +5525,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -5558,10 +5552,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -5570,10 +5564,15 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
+    },
+    "css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
     },
     "css-select": {
       "version": "1.2.0",
@@ -5581,10 +5580,10 @@
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.0",
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
         "domutils": "1.5.1",
-        "nth-check": "1.0.1"
+        "nth-check": "~1.0.1"
       }
     },
     "css-selector-tokenizer": {
@@ -5593,9 +5592,9 @@
       "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
       "dev": true,
       "requires": {
-        "cssesc": "0.1.0",
-        "fastparse": "1.1.1",
-        "regexpu-core": "1.0.0"
+        "cssesc": "^0.1.0",
+        "fastparse": "^1.1.1",
+        "regexpu-core": "^1.0.0"
       },
       "dependencies": {
         "regexpu-core": {
@@ -5604,9 +5603,9 @@
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "dev": true,
           "requires": {
-            "regenerate": "1.3.3",
-            "regjsgen": "0.2.0",
-            "regjsparser": "0.1.5"
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
           }
         }
       }
@@ -5629,38 +5628,38 @@
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
       "dev": true,
       "requires": {
-        "autoprefixer": "6.7.7",
-        "decamelize": "1.2.0",
-        "defined": "1.0.0",
-        "has": "1.0.1",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.18",
-        "postcss-calc": "5.3.1",
-        "postcss-colormin": "2.2.2",
-        "postcss-convert-values": "2.6.1",
-        "postcss-discard-comments": "2.0.4",
-        "postcss-discard-duplicates": "2.1.0",
-        "postcss-discard-empty": "2.1.0",
-        "postcss-discard-overridden": "0.1.1",
-        "postcss-discard-unused": "2.2.3",
-        "postcss-filter-plugins": "2.0.2",
-        "postcss-merge-idents": "2.1.7",
-        "postcss-merge-longhand": "2.0.2",
-        "postcss-merge-rules": "2.1.2",
-        "postcss-minify-font-values": "1.0.5",
-        "postcss-minify-gradients": "1.0.5",
-        "postcss-minify-params": "1.2.2",
-        "postcss-minify-selectors": "2.1.1",
-        "postcss-normalize-charset": "1.1.1",
-        "postcss-normalize-url": "3.0.8",
-        "postcss-ordered-values": "2.2.3",
-        "postcss-reduce-idents": "2.4.0",
-        "postcss-reduce-initial": "1.0.1",
-        "postcss-reduce-transforms": "1.0.4",
-        "postcss-svgo": "2.1.6",
-        "postcss-unique-selectors": "2.0.2",
-        "postcss-value-parser": "3.3.0",
-        "postcss-zindex": "2.2.0"
+        "autoprefixer": "^6.3.1",
+        "decamelize": "^1.1.2",
+        "defined": "^1.0.0",
+        "has": "^1.0.1",
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.14",
+        "postcss-calc": "^5.2.0",
+        "postcss-colormin": "^2.1.8",
+        "postcss-convert-values": "^2.3.4",
+        "postcss-discard-comments": "^2.0.4",
+        "postcss-discard-duplicates": "^2.0.1",
+        "postcss-discard-empty": "^2.0.1",
+        "postcss-discard-overridden": "^0.1.1",
+        "postcss-discard-unused": "^2.2.1",
+        "postcss-filter-plugins": "^2.0.0",
+        "postcss-merge-idents": "^2.1.5",
+        "postcss-merge-longhand": "^2.0.1",
+        "postcss-merge-rules": "^2.0.3",
+        "postcss-minify-font-values": "^1.0.2",
+        "postcss-minify-gradients": "^1.0.1",
+        "postcss-minify-params": "^1.0.4",
+        "postcss-minify-selectors": "^2.0.4",
+        "postcss-normalize-charset": "^1.1.0",
+        "postcss-normalize-url": "^3.0.7",
+        "postcss-ordered-values": "^2.1.0",
+        "postcss-reduce-idents": "^2.2.2",
+        "postcss-reduce-initial": "^1.0.0",
+        "postcss-reduce-transforms": "^1.0.3",
+        "postcss-svgo": "^2.1.1",
+        "postcss-unique-selectors": "^2.0.2",
+        "postcss-value-parser": "^3.2.3",
+        "postcss-zindex": "^2.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5675,12 +5674,12 @@
           "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
           "dev": true,
           "requires": {
-            "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000784",
-            "normalize-range": "0.1.2",
-            "num2fraction": "1.2.2",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.0"
+            "browserslist": "^1.7.6",
+            "caniuse-db": "^1.0.30000634",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^5.2.16",
+            "postcss-value-parser": "^3.2.3"
           }
         },
         "browserslist": {
@@ -5689,8 +5688,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000784",
-            "electron-to-chromium": "1.3.29"
+            "caniuse-db": "^1.0.30000639",
+            "electron-to-chromium": "^1.2.7"
           }
         },
         "chalk": {
@@ -5699,11 +5698,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -5726,10 +5725,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -5738,7 +5737,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -5749,8 +5748,8 @@
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
       "dev": true,
       "requires": {
-        "clap": "1.2.3",
-        "source-map": "0.5.7"
+        "clap": "^1.0.9",
+        "source-map": "^0.5.3"
       }
     },
     "cssom": {
@@ -5765,7 +5764,7 @@
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "dev": true,
       "requires": {
-        "cssom": "0.3.2"
+        "cssom": "0.3.x"
       }
     },
     "csstype": {
@@ -5780,7 +5779,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "cycle": {
@@ -5801,7 +5800,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.37"
+        "es5-ext": "^0.10.9"
       }
     },
     "damerau-levenshtein": {
@@ -5816,7 +5815,7 @@
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "dashdash": {
@@ -5825,7 +5824,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-now": {
@@ -5861,8 +5860,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "1.2.0",
-        "map-obj": "1.0.1"
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
       }
     },
     "decode-uri-component": {
@@ -5877,7 +5876,7 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "1.0.0"
+        "mimic-response": "^1.0.0"
       }
     },
     "deep-equal": {
@@ -5904,7 +5903,7 @@
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
       "dev": true,
       "requires": {
-        "strip-bom": "2.0.0"
+        "strip-bom": "^2.0.0"
       }
     },
     "define-properties": {
@@ -5912,8 +5911,8 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "define-property": {
@@ -5922,8 +5921,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       }
     },
     "defined": {
@@ -5938,13 +5937,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -5978,8 +5977,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "destroy": {
@@ -5994,7 +5993,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "detect-newline": {
@@ -6021,9 +6020,9 @@
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.5"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "dir-glob": {
@@ -6032,8 +6031,8 @@
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "path-type": "3.0.0"
+        "arrify": "^1.0.1",
+        "path-type": "^3.0.0"
       },
       "dependencies": {
         "path-type": {
@@ -6042,7 +6041,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -6071,8 +6070,8 @@
       "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "dev": true,
       "requires": {
-        "ip": "1.1.5",
-        "safe-buffer": "5.1.1"
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "dns-txt": {
@@ -6081,7 +6080,7 @@
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "dev": true,
       "requires": {
-        "buffer-indexof": "1.1.1"
+        "buffer-indexof": "^1.0.0"
       }
     },
     "doctrine": {
@@ -6090,7 +6089,7 @@
       "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "dom-converter": {
@@ -6099,7 +6098,7 @@
       "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
       "dev": true,
       "requires": {
-        "utila": "0.3.3"
+        "utila": "~0.3"
       },
       "dependencies": {
         "utila": {
@@ -6120,17 +6119,15 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-      "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-          "dev": true
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
     },
@@ -6149,8 +6146,7 @@
     "domelementtype": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-      "dev": true
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
     },
     "domexception": {
       "version": "1.0.0",
@@ -6162,19 +6158,17 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
       "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
-      "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dot-prop": {
@@ -6183,7 +6177,7 @@
       "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
       "dev": true,
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "dotenv": {
@@ -6198,7 +6192,7 @@
       "integrity": "sha1-nJLkbkEqHPvGAhftM9adK7/dv58=",
       "dev": true,
       "requires": {
-        "dotenv": "4.0.0"
+        "dotenv": "^4.0.0"
       }
     },
     "duplexer2": {
@@ -6207,7 +6201,7 @@
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.2"
       }
     },
     "duplexer3": {
@@ -6222,10 +6216,10 @@
       "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -6235,7 +6229,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ee-first": {
@@ -6256,13 +6250,13 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "email-prop-type": {
@@ -6270,7 +6264,7 @@
       "resolved": "https://registry.npmjs.org/email-prop-type/-/email-prop-type-1.1.5.tgz",
       "integrity": "sha512-I7RYQE3EGDh3GXdBICtx/zKn21720xxW2UGD4y5Pg8zAFoNjtFdh5fHDrHL/xmICiuobMdpXywfV8/FN1rCdQA==",
       "requires": {
-        "email-validator": "1.1.1"
+        "email-validator": "^1.1.1"
       }
     },
     "email-validator": {
@@ -6301,7 +6295,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.19"
+        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -6310,7 +6304,7 @@
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "enhanced-resolve": {
@@ -6319,17 +6313,16 @@
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "object-assign": "^4.0.1",
+        "tapable": "^0.2.7"
       }
     },
     "entities": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-      "dev": true
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
     "env-ci": {
       "version": "1.6.0",
@@ -6337,8 +6330,8 @@
       "integrity": "sha512-DK9wJ1s498dBW4fn8kPcGzD5QpQSCtm3tw8UgjNdhiGTvQ3PR7/WeCXHx4pltGPi2x8Wlk5s5/BNshM7aDK8XA==",
       "dev": true,
       "requires": {
-        "execa": "0.10.0",
-        "java-properties": "0.2.10"
+        "execa": "^0.10.0",
+        "java-properties": "^0.2.9"
       }
     },
     "enzyme": {
@@ -6347,17 +6340,17 @@
       "integrity": "sha512-l0HcjycivXjB4IXkwuRc1K5z8hzWIVZB2b/Y/H2bao9eFTpBz4ACOwAQf44SgG5Nu3d1jF41LasxDgFWZeeysA==",
       "dev": true,
       "requires": {
-        "cheerio": "1.0.0-rc.2",
-        "function.prototype.name": "1.0.3",
-        "has": "1.0.1",
-        "is-subset": "0.1.1",
-        "lodash": "4.17.4",
-        "object-is": "1.0.1",
-        "object.assign": "4.0.4",
-        "object.entries": "1.0.4",
-        "object.values": "1.0.4",
-        "raf": "3.4.0",
-        "rst-selector-parser": "2.2.3"
+        "cheerio": "^1.0.0-rc.2",
+        "function.prototype.name": "^1.0.3",
+        "has": "^1.0.1",
+        "is-subset": "^0.1.1",
+        "lodash": "^4.17.4",
+        "object-is": "^1.0.1",
+        "object.assign": "^4.0.4",
+        "object.entries": "^1.0.4",
+        "object.values": "^1.0.4",
+        "raf": "^3.4.0",
+        "rst-selector-parser": "^2.2.3"
       }
     },
     "enzyme-adapter-react-16": {
@@ -6366,13 +6359,13 @@
       "integrity": "sha512-kC8pAtU2Jk3OJ0EG8Y2813dg9Ol0TXi7UNxHzHiWs30Jo/hj7alc//G1YpKUsPP1oKl9X+Lkx+WlGJpPYA+nvw==",
       "dev": true,
       "requires": {
-        "enzyme-adapter-utils": "1.3.0",
-        "lodash": "4.17.4",
-        "object.assign": "4.0.4",
-        "object.values": "1.0.4",
-        "prop-types": "15.6.0",
-        "react-reconciler": "0.7.0",
-        "react-test-renderer": "16.2.0"
+        "enzyme-adapter-utils": "^1.3.0",
+        "lodash": "^4.17.4",
+        "object.assign": "^4.0.4",
+        "object.values": "^1.0.4",
+        "prop-types": "^15.6.0",
+        "react-reconciler": "^0.7.0",
+        "react-test-renderer": "^16.0.0-0"
       }
     },
     "enzyme-adapter-utils": {
@@ -6381,9 +6374,9 @@
       "integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4",
-        "object.assign": "4.0.4",
-        "prop-types": "15.6.0"
+        "lodash": "^4.17.4",
+        "object.assign": "^4.0.4",
+        "prop-types": "^15.6.0"
       }
     },
     "errno": {
@@ -6392,7 +6385,7 @@
       "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
       "dev": true,
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -6401,7 +6394,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -6409,11 +6402,11 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-check": {
@@ -6422,9 +6415,9 @@
       "integrity": "sha512-WeOLfv7W6nXYjazPfHDfcnCfBImPDSlgSyeH9JuvvE1JB79RQ+mVYlu0AJmq9vFNCzHgvb5tM+ow9oMj6K0U4g==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
-        "caporal": "0.9.0",
-        "glob": "7.1.2"
+        "acorn": "^5.1.2",
+        "caporal": "^0.9.0",
+        "glob": "^7.1.2"
       }
     },
     "es-to-primitive": {
@@ -6432,9 +6425,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "es5-ext": {
@@ -6443,8 +6436,8 @@
       "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "~3.1.1"
       }
     },
     "es5-shim": {
@@ -6459,9 +6452,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -6470,12 +6463,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-promise": {
@@ -6490,7 +6483,7 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.4"
+        "es6-promise": "^4.0.3"
       }
     },
     "es6-set": {
@@ -6499,11 +6492,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-iterator": "2.0.3",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-shim": {
@@ -6518,8 +6511,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-templates": {
@@ -6528,8 +6521,8 @@
       "integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
       "dev": true,
       "requires": {
-        "recast": "0.11.23",
-        "through": "2.3.8"
+        "recast": "~0.11.12",
+        "through": "~2.3.6"
       },
       "dependencies": {
         "ast-types": {
@@ -6551,9 +6544,9 @@
           "dev": true,
           "requires": {
             "ast-types": "0.9.6",
-            "esprima": "3.1.3",
-            "private": "0.1.8",
-            "source-map": "0.5.7"
+            "esprima": "~3.1.0",
+            "private": "~0.1.5",
+            "source-map": "~0.5.0"
           }
         }
       }
@@ -6564,10 +6557,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-html": {
@@ -6579,8 +6572,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.9.0",
@@ -6588,11 +6580,11 @@
       "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
       "dev": true,
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.5.7"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.5.6"
       },
       "dependencies": {
         "esprima": {
@@ -6609,10 +6601,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint": {
@@ -6621,43 +6613,43 @@
       "integrity": "sha512-UCJVV50RtLHYzBp1DZ8CMPtRSg4iVZvjgO9IJHIKyWU/AnJVjtdRikoUPLB29n5pzMB7TnsLQWf0V6VUJfoPfw==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.3.0",
-        "concat-stream": "1.6.0",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.0.2",
-        "eslint-scope": "3.7.1",
-        "espree": "3.5.2",
-        "esquery": "1.0.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.1.0",
-        "ignore": "3.3.7",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.0.1",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.4.1",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.2",
-        "text-table": "0.2.0"
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.0.1",
+        "doctrine": "^2.0.2",
+        "eslint-scope": "^3.7.1",
+        "espree": "^3.5.2",
+        "esquery": "^1.0.0",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^4.0.1",
+        "text-table": "~0.2.0"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -6678,7 +6670,7 @@
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           }
         },
         "cli-width": {
@@ -6702,7 +6694,7 @@
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "globals": {
@@ -6717,20 +6709,20 @@
           "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.0.0",
-            "chalk": "2.3.0",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "2.1.0",
-            "figures": "2.0.0",
-            "lodash": "4.17.4",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx-lite": "4.0.8",
-            "rx-lite-aggregates": "4.0.8",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
           }
         },
         "is-fullwidth-code-point": {
@@ -6751,7 +6743,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.1.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "restore-cursor": {
@@ -6760,8 +6752,8 @@
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "run-async": {
@@ -6770,7 +6762,7 @@
           "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
           "dev": true,
           "requires": {
-            "is-promise": "2.1.0"
+            "is-promise": "^2.1.0"
           }
         },
         "rx-lite": {
@@ -6785,8 +6777,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -6795,7 +6787,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -6806,7 +6798,7 @@
       "integrity": "sha512-zLyOhVWhzB/jwbz7IPSbkUuj7X2ox4PHXTcZkEmDqTvd0baJmJyuxlFPDlZOE/Y5bC+HQRaEkT3FoHo9wIdRiw==",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "12.1.0"
+        "eslint-config-airbnb-base": "^12.1.0"
       }
     },
     "eslint-config-airbnb-base": {
@@ -6815,7 +6807,7 @@
       "integrity": "sha512-/vjm0Px5ZCpmJqnjIzcFb9TKZrKWz0gnuG/7Gfkt0Db1ELJR51xkZth+t14rYdqWgX836XbuxtArbIHlVhbLBA==",
       "dev": true,
       "requires": {
-        "eslint-restricted-globals": "0.1.1"
+        "eslint-restricted-globals": "^0.1.1"
       }
     },
     "eslint-config-edx": {
@@ -6824,12 +6816,12 @@
       "integrity": "sha512-vQtYSYp676+/1jVh1WGW6uQW42qfp3FgU4MNVnhQpQPyvACiXa2+YIg/Xp2ewOTY78AnMXC0s4w3xdiWcP5vzg==",
       "dev": true,
       "requires": {
-        "eslint": "4.13.1",
-        "eslint-config-airbnb": "16.1.0",
-        "eslint-plugin-dollar-sign": "1.0.1",
-        "eslint-plugin-import": "2.9.0",
-        "eslint-plugin-jsx-a11y": "6.0.3",
-        "eslint-plugin-react": "7.5.1"
+        "eslint": "^4.5.0",
+        "eslint-config-airbnb": "^16.1.0",
+        "eslint-plugin-dollar-sign": "^1.0.1",
+        "eslint-plugin-import": "^2.8.0",
+        "eslint-plugin-jsx-a11y": "^6.0.2",
+        "eslint-plugin-react": "^7.5.1"
       }
     },
     "eslint-import-resolver-node": {
@@ -6838,8 +6830,8 @@
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "resolve": "1.5.0"
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
       }
     },
     "eslint-import-resolver-webpack": {
@@ -6848,16 +6840,16 @@
       "integrity": "sha1-tvJGjcPotOoHbl11vs6NqTJ4mwc=",
       "dev": true,
       "requires": {
-        "array-find": "1.0.0",
-        "debug": "2.6.9",
-        "enhanced-resolve": "0.9.1",
-        "find-root": "1.1.0",
-        "has": "1.0.1",
-        "interpret": "1.1.0",
-        "lodash": "4.17.4",
-        "node-libs-browser": "2.1.0",
-        "resolve": "1.5.0",
-        "semver": "5.4.1"
+        "array-find": "^1.0.0",
+        "debug": "^2.6.8",
+        "enhanced-resolve": "~0.9.0",
+        "find-root": "^1.1.0",
+        "has": "^1.0.1",
+        "interpret": "^1.0.0",
+        "lodash": "^4.17.4",
+        "node-libs-browser": "^1.0.0 || ^2.0.0",
+        "resolve": "^1.4.0",
+        "semver": "^5.3.0"
       },
       "dependencies": {
         "enhanced-resolve": {
@@ -6891,8 +6883,8 @@
       "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "pkg-dir": "1.0.0"
+        "debug": "^2.6.8",
+        "pkg-dir": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -6901,8 +6893,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pkg-dir": {
@@ -6911,7 +6903,7 @@
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           }
         }
       }
@@ -6922,11 +6914,11 @@
       "integrity": "sha512-nMH9Ibga+VZVLGtyxx8Dry69NN+a7YykNoUA9NtL3QNTeciV4QAAOtBLykKDR0Q37wwtKME+Inlce7JOhy5dbg==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "browserslist": "2.11.3",
-        "caniuse-db": "1.0.30000810",
-        "mdn-browser-compat-data": "0.0.20",
-        "requireindex": "1.1.0"
+        "babel-runtime": "^6.26.0",
+        "browserslist": "^2.11.3",
+        "caniuse-db": "^1.0.30000794",
+        "mdn-browser-compat-data": "^0.0.20",
+        "requireindex": "^1.1.0"
       },
       "dependencies": {
         "browserslist": {
@@ -6935,8 +6927,8 @@
           "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30000810",
-            "electron-to-chromium": "1.3.34"
+            "caniuse-lite": "^1.0.30000792",
+            "electron-to-chromium": "^1.3.30"
           }
         },
         "caniuse-db": {
@@ -6971,16 +6963,16 @@
       "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1",
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
+        "builtin-modules": "^1.1.1",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.8",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.2",
-        "eslint-module-utils": "2.1.1",
-        "has": "1.0.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "read-pkg-up": "2.0.0"
+        "eslint-import-resolver-node": "^0.3.1",
+        "eslint-module-utils": "^2.1.1",
+        "has": "^1.0.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.3",
+        "read-pkg-up": "^2.0.0"
       },
       "dependencies": {
         "doctrine": {
@@ -6989,8 +6981,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         },
         "load-json-file": {
@@ -6999,10 +6991,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "path-type": {
@@ -7011,7 +7003,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "2.3.0"
+            "pify": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -7020,9 +7012,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
           }
         },
         "read-pkg-up": {
@@ -7031,8 +7023,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -7049,13 +7041,13 @@
       "integrity": "sha1-VFg9GuRCSDFi4EDhPMMYZUZRAOU=",
       "dev": true,
       "requires": {
-        "aria-query": "0.7.1",
-        "array-includes": "3.0.3",
+        "aria-query": "^0.7.0",
+        "array-includes": "^3.0.3",
         "ast-types-flow": "0.0.7",
-        "axobject-query": "0.1.0",
-        "damerau-levenshtein": "1.0.4",
-        "emoji-regex": "6.5.1",
-        "jsx-ast-utils": "2.0.1"
+        "axobject-query": "^0.1.0",
+        "damerau-levenshtein": "^1.0.0",
+        "emoji-regex": "^6.1.0",
+        "jsx-ast-utils": "^2.0.0"
       }
     },
     "eslint-plugin-react": {
@@ -7064,10 +7056,10 @@
       "integrity": "sha512-YGSjB9Qu6QbVTroUZi66pYky3DfoIPLdHQ/wmrBGyBRnwxQsBXAov9j2rpXt/55i8nyMv6IRWJv2s4d4YnduzQ==",
       "dev": true,
       "requires": {
-        "doctrine": "2.0.2",
-        "has": "1.0.1",
-        "jsx-ast-utils": "2.0.1",
-        "prop-types": "15.6.0"
+        "doctrine": "^2.0.0",
+        "has": "^1.0.1",
+        "jsx-ast-utils": "^2.0.0",
+        "prop-types": "^15.6.0"
       }
     },
     "eslint-restricted-globals": {
@@ -7082,8 +7074,8 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "espree": {
@@ -7092,8 +7084,8 @@
       "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.2.1",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -7108,7 +7100,7 @@
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -7117,8 +7109,8 @@
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "^4.1.0",
+        "object-assign": "^4.0.1"
       }
     },
     "estraverse": {
@@ -7145,8 +7137,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "eventemitter3": {
@@ -7167,7 +7159,7 @@
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
       "dev": true,
       "requires": {
-        "original": "1.0.0"
+        "original": ">=0.0.5"
       }
     },
     "evp_bytestokey": {
@@ -7176,8 +7168,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "exec-sh": {
@@ -7186,7 +7178,7 @@
       "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "dev": true,
       "requires": {
-        "merge": "1.2.0"
+        "merge": "^1.1.3"
       }
     },
     "execa": {
@@ -7195,13 +7187,13 @@
       "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
       "dev": true,
       "requires": {
-        "cross-spawn": "6.0.5",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -7210,11 +7202,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "1.0.4",
-            "path-key": "2.0.1",
-            "semver": "5.5.0",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "semver": {
@@ -7243,7 +7235,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -7252,7 +7244,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "express": {
@@ -7261,36 +7253,36 @@
       "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "~1.3.4",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.0",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.2",
+        "proxy-addr": "~2.0.2",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.1",
         "serve-static": "1.13.1",
         "setprototypeof": "1.1.0",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       }
     },
     "extend": {
@@ -7305,8 +7297,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -7315,7 +7307,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -7326,9 +7318,9 @@
       "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "dev": true,
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.19",
-        "tmp": "0.0.33"
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -7337,7 +7329,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extract-text-webpack-plugin": {
@@ -7346,10 +7338,10 @@
       "integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.3.0",
-        "webpack-sources": "1.1.0"
+        "async": "^2.4.1",
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^0.3.0",
+        "webpack-sources": "^1.0.1"
       }
     },
     "extsprintf": {
@@ -7376,11 +7368,11 @@
       "integrity": "sha512-4F75PTznkNtSKs2pbhtBwRkw8sRwa7LfXx5XaQJOe4IQ6yTjceLDTwM5gj1s80R2t/5WeDC1gVfm3jLE+l39Tw==",
       "dev": true,
       "requires": {
-        "@mrmlnc/readdir-enhanced": "2.2.1",
-        "glob-parent": "3.1.0",
-        "is-glob": "4.0.0",
-        "merge2": "1.2.1",
-        "micromatch": "3.1.10"
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.1",
+        "micromatch": "^3.1.8"
       },
       "dependencies": {
         "arr-diff": {
@@ -7401,16 +7393,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.1",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -7419,7 +7411,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -7430,13 +7422,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -7445,7 +7437,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -7454,7 +7446,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-descriptor": {
@@ -7463,9 +7455,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -7482,14 +7474,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -7498,7 +7490,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -7507,7 +7499,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -7518,10 +7510,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -7530,7 +7522,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -7541,8 +7533,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           },
           "dependencies": {
             "is-glob": {
@@ -7551,7 +7543,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -7562,7 +7554,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7571,7 +7563,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -7582,7 +7574,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7591,7 +7583,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -7608,7 +7600,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.1"
           }
         },
         "is-number": {
@@ -7617,7 +7609,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7626,7 +7618,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -7643,19 +7635,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         }
       }
@@ -7690,7 +7682,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": "0.7.0"
+        "websocket-driver": ">=0.5.1"
       }
     },
     "fb-watchman": {
@@ -7699,7 +7691,7 @@
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "dev": true,
       "requires": {
-        "bser": "2.0.0"
+        "bser": "^2.0.0"
       }
     },
     "fbjs": {
@@ -7707,13 +7699,13 @@
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
       "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
       "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.17"
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.9"
       },
       "dependencies": {
         "core-js": {
@@ -7729,8 +7721,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-entry-cache": {
@@ -7739,8 +7731,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "file-loader": {
@@ -7749,8 +7741,8 @@
       "integrity": "sha512-873ztuL+/hfvXbLDJ262PGO6XjERnybJu2gW1/5j8HUfxSiFJI9Hj/DhZ50ZGRUxBvuNiazb/cM2rh9pqrxP6Q==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.3.0"
+        "loader-utils": "^1.0.2",
+        "schema-utils": "^0.3.0"
       }
     },
     "filename-regex": {
@@ -7765,8 +7757,8 @@
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "minimatch": "3.0.4"
+        "glob": "^7.0.3",
+        "minimatch": "^3.0.3"
       }
     },
     "fill-range": {
@@ -7775,11 +7767,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       },
       "dependencies": {
         "isobject": {
@@ -7800,12 +7792,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       }
     },
     "find-cache-dir": {
@@ -7814,9 +7806,9 @@
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "dev": true,
       "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "1.1.0",
-        "pkg-dir": "2.0.0"
+        "commondir": "^1.0.1",
+        "make-dir": "^1.0.0",
+        "pkg-dir": "^2.0.0"
       }
     },
     "find-root": {
@@ -7831,7 +7823,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -7840,10 +7832,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "flatten": {
@@ -7858,8 +7850,8 @@
       "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
       }
     },
     "font-awesome": {
@@ -7879,7 +7871,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -7899,9 +7891,9 @@
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -7916,7 +7908,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fresh": {
@@ -7931,8 +7923,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs-extra": {
@@ -7941,9 +7933,9 @@
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs-readdir-recursive": {
@@ -7958,10 +7950,10 @@
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "2.3.3"
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
       }
     },
     "fs.realpath": {
@@ -7977,8 +7969,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39"
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -7993,8 +7985,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ansi-regex": {
@@ -8014,8 +8006,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "asn1": {
@@ -8059,7 +8051,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "block-stream": {
@@ -8067,7 +8059,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "~2.0.0"
           }
         },
         "boom": {
@@ -8075,7 +8067,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "brace-expansion": {
@@ -8083,7 +8075,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
           }
         },
@@ -8114,7 +8106,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
@@ -8137,7 +8129,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "dashdash": {
@@ -8146,7 +8138,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -8195,7 +8187,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "extend": {
@@ -8221,9 +8213,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs.realpath": {
@@ -8236,10 +8228,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "fstream-ignore": {
@@ -8248,9 +8240,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
+            "fstream": "^1.0.0",
+            "inherits": "2",
+            "minimatch": "^3.0.0"
           }
         },
         "gauge": {
@@ -8259,14 +8251,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "getpass": {
@@ -8275,7 +8267,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -8291,12 +8283,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -8316,8 +8308,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "has-unicode": {
@@ -8331,10 +8323,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -8348,9 +8340,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "inflight": {
@@ -8358,8 +8350,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -8378,7 +8370,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -8404,7 +8396,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "jsbn": {
@@ -8425,7 +8417,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -8470,7 +8462,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "1.27.0"
+            "mime-db": "~1.27.0"
           }
         },
         "minimatch": {
@@ -8478,7 +8470,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -8506,17 +8498,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.2",
+            "detect-libc": "^1.0.2",
             "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
             "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^2.2.1",
+            "tar-pack": "^3.4.0"
           }
         },
         "nopt": {
@@ -8525,8 +8517,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npmlog": {
@@ -8535,10 +8527,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -8563,7 +8555,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -8584,8 +8576,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -8622,10 +8614,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -8641,13 +8633,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
           }
         },
         "request": {
@@ -8656,28 +8648,28 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
           }
         },
         "rimraf": {
@@ -8685,7 +8677,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -8716,7 +8708,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "sshpk": {
@@ -8725,15 +8717,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jodid25519": "^1.0.0",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -8749,9 +8741,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -8759,7 +8751,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "stringstream": {
@@ -8773,7 +8765,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -8787,9 +8779,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           }
         },
         "tar-pack": {
@@ -8798,14 +8790,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "debug": "^2.2.0",
+            "fstream": "^1.0.10",
+            "fstream-ignore": "^1.0.5",
+            "once": "^1.3.3",
+            "readable-stream": "^2.1.4",
+            "rimraf": "^2.5.1",
+            "tar": "^2.2.1",
+            "uid-number": "^0.0.6"
           }
         },
         "tough-cookie": {
@@ -8814,7 +8806,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "tunnel-agent": {
@@ -8823,7 +8815,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -8864,7 +8856,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -8880,10 +8872,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "function-bind": {
@@ -8897,9 +8889,9 @@
       "integrity": "sha512-5EblxZUdioXi2JiMZ9FUbwYj40eQ9MFHyzFLBSPdlRl3SO8l7SLWuAnQ/at/1Wi4hjJwME/C5WpF2ZfAc8nGNw==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.1",
-        "is-callable": "1.1.3"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.0",
+        "is-callable": "^1.1.3"
       }
     },
     "functional-red-black-tree": {
@@ -8920,14 +8912,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "gaze": {
@@ -8936,7 +8928,7 @@
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
       "dev": true,
       "requires": {
-        "globule": "1.2.0"
+        "globule": "^1.0.0"
       }
     },
     "generate-function": {
@@ -8951,7 +8943,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "get-caller-file": {
@@ -8984,7 +8976,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "git-log-parser": {
@@ -8993,12 +8985,12 @@
       "integrity": "sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=",
       "dev": true,
       "requires": {
-        "argv-formatter": "1.0.0",
-        "spawn-error-forwarder": "1.0.0",
-        "split2": "1.0.0",
-        "stream-combiner2": "1.1.1",
-        "through2": "2.0.3",
-        "traverse": "0.6.6"
+        "argv-formatter": "~1.0.0",
+        "spawn-error-forwarder": "~1.0.0",
+        "split2": "~1.0.0",
+        "stream-combiner2": "~1.1.1",
+        "through2": "~2.0.0",
+        "traverse": "~0.6.6"
       },
       "dependencies": {
         "split2": {
@@ -9007,7 +8999,7 @@
           "integrity": "sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=",
           "dev": true,
           "requires": {
-            "through2": "2.0.3"
+            "through2": "~2.0.0"
           }
         }
       }
@@ -9018,11 +9010,11 @@
       "integrity": "sha1-C8hZbpDV/+c29/VUa9LRL3OrqsY=",
       "dev": true,
       "requires": {
-        "dargs": "4.1.0",
-        "lodash.template": "4.4.0",
-        "meow": "3.7.0",
-        "split2": "2.2.0",
-        "through2": "2.0.3"
+        "dargs": "^4.0.1",
+        "lodash.template": "^4.0.2",
+        "meow": "^3.3.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0"
       }
     },
     "git-up": {
@@ -9031,8 +9023,8 @@
       "integrity": "sha512-2v4UN3qV2RGypD9QpmUjpk+4+RlYpW8GFuiZqQnKmvei08HsFPd0RfbDvEhnE4wBvnYs8ORVtYpOFuuCEmBVBw==",
       "dev": true,
       "requires": {
-        "is-ssh": "1.3.0",
-        "parse-url": "1.3.11"
+        "is-ssh": "^1.3.0",
+        "parse-url": "^1.3.0"
       }
     },
     "git-url-parse": {
@@ -9041,7 +9033,7 @@
       "integrity": "sha512-tSdNasqIc9cjK75DRsirb5sqVJ4V4cCmCuuOyyx2SuYeJx4o9AOx+/ZCSwRrYjZ8zavtuhGjCqXlCo9Db0YIVA==",
       "dev": true,
       "requires": {
-        "git-up": "2.0.10"
+        "git-up": "^2.0.0"
       }
     },
     "glamor": {
@@ -9050,11 +9042,11 @@
       "integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
-        "inline-style-prefixer": "3.0.8",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0",
-        "through": "2.3.8"
+        "fbjs": "^0.8.12",
+        "inline-style-prefixer": "^3.0.6",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.5.10",
+        "through": "^2.3.8"
       }
     },
     "glamorous": {
@@ -9063,13 +9055,13 @@
       "integrity": "sha512-H7e28mVL8IUGMD3yL6W3A/wtdZ7gM69xV6VMRe3ciI+5SgZxENiKDW49Tv14IhKeFVlUrBmhyAgzzUMMw4H0Cw==",
       "dev": true,
       "requires": {
-        "brcast": "3.0.1",
-        "fast-memoize": "2.2.8",
-        "html-tag-names": "1.1.2",
-        "is-function": "1.0.1",
-        "is-plain-object": "2.0.4",
-        "react-html-attributes": "1.4.1",
-        "svg-tag-names": "1.1.1"
+        "brcast": "^3.0.0",
+        "fast-memoize": "^2.2.7",
+        "html-tag-names": "^1.1.1",
+        "is-function": "^1.0.1",
+        "is-plain-object": "^2.0.4",
+        "react-html-attributes": "^1.3.0",
+        "svg-tag-names": "^1.1.0"
       }
     },
     "glob": {
@@ -9078,12 +9070,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -9092,8 +9084,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -9102,7 +9094,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "glob-to-regexp": {
@@ -9117,8 +9109,8 @@
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "dev": true,
       "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
       }
     },
     "global-dirs": {
@@ -9127,7 +9119,7 @@
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "1.3.5"
+        "ini": "^1.3.4"
       }
     },
     "globals": {
@@ -9142,12 +9134,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "globule": {
@@ -9156,9 +9148,9 @@
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4"
+        "glob": "~7.1.1",
+        "lodash": "~4.17.4",
+        "minimatch": "~3.0.2"
       }
     },
     "good-listener": {
@@ -9168,7 +9160,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "delegate": "3.2.0"
+        "delegate": "^3.1.2"
       }
     },
     "got": {
@@ -9177,23 +9169,23 @@
       "integrity": "sha512-kBNy/S2CGwrYgDSec5KTWGKUvupwkkTVAjIsVFF2shXO13xpZdFP4d4kxa//CLX2tN/rV0aYwK8vY6UKWGn2vQ==",
       "dev": true,
       "requires": {
-        "@sindresorhus/is": "0.7.0",
-        "cacheable-request": "2.1.4",
-        "decompress-response": "3.3.0",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "into-stream": "3.1.0",
-        "is-retry-allowed": "1.1.0",
-        "isurl": "1.0.0",
-        "lowercase-keys": "1.0.1",
-        "mimic-response": "1.0.0",
-        "p-cancelable": "0.4.1",
-        "p-timeout": "2.0.1",
-        "pify": "3.0.0",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "url-parse-lax": "3.0.0",
-        "url-to-options": "1.0.1"
+        "@sindresorhus/is": "^0.7.0",
+        "cacheable-request": "^2.1.1",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "into-stream": "^3.1.0",
+        "is-retry-allowed": "^1.1.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "mimic-response": "^1.0.0",
+        "p-cancelable": "^0.4.0",
+        "p-timeout": "^2.0.1",
+        "pify": "^3.0.0",
+        "safe-buffer": "^5.1.1",
+        "timed-out": "^4.0.1",
+        "url-parse-lax": "^3.0.0",
+        "url-to-options": "^1.0.1"
       },
       "dependencies": {
         "pify": {
@@ -9216,9 +9208,9 @@
       "integrity": "sha512-Y0l11L0idKEtrtGutgjA6htGmh8VOuIy9nfZrpWbsT3hfK8JF0CMjF73go9JY4sU4TMvLyBV9MmcbbHuDhNWRw==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4",
-        "require-relative": "0.8.7",
-        "semver": "5.4.1"
+        "lodash": "^4.17.4",
+        "require-relative": "^0.8.7",
+        "semver": "^5.3.0"
       }
     },
     "growly": {
@@ -9239,10 +9231,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "async": {
@@ -9257,7 +9249,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -9274,8 +9266,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "harmony-reflect": {
@@ -9289,7 +9281,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -9298,14 +9290,13 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "has-symbol-support-x": {
       "version": "1.4.2",
@@ -9324,7 +9315,7 @@
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "1.4.2"
+        "has-symbol-support-x": "^1.4.1"
       }
     },
     "has-unicode": {
@@ -9339,9 +9330,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -9350,8 +9341,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -9360,7 +9351,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9369,7 +9360,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -9380,7 +9371,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -9391,7 +9382,7 @@
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "hash.js": {
@@ -9400,8 +9391,8 @@
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "hawk": {
@@ -9410,10 +9401,10 @@
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "he": {
@@ -9428,11 +9419,11 @@
       "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
       "dev": true,
       "requires": {
-        "invariant": "2.2.2",
-        "loose-envify": "1.3.1",
-        "resolve-pathname": "2.2.0",
-        "value-equal": "0.4.0",
-        "warning": "3.0.0"
+        "invariant": "^2.2.1",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^2.2.0",
+        "value-equal": "^0.4.0",
+        "warning": "^3.0.0"
       }
     },
     "hmac-drbg": {
@@ -9441,9 +9432,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoek": {
@@ -9464,8 +9455,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "hook-std": {
@@ -9486,10 +9477,10 @@
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "obuf": "1.1.1",
-        "readable-stream": "2.3.3",
-        "wbuf": "1.7.2"
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
       }
     },
     "html-comment-regex": {
@@ -9510,7 +9501,7 @@
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "1.0.3"
+        "whatwg-encoding": "^1.0.1"
       }
     },
     "html-entities": {
@@ -9525,11 +9516,11 @@
       "integrity": "sha512-7hIW7YinOYUpo//kSYcPB6dCKoceKLmOwjEMmhIobHuWGDVl0Nwe4l68mdG/Ru0wcUxQjVMEoZpkalZ/SE7zog==",
       "dev": true,
       "requires": {
-        "es6-templates": "0.2.3",
-        "fastparse": "1.1.1",
-        "html-minifier": "3.5.8",
-        "loader-utils": "1.1.0",
-        "object-assign": "4.1.1"
+        "es6-templates": "^0.2.3",
+        "fastparse": "^1.1.1",
+        "html-minifier": "^3.5.8",
+        "loader-utils": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "html-minifier": {
@@ -9538,14 +9529,14 @@
       "integrity": "sha512-WX7D6PB9PFq05fZ1/CyxPUuyqXed6vh2fGOM80+zJT5wAO93D/cUjLs0CcbBFjQmlwmCgRvl97RurtArIpOnkw==",
       "dev": true,
       "requires": {
-        "camel-case": "3.0.0",
-        "clean-css": "4.1.9",
-        "commander": "2.12.2",
-        "he": "1.1.1",
-        "ncname": "1.0.0",
-        "param-case": "2.1.1",
-        "relateurl": "0.2.7",
-        "uglify-js": "3.3.8"
+        "camel-case": "3.0.x",
+        "clean-css": "4.1.x",
+        "commander": "2.12.x",
+        "he": "1.1.x",
+        "ncname": "1.0.x",
+        "param-case": "2.1.x",
+        "relateurl": "0.2.x",
+        "uglify-js": "3.3.x"
       },
       "dependencies": {
         "source-map": {
@@ -9560,8 +9551,8 @@
           "integrity": "sha512-X0jAGtpSZRtd4RhbVNuGHyjZNa/h2MrVkKrR3Ew5iL2MJw6d7FmBke+fhVCALWySv1ygHnjjROG1KI1FAPvddw==",
           "dev": true,
           "requires": {
-            "commander": "2.13.0",
-            "source-map": "0.6.1"
+            "commander": "~2.13.0",
+            "source-map": "~0.6.1"
           },
           "dependencies": {
             "commander": {
@@ -9586,12 +9577,12 @@
       "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
-        "html-minifier": "3.5.8",
-        "loader-utils": "0.2.17",
-        "lodash": "4.17.4",
-        "pretty-error": "2.1.1",
-        "toposort": "1.0.6"
+        "bluebird": "^3.4.7",
+        "html-minifier": "^3.2.3",
+        "loader-utils": "^0.2.16",
+        "lodash": "^4.17.3",
+        "pretty-error": "^2.0.2",
+        "toposort": "^1.0.0"
       },
       "dependencies": {
         "loader-utils": {
@@ -9600,10 +9591,10 @@
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true,
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
           }
         }
       }
@@ -9612,14 +9603,13 @@
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
-      "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.1",
-        "domutils": "1.5.1",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "http-cache-semantics": {
@@ -9643,7 +9633,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
+        "statuses": ">= 1.3.1 < 2"
       },
       "dependencies": {
         "setprototypeof": {
@@ -9666,8 +9656,8 @@
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.2.0",
-        "requires-port": "1.0.0"
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
       }
     },
     "http-proxy-agent": {
@@ -9676,7 +9666,7 @@
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.0",
+        "agent-base": "4",
         "debug": "3.1.0"
       },
       "dependencies": {
@@ -9697,10 +9687,10 @@
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
       "dev": true,
       "requires": {
-        "http-proxy": "1.16.2",
-        "is-glob": "3.1.0",
-        "lodash": "4.17.4",
-        "micromatch": "2.3.11"
+        "http-proxy": "^1.16.2",
+        "is-glob": "^3.1.0",
+        "lodash": "^4.17.2",
+        "micromatch": "^2.3.11"
       },
       "dependencies": {
         "is-extglob": {
@@ -9715,7 +9705,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         }
       }
@@ -9726,9 +9716,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -9743,8 +9733,8 @@
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.0",
-        "debug": "3.1.0"
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -9764,9 +9754,9 @@
       "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
       "dev": true,
       "requires": {
-        "is-ci": "1.0.10",
-        "normalize-path": "1.0.0",
-        "strip-indent": "2.0.0"
+        "is-ci": "^1.0.10",
+        "normalize-path": "^1.0.0",
+        "strip-indent": "^2.0.0"
       },
       "dependencies": {
         "normalize-path": {
@@ -9786,8 +9776,7 @@
     "hyphenate-style-name": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
-      "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es=",
-      "dev": true
+      "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
     },
     "iconv-lite": {
       "version": "0.4.19",
@@ -9806,7 +9795,7 @@
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14"
+        "postcss": "^6.0.1"
       }
     },
     "identity-obj-proxy": {
@@ -9815,7 +9804,7 @@
       "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
       "dev": true,
       "requires": {
-        "harmony-reflect": "1.5.1"
+        "harmony-reflect": "^1.4.6"
       }
     },
     "ieee754": {
@@ -9848,7 +9837,7 @@
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -9871,8 +9860,8 @@
       "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "2.0.0",
-        "resolve-cwd": "2.0.0"
+        "pkg-dir": "^2.0.0",
+        "resolve-cwd": "^2.0.0"
       }
     },
     "imurmurhash": {
@@ -9893,7 +9882,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "indexes-of": {
@@ -9914,15 +9903,14 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
@@ -9936,8 +9924,8 @@
       "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
       "dev": true,
       "requires": {
-        "bowser": "1.9.1",
-        "css-in-js-utils": "2.0.0"
+        "bowser": "^1.7.3",
+        "css-in-js-utils": "^2.0.0"
       }
     },
     "inquirer": {
@@ -9946,18 +9934,18 @@
       "integrity": "sha1-dEi/qSQJKvMR1HFzu6uZDK4rsCc=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "1.1.1",
-        "figures": "1.7.0",
-        "lodash": "3.10.1",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^1.0.1",
+        "figures": "^1.3.5",
+        "lodash": "^3.3.1",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9972,11 +9960,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "lodash": {
@@ -9999,7 +9987,7 @@
       "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
       "dev": true,
       "requires": {
-        "meow": "3.7.0"
+        "meow": "^3.3.0"
       }
     },
     "interpret": {
@@ -10014,8 +10002,8 @@
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "requires": {
-        "from2": "2.3.0",
-        "p-is-promise": "1.1.0"
+        "from2": "^2.1.1",
+        "p-is-promise": "^1.1.0"
       }
     },
     "invariant": {
@@ -10024,7 +10012,7 @@
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -10057,7 +10045,7 @@
       "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
       "dev": true,
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -10080,7 +10068,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -10095,7 +10083,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -10109,7 +10097,7 @@
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.2"
+        "ci-info": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -10118,7 +10106,7 @@
       "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
       "dev": true,
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -10140,9 +10128,9 @@
       "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "1.0.0",
-        "is-data-descriptor": "1.0.0",
-        "kind-of": "6.0.2"
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -10177,7 +10165,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -10198,7 +10186,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -10207,7 +10195,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-function": {
@@ -10222,7 +10210,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-installed-globally": {
@@ -10231,8 +10219,8 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "0.1.1",
-        "is-path-inside": "1.0.1"
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-my-json-valid": {
@@ -10241,10 +10229,10 @@
       "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-npm": {
@@ -10259,7 +10247,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-obj": {
@@ -10280,7 +10268,7 @@
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "dev": true,
       "requires": {
-        "is-number": "4.0.0"
+        "is-number": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -10303,7 +10291,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -10312,7 +10300,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -10327,7 +10315,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-posix-bracket": {
@@ -10365,7 +10353,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-resolvable": {
@@ -10386,7 +10374,7 @@
       "integrity": "sha1-6+oRaaJhTaOSpjdANmw84EnY3/Y=",
       "dev": true,
       "requires": {
-        "protocols": "1.4.6"
+        "protocols": "^1.1.0"
       }
     },
     "is-stream": {
@@ -10406,7 +10394,7 @@
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
       "dev": true,
       "requires": {
-        "html-comment-regex": "1.1.1"
+        "html-comment-regex": "^1.1.0"
       }
     },
     "is-symbol": {
@@ -10420,7 +10408,7 @@
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
-        "text-extensions": "1.7.0"
+        "text-extensions": "^1.0.0"
       }
     },
     "is-typedarray": {
@@ -10444,8 +10432,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -10464,8 +10451,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "isstream": {
@@ -10480,7 +10467,7 @@
       "integrity": "sha512-jJeDfplV9Y3ZQIKodmu1aB8X8oNusb8PCL6iK9Z0umJWnmvvu1NJZ2aWitJlEmYOdJOLhcKcFirDX6z/nECNvQ==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.17.4"
       }
     },
     "istanbul-api": {
@@ -10489,17 +10476,17 @@
       "integrity": "sha512-oFCwXvd65amgaPCzqrR+a2XjanS1MvpXN6l/MlMUTv6uiA1NOgGX+I0uyq8Lg3GDxsxPsaP1049krz3hIJ5+KA==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "fileset": "2.0.3",
-        "istanbul-lib-coverage": "1.1.1",
-        "istanbul-lib-hook": "1.1.0",
-        "istanbul-lib-instrument": "1.9.1",
-        "istanbul-lib-report": "1.1.2",
-        "istanbul-lib-source-maps": "1.2.2",
-        "istanbul-reports": "1.1.3",
-        "js-yaml": "3.10.0",
-        "mkdirp": "0.5.1",
-        "once": "1.4.0"
+        "async": "^2.1.4",
+        "fileset": "^2.0.2",
+        "istanbul-lib-coverage": "^1.1.1",
+        "istanbul-lib-hook": "^1.1.0",
+        "istanbul-lib-instrument": "^1.9.1",
+        "istanbul-lib-report": "^1.1.2",
+        "istanbul-lib-source-maps": "^1.2.2",
+        "istanbul-reports": "^1.1.3",
+        "js-yaml": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0"
       }
     },
     "istanbul-lib-coverage": {
@@ -10514,7 +10501,7 @@
       "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
       "dev": true,
       "requires": {
-        "append-transform": "0.4.0"
+        "append-transform": "^0.4.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -10523,13 +10510,13 @@
       "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
       "dev": true,
       "requires": {
-        "babel-generator": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.1.1",
-        "semver": "5.4.1"
+        "babel-generator": "^6.18.0",
+        "babel-template": "^6.16.0",
+        "babel-traverse": "^6.18.0",
+        "babel-types": "^6.18.0",
+        "babylon": "^6.18.0",
+        "istanbul-lib-coverage": "^1.1.1",
+        "semver": "^5.3.0"
       }
     },
     "istanbul-lib-report": {
@@ -10538,10 +10525,10 @@
       "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "1.1.1",
-        "mkdirp": "0.5.1",
-        "path-parse": "1.0.5",
-        "supports-color": "3.2.3"
+        "istanbul-lib-coverage": "^1.1.1",
+        "mkdirp": "^0.5.1",
+        "path-parse": "^1.0.5",
+        "supports-color": "^3.1.2"
       },
       "dependencies": {
         "has-flag": {
@@ -10556,7 +10543,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -10567,11 +10554,11 @@
       "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
       "dev": true,
       "requires": {
-        "debug": "3.1.0",
-        "istanbul-lib-coverage": "1.1.1",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "source-map": "0.5.7"
+        "debug": "^3.1.0",
+        "istanbul-lib-coverage": "^1.1.1",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.6.1",
+        "source-map": "^0.5.3"
       },
       "dependencies": {
         "debug": {
@@ -10591,7 +10578,7 @@
       "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
       "dev": true,
       "requires": {
-        "handlebars": "4.0.11"
+        "handlebars": "^4.0.3"
       }
     },
     "isurl": {
@@ -10600,8 +10587,8 @@
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
       "requires": {
-        "has-to-string-tag-x": "1.4.1",
-        "is-object": "1.0.1"
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
       }
     },
     "java-properties": {
@@ -10616,7 +10603,7 @@
       "integrity": "sha512-S0tmgK5psULvt/11QzgAZWGpY5y5TkMRzd3T21Q13JzTx37Vx6F0Nw022c9Kc/IbEy+AHkKkGFVO5QafE8MrDg==",
       "dev": true,
       "requires": {
-        "jest-cli": "22.0.4"
+        "jest-cli": "^22.0.4"
       }
     },
     "jest-cli": {
@@ -10625,37 +10612,37 @@
       "integrity": "sha512-f1lZRM13IwIINzjE3RebXQKtQLiKncpSrbJZ/aTZJXmzEWGdgSayW4ESyhU+xK3uGiJEUSzbHjwPY6nGJ8VbUA==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.0.0",
-        "chalk": "2.3.0",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "is-ci": "1.0.10",
-        "istanbul-api": "1.2.1",
-        "istanbul-lib-coverage": "1.1.1",
-        "istanbul-lib-instrument": "1.9.1",
-        "istanbul-lib-source-maps": "1.2.2",
-        "jest-changed-files": "22.0.3",
-        "jest-config": "22.0.4",
-        "jest-environment-jsdom": "22.0.4",
-        "jest-get-type": "22.0.3",
-        "jest-haste-map": "22.0.3",
-        "jest-message-util": "22.0.3",
-        "jest-regex-util": "22.0.3",
-        "jest-resolve-dependencies": "22.0.3",
-        "jest-runner": "22.0.4",
-        "jest-runtime": "22.0.4",
-        "jest-snapshot": "22.0.3",
-        "jest-util": "22.0.4",
-        "jest-worker": "22.0.3",
-        "micromatch": "2.3.11",
-        "node-notifier": "5.1.2",
-        "realpath-native": "1.0.0",
-        "rimraf": "2.6.2",
-        "slash": "1.0.0",
-        "string-length": "2.0.0",
-        "strip-ansi": "4.0.0",
-        "which": "1.3.0",
-        "yargs": "10.0.3"
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "is-ci": "^1.0.10",
+        "istanbul-api": "^1.1.14",
+        "istanbul-lib-coverage": "^1.1.1",
+        "istanbul-lib-instrument": "^1.8.0",
+        "istanbul-lib-source-maps": "^1.2.1",
+        "jest-changed-files": "^22.0.3",
+        "jest-config": "^22.0.4",
+        "jest-environment-jsdom": "^22.0.4",
+        "jest-get-type": "^22.0.3",
+        "jest-haste-map": "^22.0.3",
+        "jest-message-util": "^22.0.3",
+        "jest-regex-util": "^22.0.3",
+        "jest-resolve-dependencies": "^22.0.3",
+        "jest-runner": "^22.0.4",
+        "jest-runtime": "^22.0.4",
+        "jest-snapshot": "^22.0.3",
+        "jest-util": "^22.0.4",
+        "jest-worker": "^22.0.3",
+        "micromatch": "^2.3.11",
+        "node-notifier": "^5.1.2",
+        "realpath-native": "^1.0.0",
+        "rimraf": "^2.5.4",
+        "slash": "^1.0.0",
+        "string-length": "^2.0.0",
+        "strip-ansi": "^4.0.0",
+        "which": "^1.2.12",
+        "yargs": "^10.0.3"
       },
       "dependencies": {
         "acorn-globals": {
@@ -10664,7 +10651,7 @@
           "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
           "dev": true,
           "requires": {
-            "acorn": "5.2.1"
+            "acorn": "^5.0.0"
           }
         },
         "ansi-escapes": {
@@ -10685,8 +10672,8 @@
           "integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
           "dev": true,
           "requires": {
-            "babel-plugin-istanbul": "4.1.5",
-            "babel-preset-jest": "22.4.4"
+            "babel-plugin-istanbul": "^4.1.5",
+            "babel-preset-jest": "^22.4.4"
           }
         },
         "babel-plugin-jest-hoist": {
@@ -10701,8 +10688,8 @@
           "integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
           "dev": true,
           "requires": {
-            "babel-plugin-jest-hoist": "22.4.4",
-            "babel-plugin-syntax-object-rest-spread": "6.13.0"
+            "babel-plugin-jest-hoist": "^22.4.4",
+            "babel-plugin-syntax-object-rest-spread": "^6.13.0"
           }
         },
         "callsites": {
@@ -10723,9 +10710,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -10740,9 +10727,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             },
             "strip-ansi": {
@@ -10751,7 +10738,7 @@
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             }
           }
@@ -10762,12 +10749,12 @@
           "integrity": "sha512-QapzeQkcA3jCx4pDnD07I4SPPxScKbey8TD/WwrnzmpHmL5q0dUtXfUt5OIFOjVBCg+C4zn4Y1zK9Rb9SIDL1g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "jest-diff": "22.0.3",
-            "jest-get-type": "22.0.3",
-            "jest-matcher-utils": "22.0.3",
-            "jest-message-util": "22.0.3",
-            "jest-regex-util": "22.0.3"
+            "ansi-styles": "^3.2.0",
+            "jest-diff": "^22.0.3",
+            "jest-get-type": "^22.0.3",
+            "jest-matcher-utils": "^22.0.3",
+            "jest-message-util": "^22.0.3",
+            "jest-regex-util": "^22.0.3"
           }
         },
         "jest-changed-files": {
@@ -10776,7 +10763,7 @@
           "integrity": "sha512-CG7eNJNO9x1O/3J4Uhe2QXra1MnC9+KS1f2NeOg+7iQ+8dDCgxCtpusmKfu44TnEyKwkIDhDr6htPfPaI+Fwbw==",
           "dev": true,
           "requires": {
-            "throat": "4.1.0"
+            "throat": "^4.0.0"
           }
         },
         "jest-config": {
@@ -10785,17 +10772,17 @@
           "integrity": "sha512-NcBeixqHjHDZO9+pUj+365LQV2s65d2f0/IrwlUyv0xaJovRNc6eDvoJ/r2UUlHnqjP3Go+R0ECUsXPXjk4SHw==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
-            "glob": "7.1.2",
-            "jest-environment-jsdom": "22.0.4",
-            "jest-environment-node": "22.0.4",
-            "jest-get-type": "22.0.3",
-            "jest-jasmine2": "22.0.4",
-            "jest-regex-util": "22.0.3",
-            "jest-resolve": "22.0.4",
-            "jest-util": "22.0.4",
-            "jest-validate": "22.0.3",
-            "pretty-format": "22.0.3"
+            "chalk": "^2.0.1",
+            "glob": "^7.1.1",
+            "jest-environment-jsdom": "^22.0.4",
+            "jest-environment-node": "^22.0.4",
+            "jest-get-type": "^22.0.3",
+            "jest-jasmine2": "^22.0.4",
+            "jest-regex-util": "^22.0.3",
+            "jest-resolve": "^22.0.4",
+            "jest-util": "^22.0.4",
+            "jest-validate": "^22.0.3",
+            "pretty-format": "^22.0.3"
           }
         },
         "jest-diff": {
@@ -10804,10 +10791,10 @@
           "integrity": "sha512-Y7xN9Lc/NgFvR14lvjrJXB6x2x1LLe5NnMyzLvilBSSOyjy9uAVnR2Bt1YgzdfRrfaxsx7xFUVcqXLUnPkrJcA==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
-            "diff": "3.4.0",
-            "jest-get-type": "22.0.3",
-            "pretty-format": "22.0.3"
+            "chalk": "^2.0.1",
+            "diff": "^3.2.0",
+            "jest-get-type": "^22.0.3",
+            "pretty-format": "^22.0.3"
           }
         },
         "jest-docblock": {
@@ -10816,7 +10803,7 @@
           "integrity": "sha512-LhviP2rqIg2IzS6m97W7T032oMrT699Tr6Njjhhl4FCLj+75BUy9CsSmGgfoVEql1uc+myBkssvcbn7T9xDR+A==",
           "dev": true,
           "requires": {
-            "detect-newline": "2.1.0"
+            "detect-newline": "^2.1.0"
           }
         },
         "jest-environment-jsdom": {
@@ -10825,9 +10812,9 @@
           "integrity": "sha512-vnjefLZlsNsmnjKcaXkx2IxTBNG40vfRVOdMfcfkPkq85JxFB7wzNtjLx+RIfiNpIZd04C1PXbF0aJIenY85Ng==",
           "dev": true,
           "requires": {
-            "jest-mock": "22.0.3",
-            "jest-util": "22.0.4",
-            "jsdom": "11.5.1"
+            "jest-mock": "^22.0.3",
+            "jest-util": "^22.0.4",
+            "jsdom": "^11.5.1"
           }
         },
         "jest-environment-node": {
@@ -10836,8 +10823,8 @@
           "integrity": "sha512-9vjNKb86UivvKCZCudMNixQgdMnOG7ql6iVYnaiK0CmvZ0WQD+mlM10NvgiWpRv4HstcnRL1pY/GSIHXAD6qXw==",
           "dev": true,
           "requires": {
-            "jest-mock": "22.0.3",
-            "jest-util": "22.0.4"
+            "jest-mock": "^22.0.3",
+            "jest-util": "^22.0.4"
           }
         },
         "jest-get-type": {
@@ -10852,12 +10839,12 @@
           "integrity": "sha512-VosIMOFQFu1rTF+MvOWVuv2KVmZ9eTkRgfwW2yUAs6/AhwmIfXRl/tih+fIOYcHzU4Auu1G8Fvl2kkF5g0k6/A==",
           "dev": true,
           "requires": {
-            "fb-watchman": "2.0.0",
-            "graceful-fs": "4.1.11",
-            "jest-docblock": "22.0.3",
-            "jest-worker": "22.0.3",
-            "micromatch": "2.3.11",
-            "sane": "2.2.0"
+            "fb-watchman": "^2.0.0",
+            "graceful-fs": "^4.1.11",
+            "jest-docblock": "^22.0.3",
+            "jest-worker": "^22.0.3",
+            "micromatch": "^2.3.11",
+            "sane": "^2.0.0"
           }
         },
         "jest-jasmine2": {
@@ -10866,15 +10853,15 @@
           "integrity": "sha512-pn1XPHUkffHK6oNY1Dfl/+Rg0UuTdlg3aGDnjyK6dZzGEBeiH1uKuSgZEjy3Lj461l3atpzsQyw7ilXPyjFnUw==",
           "dev": true,
           "requires": {
-            "callsites": "2.0.0",
-            "chalk": "2.3.0",
-            "expect": "22.0.3",
-            "graceful-fs": "4.1.11",
-            "jest-diff": "22.0.3",
-            "jest-matcher-utils": "22.0.3",
-            "jest-message-util": "22.0.3",
-            "jest-snapshot": "22.0.3",
-            "source-map-support": "0.5.0"
+            "callsites": "^2.0.0",
+            "chalk": "^2.0.1",
+            "expect": "^22.0.3",
+            "graceful-fs": "^4.1.11",
+            "jest-diff": "^22.0.3",
+            "jest-matcher-utils": "^22.0.3",
+            "jest-message-util": "^22.0.3",
+            "jest-snapshot": "^22.0.3",
+            "source-map-support": "^0.5.0"
           }
         },
         "jest-matcher-utils": {
@@ -10883,9 +10870,9 @@
           "integrity": "sha512-FJbKpCR3K7YYE/Pnvy5OrLFgPEswpYWIfVtdwT2NC6pBARbYGX39KF3bTxS9yg2mv0YL2zHe3UbwzFsi9nFpVA==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
-            "jest-get-type": "22.0.3",
-            "pretty-format": "22.0.3"
+            "chalk": "^2.0.1",
+            "jest-get-type": "^22.0.3",
+            "pretty-format": "^22.0.3"
           }
         },
         "jest-message-util": {
@@ -10894,11 +10881,11 @@
           "integrity": "sha512-AVBdCx7Oj5wBpMOH089lx7Zgwpdz9HbReA82HuVAlIT4kEQRvCy6Sl9yVWDGJwHTgB/OYQGkgmbv/P/K8TkWNw==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "7.0.0-beta.36",
-            "chalk": "2.3.0",
-            "micromatch": "2.3.11",
-            "slash": "1.0.0",
-            "stack-utils": "1.0.1"
+            "@babel/code-frame": "^7.0.0-beta.35",
+            "chalk": "^2.0.1",
+            "micromatch": "^2.3.11",
+            "slash": "^1.0.0",
+            "stack-utils": "^1.0.1"
           }
         },
         "jest-mock": {
@@ -10919,8 +10906,8 @@
           "integrity": "sha512-yoxHsX4MTT2Ra/dFia9VCunzsA/4jMBENMmLjREIUkCIP1edk/PZUOGVVf680Gw04CtmT5stETylcbmbL7hJBw==",
           "dev": true,
           "requires": {
-            "browser-resolve": "1.11.2",
-            "chalk": "2.3.0"
+            "browser-resolve": "^1.11.2",
+            "chalk": "^2.0.1"
           }
         },
         "jest-resolve-dependencies": {
@@ -10929,7 +10916,7 @@
           "integrity": "sha512-u9MUNJIa9GJ0YFhvM0+Scr4tyX84nC42d3w18Cly1doY7pTT+9momm+TncpuDlFyB2aNmS8SfdEbiLr1e6tBwg==",
           "dev": true,
           "requires": {
-            "jest-regex-util": "22.0.3"
+            "jest-regex-util": "^22.0.3"
           }
         },
         "jest-runner": {
@@ -10938,16 +10925,16 @@
           "integrity": "sha512-srBkbqmiSB+jzSaG652fmi3kS6rV6wS/4fOG8dxxBg3dCqNQcM2/L3TI3ZK0SwIAcdGJh5Gybs8aDboT8K9Cdw==",
           "dev": true,
           "requires": {
-            "jest-config": "22.0.4",
-            "jest-docblock": "22.0.3",
-            "jest-haste-map": "22.0.3",
-            "jest-jasmine2": "22.0.4",
-            "jest-leak-detector": "22.0.3",
-            "jest-message-util": "22.0.3",
-            "jest-runtime": "22.0.4",
-            "jest-util": "22.0.4",
-            "jest-worker": "22.0.3",
-            "throat": "4.1.0"
+            "jest-config": "^22.0.4",
+            "jest-docblock": "^22.0.3",
+            "jest-haste-map": "^22.0.3",
+            "jest-jasmine2": "^22.0.4",
+            "jest-leak-detector": "^22.0.3",
+            "jest-message-util": "^22.0.3",
+            "jest-runtime": "^22.0.4",
+            "jest-util": "^22.0.4",
+            "jest-worker": "^22.0.3",
+            "throat": "^4.0.0"
           }
         },
         "jest-runtime": {
@@ -10956,24 +10943,24 @@
           "integrity": "sha512-+7uEwf/4f8k1E/eViyGK6/M5yA4O3f6TdWViuqF9MV7vXwG2OVJu8YEZa5239nEnHJiwinXp4eZXX+HB4pQRPg==",
           "dev": true,
           "requires": {
-            "babel-core": "6.26.0",
-            "babel-jest": "22.4.4",
-            "babel-plugin-istanbul": "4.1.5",
-            "chalk": "2.3.0",
-            "convert-source-map": "1.5.1",
-            "graceful-fs": "4.1.11",
-            "jest-config": "22.0.4",
-            "jest-haste-map": "22.0.3",
-            "jest-regex-util": "22.0.3",
-            "jest-resolve": "22.0.4",
-            "jest-util": "22.0.4",
-            "json-stable-stringify": "1.0.1",
-            "micromatch": "2.3.11",
-            "realpath-native": "1.0.0",
-            "slash": "1.0.0",
+            "babel-core": "^6.0.0",
+            "babel-jest": "^22.0.4",
+            "babel-plugin-istanbul": "^4.1.5",
+            "chalk": "^2.0.1",
+            "convert-source-map": "^1.4.0",
+            "graceful-fs": "^4.1.11",
+            "jest-config": "^22.0.4",
+            "jest-haste-map": "^22.0.3",
+            "jest-regex-util": "^22.0.3",
+            "jest-resolve": "^22.0.4",
+            "jest-util": "^22.0.4",
+            "json-stable-stringify": "^1.0.1",
+            "micromatch": "^2.3.11",
+            "realpath-native": "^1.0.0",
+            "slash": "^1.0.0",
             "strip-bom": "3.0.0",
-            "write-file-atomic": "2.3.0",
-            "yargs": "10.0.3"
+            "write-file-atomic": "^2.1.0",
+            "yargs": "^10.0.3"
           }
         },
         "jest-snapshot": {
@@ -10982,12 +10969,12 @@
           "integrity": "sha512-e/a/EvMsY5XROWy4QWX6PvYziuJ8ttD6+QcnbogODWtx2LGhvVQOb7pmqGTo0tL/p0vzFetZA9GlZSh/EfMepg==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
-            "jest-diff": "22.0.3",
-            "jest-matcher-utils": "22.0.3",
-            "mkdirp": "0.5.1",
-            "natural-compare": "1.4.0",
-            "pretty-format": "22.0.3"
+            "chalk": "^2.0.1",
+            "jest-diff": "^22.0.3",
+            "jest-matcher-utils": "^22.0.3",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^22.0.3"
           }
         },
         "jest-util": {
@@ -10996,13 +10983,13 @@
           "integrity": "sha512-gNNPtcCFkVh7daKIl3/06eoQ90QXGXCyDOfyZ3IEyTWmHBdX3GvklcOtyGcdOvrYEubaZTfMcMKmEeo/6sRTog==",
           "dev": true,
           "requires": {
-            "callsites": "2.0.0",
-            "chalk": "2.3.0",
-            "graceful-fs": "4.1.11",
-            "is-ci": "1.0.10",
-            "jest-message-util": "22.0.3",
-            "jest-validate": "22.0.3",
-            "mkdirp": "0.5.1"
+            "callsites": "^2.0.0",
+            "chalk": "^2.0.1",
+            "graceful-fs": "^4.1.11",
+            "is-ci": "^1.0.10",
+            "jest-message-util": "^22.0.3",
+            "jest-validate": "^22.0.3",
+            "mkdirp": "^0.5.1"
           }
         },
         "jest-validate": {
@@ -11011,10 +10998,10 @@
           "integrity": "sha512-GmlLmPCtrSQ3iB4A1uxcfjawaaQnwESCDcUg5tMxJKeBbmPdcWPAb6EWzvANxULPUV7hfPKLwg4xIPpi7cx1/g==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
-            "jest-get-type": "22.0.3",
-            "leven": "2.1.0",
-            "pretty-format": "22.0.3"
+            "chalk": "^2.0.1",
+            "jest-get-type": "^22.0.3",
+            "leven": "^2.1.0",
+            "pretty-format": "^22.0.3"
           }
         },
         "jsdom": {
@@ -11023,30 +11010,30 @@
           "integrity": "sha512-89ztIZ03aYK9f1uUrLXLsZndRge/JnZjzjpaN+lrse3coqz+8PR/dX4WLHpbF5fIKTXhDjFODOJw2328lPJ90g==",
           "dev": true,
           "requires": {
-            "abab": "1.0.4",
-            "acorn": "5.2.1",
-            "acorn-globals": "4.1.0",
-            "array-equal": "1.0.0",
-            "browser-process-hrtime": "0.1.2",
-            "content-type-parser": "1.0.2",
-            "cssom": "0.3.2",
-            "cssstyle": "0.2.37",
-            "domexception": "1.0.0",
-            "escodegen": "1.9.0",
-            "html-encoding-sniffer": "1.0.2",
-            "left-pad": "1.2.0",
-            "nwmatcher": "1.4.3",
-            "parse5": "3.0.3",
-            "pn": "1.0.0",
-            "request": "2.83.0",
-            "request-promise-native": "1.0.5",
-            "sax": "1.2.4",
-            "symbol-tree": "3.2.2",
-            "tough-cookie": "2.3.3",
-            "webidl-conversions": "4.0.2",
-            "whatwg-encoding": "1.0.3",
-            "whatwg-url": "6.4.0",
-            "xml-name-validator": "2.0.1"
+            "abab": "^1.0.3",
+            "acorn": "^5.1.2",
+            "acorn-globals": "^4.0.0",
+            "array-equal": "^1.0.0",
+            "browser-process-hrtime": "^0.1.2",
+            "content-type-parser": "^1.0.1",
+            "cssom": ">= 0.3.2 < 0.4.0",
+            "cssstyle": ">= 0.2.37 < 0.3.0",
+            "domexception": "^1.0.0",
+            "escodegen": "^1.9.0",
+            "html-encoding-sniffer": "^1.0.1",
+            "left-pad": "^1.2.0",
+            "nwmatcher": "^1.4.3",
+            "parse5": "^3.0.2",
+            "pn": "^1.0.0",
+            "request": "^2.83.0",
+            "request-promise-native": "^1.0.3",
+            "sax": "^1.2.1",
+            "symbol-tree": "^3.2.1",
+            "tough-cookie": "^2.3.3",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.1",
+            "whatwg-url": "^6.3.0",
+            "xml-name-validator": "^2.0.1"
           }
         },
         "pretty-format": {
@@ -11055,8 +11042,8 @@
           "integrity": "sha512-qXbDFJ2/Kk3HFIaLdOblbsCKQ09kZu4MKbXB+m/EaqD7PZ/wXe2XcRREmQleMh4wmerxlma6eJTh3nxCXYUmmA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0",
-            "ansi-styles": "3.2.0"
+            "ansi-regex": "^3.0.0",
+            "ansi-styles": "^3.2.0"
           }
         },
         "punycode": {
@@ -11077,7 +11064,7 @@
           "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
           "dev": true,
           "requires": {
-            "source-map": "0.6.1"
+            "source-map": "^0.6.0"
           }
         },
         "string-width": {
@@ -11086,8 +11073,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -11104,7 +11091,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "strip-bom": {
@@ -11119,7 +11106,7 @@
           "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
           "dev": true,
           "requires": {
-            "punycode": "2.1.0"
+            "punycode": "^2.1.0"
           }
         },
         "whatwg-url": {
@@ -11128,9 +11115,9 @@
           "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
           "dev": true,
           "requires": {
-            "lodash.sortby": "4.7.0",
-            "tr46": "1.0.1",
-            "webidl-conversions": "4.0.2"
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.0",
+            "webidl-conversions": "^4.0.1"
           }
         },
         "yargs": {
@@ -11139,18 +11126,18 @@
           "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
           "dev": true,
           "requires": {
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "8.1.0"
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^8.0.0"
           }
         },
         "yargs-parser": {
@@ -11159,7 +11146,7 @@
           "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -11170,10 +11157,10 @@
       "integrity": "sha512-lowdbU/dzXh+2/MR5QcvU5KPNkO4JdAEYw0PkQCbIQIuy5+g3QZBuVhWh8179Fmpg4CQrz1WgoK/yQHDCHbqqw==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "diff": "3.4.0",
-        "jest-get-type": "22.1.0",
-        "pretty-format": "22.1.0"
+        "chalk": "^2.0.1",
+        "diff": "^3.2.0",
+        "jest-get-type": "^22.1.0",
+        "pretty-format": "^22.1.0"
       }
     },
     "jest-get-type": {
@@ -11188,8 +11175,8 @@
       "integrity": "sha512-xyVdAmcG8M3jWtVeadDUU6MAHLBrjkP4clz2UtTZ1gpe5bRLk27VjQOpzTwK20MkV/6iZQhSuRVuzHS5kD0HpA==",
       "dev": true,
       "requires": {
-        "pretty-format": "22.0.3",
-        "weak": "1.0.1"
+        "pretty-format": "^22.0.3",
+        "weak": "^1.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -11204,8 +11191,8 @@
           "integrity": "sha512-qXbDFJ2/Kk3HFIaLdOblbsCKQ09kZu4MKbXB+m/EaqD7PZ/wXe2XcRREmQleMh4wmerxlma6eJTh3nxCXYUmmA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0",
-            "ansi-styles": "3.2.0"
+            "ansi-regex": "^3.0.0",
+            "ansi-styles": "^3.2.0"
           }
         }
       }
@@ -11216,9 +11203,9 @@
       "integrity": "sha512-Zn1OD9wVjILOdvRxgAnqiCN36OX6KJx+P2FHN+3lzQ0omG2N2OAguxE1QXuJJneG2yndlkXjekXFP254c0cSpw==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "jest-get-type": "22.1.0",
-        "pretty-format": "22.1.0"
+        "chalk": "^2.0.1",
+        "jest-get-type": "^22.1.0",
+        "pretty-format": "^22.1.0"
       }
     },
     "jest-snapshot": {
@@ -11227,12 +11214,12 @@
       "integrity": "sha512-45co/M0gTe6Y6yHaJLydEZKHOFpFHESLah40jW35DWd3pd7q188bsi0oUY4Kls7PDXUamvTWuTKTZXCtzwSvCw==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "jest-diff": "22.1.0",
-        "jest-matcher-utils": "22.1.0",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "pretty-format": "22.1.0"
+        "chalk": "^2.0.1",
+        "jest-diff": "^22.1.0",
+        "jest-matcher-utils": "^22.1.0",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^22.1.0"
       }
     },
     "jest-specific-snapshot": {
@@ -11241,7 +11228,7 @@
       "integrity": "sha512-BzwtkVrYwKSE/ZLwGgG2uoyBe3U9Wl8hdRSzi/BM66m3Lnue9FN+Y+GY5LMapdcxg750AkFIf6O0FK9RCxqdOg==",
       "dev": true,
       "requires": {
-        "jest-snapshot": "22.1.2"
+        "jest-snapshot": ">=20.0.3"
       }
     },
     "jest-worker": {
@@ -11250,7 +11237,7 @@
       "integrity": "sha512-fPdCTnogFQiR0CP6whEsIly2RfcHxvalqyLjhui6qa1SnOmHiX7L8k4Umo8CBIp5ndWY0+ej1o7OTE5MlzPabg==",
       "dev": true,
       "requires": {
-        "merge-stream": "1.0.1"
+        "merge-stream": "^1.0.1"
       }
     },
     "jquery": {
@@ -11275,8 +11262,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -11328,7 +11315,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stable-stringify-without-jsonify": {
@@ -11361,7 +11348,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -11400,7 +11387,7 @@
       "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
       "dev": true,
       "requires": {
-        "array-includes": "3.0.3"
+        "array-includes": "^3.0.3"
       }
     },
     "keycode": {
@@ -11430,7 +11417,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "latest-version": {
@@ -11439,7 +11426,7 @@
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
-        "package-json": "4.0.1"
+        "package-json": "^4.0.0"
       }
     },
     "lazy-cache": {
@@ -11454,7 +11441,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "lcov-parse": {
@@ -11481,8 +11468,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -11491,11 +11478,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "loader-runner": {
@@ -11510,9 +11497,9 @@
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "dev": true,
       "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
       }
     },
     "locate-path": {
@@ -11521,8 +11508,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -11572,8 +11559,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -11592,6 +11578,11 @@
       "resolved": "https://registry.npmjs.org/lodash.endswith/-/lodash.endswith-4.2.1.tgz",
       "integrity": "sha1-/tWawXOO0+I27dcGTsRWRIs3vAk=",
       "dev": true
+    },
+    "lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -11620,14 +11611,12 @@
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "dev": true
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-      "dev": true
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.kebabcase": {
       "version": "4.1.1",
@@ -11641,9 +11630,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.memoize": {
@@ -11661,8 +11650,7 @@
     "lodash.mergewith": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
-      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
-      "dev": true
+      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU="
     },
     "lodash.omit": {
       "version": "4.5.0",
@@ -11736,8 +11724,8 @@
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.templatesettings": "4.1.0"
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
       }
     },
     "lodash.templatesettings": {
@@ -11746,7 +11734,7 @@
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0"
+        "lodash._reinterpolate": "~3.0.0"
       }
     },
     "lodash.toarray": {
@@ -11785,7 +11773,7 @@
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0"
+        "chalk": "^2.0.1"
       }
     },
     "log-update": {
@@ -11794,8 +11782,8 @@
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "cli-cursor": "1.0.2"
+        "ansi-escapes": "^1.0.0",
+        "cli-cursor": "^1.0.2"
       }
     },
     "loglevel": {
@@ -11821,7 +11809,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "loud-rejection": {
@@ -11830,8 +11818,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lower-case": {
@@ -11852,8 +11840,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "macaddress": {
@@ -11867,10 +11855,10 @@
       "resolved": "https://registry.npmjs.org/mailto-link/-/mailto-link-1.0.0.tgz",
       "integrity": "sha1-9Sqp/MEXPLOAkV3xZNsxSRiRUl0=",
       "requires": {
-        "assert-ok": "1.0.0",
-        "cast-array": "1.0.1",
-        "object-filter": "1.0.2",
-        "query-string": "2.4.2"
+        "assert-ok": "~1.0.0",
+        "cast-array": "~1.0.0",
+        "object-filter": "~1.0.2",
+        "query-string": "~2.4.1"
       },
       "dependencies": {
         "query-string": {
@@ -11878,7 +11866,7 @@
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-2.4.2.tgz",
           "integrity": "sha1-fbBmZCCAS6qSrp8miWKFWnYUPfs=",
           "requires": {
-            "strict-uri-encode": "1.1.0"
+            "strict-uri-encode": "^1.0.0"
           }
         }
       }
@@ -11889,7 +11877,7 @@
       "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -11912,7 +11900,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.4"
+        "tmpl": "1.0.x"
       }
     },
     "map-cache": {
@@ -11933,7 +11921,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "markdown-loader": {
@@ -11942,8 +11930,8 @@
       "integrity": "sha512-v/ej7DflZbb6t//3Yu9vg0T+sun+Q9EoqggifeyABKfvFROqPwwwpv+hd1NKT2QxTRg6VCFk10IIJcMI13yCoQ==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "marked": "0.3.12"
+        "loader-utils": "^1.1.0",
+        "marked": "^0.3.9"
       }
     },
     "markdown-loader-jest": {
@@ -11952,8 +11940,8 @@
       "integrity": "sha512-osdgJgjxP/9C+vcIkTxU5p91C3+IkD2yY+SvG4GcFOOfAK0mixqepDSkNdMIsCf10KK9DfHjPUslnzKLH1tktg==",
       "dev": true,
       "requires": {
-        "html-loader": "0.5.5",
-        "markdown-loader": "2.0.2"
+        "html-loader": "^0.5.1",
+        "markdown-loader": "^2.0.1"
       }
     },
     "marked": {
@@ -11968,11 +11956,11 @@
       "integrity": "sha1-Xq9Wi+ZvaGVBr6UqVYKAMQox3i0=",
       "dev": true,
       "requires": {
-        "cardinal": "1.0.0",
-        "chalk": "1.1.3",
-        "cli-table": "0.3.1",
-        "lodash.assign": "4.2.0",
-        "node-emoji": "1.8.1"
+        "cardinal": "^1.0.0",
+        "chalk": "^1.1.3",
+        "cli-table": "^0.3.1",
+        "lodash.assign": "^4.2.0",
+        "node-emoji": "^1.4.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -11987,11 +11975,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -12008,9 +11996,17 @@
       "integrity": "sha512-k9r4HIpKlreInh6IVDGxhRs0veCr6WfLwP6lr2HXG8so+N6m6rfFKSpik9ZbvnTfKvdPhehwBWT5W+Fli29Ebg==",
       "dev": true,
       "requires": {
-        "babel-standalone": "6.26.0",
-        "he": "1.1.1",
-        "marked": "0.3.12"
+        "babel-standalone": "^6.26.0",
+        "he": "^1.1.1",
+        "marked": "^0.3.9"
+      }
+    },
+    "matchmediaquery": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.2.1.tgz",
+      "integrity": "sha1-IjxwBXk94D5HzpKxMoWnLEStos8=",
+      "requires": {
+        "css-mediaquery": "^0.1.2"
       }
     },
     "math-expression-evaluator": {
@@ -12025,8 +12021,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       },
       "dependencies": {
         "hash-base": {
@@ -12035,8 +12031,8 @@
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         }
       }
@@ -12062,7 +12058,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "memory-fs": {
@@ -12071,8 +12067,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.6",
-        "readable-stream": "2.3.3"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       }
     },
     "meow": {
@@ -12081,16 +12077,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -12119,7 +12115,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.1"
       }
     },
     "merge2": {
@@ -12140,19 +12136,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "micromist": {
@@ -12161,7 +12157,7 @@
       "integrity": "sha1-QfhJSaBMMM3GCjlNDLBqqgi4Y2Q=",
       "dev": true,
       "requires": {
-        "lodash.camelcase": "4.3.0"
+        "lodash.camelcase": "^4.3.0"
       }
     },
     "miller-rabin": {
@@ -12170,8 +12166,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -12192,7 +12188,7 @@
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "dev": true,
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.30.0"
       }
     },
     "mimic-fn": {
@@ -12213,7 +12209,7 @@
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "dev": true,
       "requires": {
-        "dom-walk": "0.1.1"
+        "dom-walk": "^0.1.0"
       }
     },
     "minimalistic-assert": {
@@ -12234,7 +12230,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -12249,8 +12245,8 @@
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "is-plain-obj": "1.1.0"
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
       }
     },
     "mississippi": {
@@ -12259,16 +12255,16 @@
       "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
-        "duplexify": "3.5.1",
-        "end-of-stream": "1.4.0",
-        "flush-write-stream": "1.0.2",
-        "from2": "2.3.0",
-        "parallel-transform": "1.1.0",
-        "pump": "1.0.3",
-        "pumpify": "1.3.5",
-        "stream-each": "1.2.2",
-        "through2": "2.0.3"
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^1.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
       }
     },
     "mixin-deep": {
@@ -12277,8 +12273,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -12287,7 +12283,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -12298,8 +12294,8 @@
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
       "dev": true,
       "requires": {
-        "for-in": "0.1.8",
-        "is-extendable": "0.1.1"
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
       },
       "dependencies": {
         "for-in": {
@@ -12331,12 +12327,12 @@
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "copy-concurrently": "1.0.5",
-        "fs-write-stream-atomic": "1.0.10",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
       }
     },
     "ms": {
@@ -12351,8 +12347,8 @@
       "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "dev": true,
       "requires": {
-        "dns-packet": "1.3.1",
-        "thunky": "1.0.2"
+        "dns-packet": "^1.3.1",
+        "thunky": "^1.0.2"
       }
     },
     "multicast-dns-service-types": {
@@ -12379,18 +12375,18 @@
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-odd": "2.0.0",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.1",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-odd": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -12431,7 +12427,7 @@
       "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
       "dev": true,
       "requires": {
-        "xml-char-classes": "1.0.0"
+        "xml-char-classes": "^1.0.0"
       }
     },
     "nearley": {
@@ -12440,9 +12436,9 @@
       "integrity": "sha512-clqqhEuP0ZCJQ85Xv2I/4o2Gs/fvSR6fCg5ZHVE2c8evWyNk2G++ih4JOO3lMb/k/09x6ihQ2nzKUlB/APCWjg==",
       "dev": true,
       "requires": {
-        "nomnom": "1.6.2",
-        "railroad-diagrams": "1.0.0",
-        "randexp": "0.4.6"
+        "nomnom": "~1.6.2",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "^0.4.2"
       }
     },
     "negotiator": {
@@ -12475,7 +12471,7 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.1"
       }
     },
     "node-dir": {
@@ -12484,7 +12480,7 @@
       "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
       "dev": true,
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.2"
       }
     },
     "node-emoji": {
@@ -12493,7 +12489,7 @@
       "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
       "dev": true,
       "requires": {
-        "lodash.toarray": "4.4.0"
+        "lodash.toarray": "^4.4.0"
       }
     },
     "node-fetch": {
@@ -12501,8 +12497,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-forge": {
@@ -12517,19 +12513,19 @@
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
       "requires": {
-        "fstream": "1.0.11",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.2",
-        "osenv": "0.1.4",
-        "request": "2.83.0",
-        "rimraf": "2.6.2",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "which": "1.3.0"
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "2",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
       },
       "dependencies": {
         "semver": {
@@ -12552,28 +12548,28 @@
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "dev": true,
       "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.1.7",
-        "events": "1.1.1",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
         "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.3",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.7.2",
-        "string_decoder": "1.0.3",
-        "timers-browserify": "2.0.4",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -12597,10 +12593,10 @@
       "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
       "dev": true,
       "requires": {
-        "growly": "1.3.0",
-        "semver": "5.4.1",
-        "shellwords": "0.1.1",
-        "which": "1.3.0"
+        "growly": "^1.3.0",
+        "semver": "^5.3.0",
+        "shellwords": "^0.1.0",
+        "which": "^1.2.12"
       }
     },
     "node-sass": {
@@ -12609,25 +12605,25 @@
       "integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
       "dev": true,
       "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
-        "get-stdin": "4.0.1",
-        "glob": "7.1.2",
-        "in-publish": "2.0.0",
-        "lodash.assign": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.mergewith": "4.6.0",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nan": "2.8.0",
-        "node-gyp": "3.6.2",
-        "npmlog": "4.1.2",
-        "request": "2.79.0",
-        "sass-graph": "2.2.4",
-        "stdout-stream": "1.4.0",
-        "true-case-path": "1.0.2"
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.clonedeep": "^4.3.2",
+        "lodash.mergewith": "^4.6.0",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.3.2",
+        "node-gyp": "^3.3.1",
+        "npmlog": "^4.0.0",
+        "request": "~2.79.0",
+        "sass-graph": "^2.2.4",
+        "stdout-stream": "^1.4.0",
+        "true-case-path": "^1.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12654,7 +12650,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "caseless": {
@@ -12669,11 +12665,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "cross-spawn": {
@@ -12682,8 +12678,8 @@
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.1",
-            "which": "1.3.0"
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
           }
         },
         "cryptiles": {
@@ -12692,7 +12688,7 @@
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "form-data": {
@@ -12701,9 +12697,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "get-stdin": {
@@ -12718,10 +12714,10 @@
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.12.2",
-            "is-my-json-valid": "2.17.1",
-            "pinkie-promise": "2.0.1"
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "hawk": {
@@ -12730,10 +12726,10 @@
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -12748,9 +12744,9 @@
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "qs": {
@@ -12765,26 +12761,26 @@
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.1.0"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.3.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "~0.4.1",
+            "uuid": "^3.0.0"
           }
         },
         "sntp": {
@@ -12793,7 +12789,7 @@
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "supports-color": {
@@ -12816,8 +12812,8 @@
       "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
       "dev": true,
       "requires": {
-        "colors": "0.5.1",
-        "underscore": "1.4.4"
+        "colors": "0.5.x",
+        "underscore": "~1.4.4"
       },
       "dependencies": {
         "colors": {
@@ -12834,7 +12830,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -12843,10 +12839,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -12855,7 +12851,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-range": {
@@ -12870,10 +12866,10 @@
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "prepend-http": "1.0.4",
-        "query-string": "4.3.4",
-        "sort-keys": "1.1.2"
+        "object-assign": "^4.0.1",
+        "prepend-http": "^1.0.0",
+        "query-string": "^4.1.0",
+        "sort-keys": "^1.0.0"
       }
     },
     "npm-run-path": {
@@ -12882,7 +12878,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npmlog": {
@@ -12891,10 +12887,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nth-check": {
@@ -12903,7 +12899,7 @@
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "num2fraction": {
@@ -12915,8 +12911,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwmatcher": {
       "version": "1.4.3",
@@ -12941,9 +12936,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -12952,7 +12947,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -12961,7 +12956,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-data-descriptor": {
@@ -12970,7 +12965,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-descriptor": {
@@ -12979,9 +12974,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -13015,7 +13010,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.assign": {
@@ -13024,9 +13019,9 @@
       "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.1",
-        "object-keys": "1.0.11"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.0",
+        "object-keys": "^1.0.10"
       }
     },
     "object.entries": {
@@ -13034,10 +13029,10 @@
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
       "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.6.1",
+        "function-bind": "^1.1.0",
+        "has": "^1.0.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -13046,8 +13041,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.omit": {
@@ -13056,8 +13051,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.pick": {
@@ -13066,7 +13061,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "object.values": {
@@ -13075,10 +13070,10 @@
       "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.6.1",
+        "function-bind": "^1.1.0",
+        "has": "^1.0.1"
       }
     },
     "obuf": {
@@ -13108,7 +13103,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -13123,7 +13118,7 @@
       "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
       "dev": true,
       "requires": {
-        "is-wsl": "1.1.0"
+        "is-wsl": "^1.1.0"
       }
     },
     "optimist": {
@@ -13132,8 +13127,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.2"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -13142,12 +13137,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -13164,7 +13159,7 @@
       "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
       "dev": true,
       "requires": {
-        "url-parse": "1.0.5"
+        "url-parse": "1.0.x"
       },
       "dependencies": {
         "url-parse": {
@@ -13173,8 +13168,8 @@
           "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
           "dev": true,
           "requires": {
-            "querystringify": "0.0.4",
-            "requires-port": "1.0.0"
+            "querystringify": "0.0.x",
+            "requires-port": "1.0.x"
           }
         }
       }
@@ -13197,9 +13192,9 @@
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       },
       "dependencies": {
         "execa": {
@@ -13208,13 +13203,13 @@
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         }
       }
@@ -13237,8 +13232,8 @@
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "output-file-sync": {
@@ -13247,9 +13242,9 @@
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
+        "graceful-fs": "^4.1.4",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.0"
       }
     },
     "p-cancelable": {
@@ -13264,7 +13259,7 @@
       "integrity": "sha1-Yp0xcVAgnI/VCLoTdxPvS7kg6ds=",
       "dev": true,
       "requires": {
-        "p-map": "1.2.0"
+        "p-map": "^1.0.0"
       }
     },
     "p-finally": {
@@ -13291,7 +13286,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-map": {
@@ -13312,7 +13307,7 @@
       "integrity": "sha1-OSczKkt9cCabU1UVEX/FR9oaaWg=",
       "dev": true,
       "requires": {
-        "retry": "0.10.1"
+        "retry": "^0.10.0"
       }
     },
     "p-timeout": {
@@ -13321,7 +13316,7 @@
       "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
       "dev": true,
       "requires": {
-        "p-finally": "1.0.0"
+        "p-finally": "^1.0.0"
       }
     },
     "package-json": {
@@ -13330,10 +13325,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.3.1",
-        "registry-url": "3.1.0",
-        "semver": "5.4.1"
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
       },
       "dependencies": {
         "got": {
@@ -13342,17 +13337,17 @@
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
-            "create-error-class": "3.0.2",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-redirect": "1.0.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.1",
-            "safe-buffer": "5.1.1",
-            "timed-out": "4.0.1",
-            "unzip-response": "2.0.1",
-            "url-parse-lax": "1.0.0"
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
           }
         },
         "url-parse-lax": {
@@ -13361,7 +13356,7 @@
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "dev": true,
           "requires": {
-            "prepend-http": "1.0.4"
+            "prepend-http": "^1.0.1"
           }
         }
       }
@@ -13378,9 +13373,9 @@
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "dev": true,
       "requires": {
-        "cyclist": "0.2.2",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
       }
     },
     "param-case": {
@@ -13389,7 +13384,7 @@
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2"
+        "no-case": "^2.2.0"
       }
     },
     "parse-asn1": {
@@ -13398,11 +13393,11 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.9.2",
-        "browserify-aes": "1.1.1",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.14"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-domain": {
@@ -13423,10 +13418,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-json": {
@@ -13435,7 +13430,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-repo": {
@@ -13450,8 +13445,8 @@
       "integrity": "sha1-V8FUKKuKiSsfQ4aWRccR0OFEtVQ=",
       "dev": true,
       "requires": {
-        "is-ssh": "1.3.0",
-        "protocols": "1.4.6"
+        "is-ssh": "^1.3.0",
+        "protocols": "^1.4.0"
       }
     },
     "parse5": {
@@ -13460,7 +13455,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.2"
+        "@types/node": "*"
       }
     },
     "parseurl": {
@@ -13493,7 +13488,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -13532,9 +13527,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pbkdf2": {
@@ -13543,11 +13538,11 @@
       "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.9"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "performance-now": {
@@ -13574,7 +13569,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -13583,7 +13578,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "pluralize": {
@@ -13604,8 +13599,8 @@
       "integrity": "sha1-FbDtvTNK3hRYEzQ/Xs+cEKcc9QA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "immutable": "3.8.2"
+        "babel-runtime": "^6.11.6",
+        "immutable": "^3.8.1"
       }
     },
     "popper.js": {
@@ -13619,9 +13614,9 @@
       "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1"
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
       },
       "dependencies": {
         "async": {
@@ -13642,18 +13637,16 @@
       "version": "6.0.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
       "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
-      "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "source-map": "0.6.1",
-        "supports-color": "4.5.0"
+        "chalk": "^2.3.0",
+        "source-map": "^0.6.1",
+        "supports-color": "^4.4.0"
       },
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -13663,9 +13656,9 @@
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "postcss-message-helpers": "2.0.0",
-        "reduce-css-calc": "1.3.0"
+        "postcss": "^5.0.2",
+        "postcss-message-helpers": "^2.0.0",
+        "reduce-css-calc": "^1.2.6"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13680,11 +13673,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13707,10 +13700,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13719,7 +13712,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13730,9 +13723,9 @@
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
       "dev": true,
       "requires": {
-        "colormin": "1.1.2",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "colormin": "^1.0.5",
+        "postcss": "^5.0.13",
+        "postcss-value-parser": "^3.2.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13747,11 +13740,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13774,10 +13767,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13786,7 +13779,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13797,8 +13790,8 @@
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "^5.0.11",
+        "postcss-value-parser": "^3.1.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13813,11 +13806,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13840,10 +13833,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13852,7 +13845,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13863,7 +13856,7 @@
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.14"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13878,11 +13871,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13905,10 +13898,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13917,7 +13910,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13928,7 +13921,7 @@
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13943,11 +13936,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13970,10 +13963,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13982,7 +13975,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13993,7 +13986,7 @@
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.14"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14008,11 +14001,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14035,10 +14028,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -14047,7 +14040,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14058,7 +14051,7 @@
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.16"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14073,11 +14066,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14100,10 +14093,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -14112,7 +14105,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14123,8 +14116,8 @@
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "uniqs": "2.0.0"
+        "postcss": "^5.0.14",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14139,11 +14132,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14166,10 +14159,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -14178,7 +14171,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14189,8 +14182,8 @@
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "uniqid": "4.1.1"
+        "postcss": "^5.0.4",
+        "uniqid": "^4.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14205,11 +14198,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14232,10 +14225,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -14244,7 +14237,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14255,7 +14248,7 @@
       "integrity": "sha512-15JauG6a2hu2XZHdB9BaOwCLrI9oyK2UB8kt1ToTGdP1Pd3BQ/TJI9tNiTALntll25/66xMLUIyUPA9w/3BLtg==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14"
+        "postcss": "^6.0.1"
       }
     },
     "postcss-load-config": {
@@ -14264,10 +14257,10 @@
       "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
       "dev": true,
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1",
-        "postcss-load-options": "1.2.0",
-        "postcss-load-plugins": "2.3.0"
+        "cosmiconfig": "^2.1.0",
+        "object-assign": "^4.1.0",
+        "postcss-load-options": "^1.2.0",
+        "postcss-load-plugins": "^2.3.0"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -14276,13 +14269,13 @@
           "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
           "dev": true,
           "requires": {
-            "is-directory": "0.3.1",
-            "js-yaml": "3.10.0",
-            "minimist": "1.2.0",
-            "object-assign": "4.1.1",
-            "os-homedir": "1.0.2",
-            "parse-json": "2.2.0",
-            "require-from-string": "1.2.1"
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.4.3",
+            "minimist": "^1.2.0",
+            "object-assign": "^4.1.0",
+            "os-homedir": "^1.0.1",
+            "parse-json": "^2.2.0",
+            "require-from-string": "^1.1.0"
           }
         },
         "minimist": {
@@ -14305,8 +14298,8 @@
       "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
       "dev": true,
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
+        "cosmiconfig": "^2.1.0",
+        "object-assign": "^4.1.0"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -14315,13 +14308,13 @@
           "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
           "dev": true,
           "requires": {
-            "is-directory": "0.3.1",
-            "js-yaml": "3.10.0",
-            "minimist": "1.2.0",
-            "object-assign": "4.1.1",
-            "os-homedir": "1.0.2",
-            "parse-json": "2.2.0",
-            "require-from-string": "1.2.1"
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.4.3",
+            "minimist": "^1.2.0",
+            "object-assign": "^4.1.0",
+            "os-homedir": "^1.0.1",
+            "parse-json": "^2.2.0",
+            "require-from-string": "^1.1.0"
           }
         },
         "minimist": {
@@ -14344,8 +14337,8 @@
       "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
       "dev": true,
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
+        "cosmiconfig": "^2.1.1",
+        "object-assign": "^4.1.0"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -14354,13 +14347,13 @@
           "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
           "dev": true,
           "requires": {
-            "is-directory": "0.3.1",
-            "js-yaml": "3.10.0",
-            "minimist": "1.2.0",
-            "object-assign": "4.1.1",
-            "os-homedir": "1.0.2",
-            "parse-json": "2.2.0",
-            "require-from-string": "1.2.1"
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.4.3",
+            "minimist": "^1.2.0",
+            "object-assign": "^4.1.0",
+            "os-homedir": "^1.0.1",
+            "parse-json": "^2.2.0",
+            "require-from-string": "^1.1.0"
           }
         },
         "minimist": {
@@ -14383,10 +14376,10 @@
       "integrity": "sha512-xQaDcEgJ/2JqFY18zpFkik8vyYs7oS5ZRbrjvDqkP97k2wYWfPT4+qA0m4o3pTSCsz0u26PNqs8ZO9FRUWAqrA==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "postcss": "6.0.14",
-        "postcss-load-config": "1.2.0",
-        "schema-utils": "0.3.0"
+        "loader-utils": "^1.1.0",
+        "postcss": "^6.0.0",
+        "postcss-load-config": "^1.2.0",
+        "schema-utils": "^0.3.0"
       }
     },
     "postcss-merge-idents": {
@@ -14395,9 +14388,9 @@
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "dev": true,
       "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "has": "^1.0.1",
+        "postcss": "^5.0.10",
+        "postcss-value-parser": "^3.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14412,11 +14405,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14439,10 +14432,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -14451,7 +14444,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14462,7 +14455,7 @@
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14477,11 +14470,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14504,10 +14497,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -14516,7 +14509,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14527,11 +14520,11 @@
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
       "dev": true,
       "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-api": "1.6.1",
-        "postcss": "5.2.18",
-        "postcss-selector-parser": "2.2.3",
-        "vendors": "1.0.1"
+        "browserslist": "^1.5.2",
+        "caniuse-api": "^1.5.2",
+        "postcss": "^5.0.4",
+        "postcss-selector-parser": "^2.2.2",
+        "vendors": "^1.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14546,8 +14539,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000784",
-            "electron-to-chromium": "1.3.29"
+            "caniuse-db": "^1.0.30000639",
+            "electron-to-chromium": "^1.2.7"
           }
         },
         "chalk": {
@@ -14556,11 +14549,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14583,10 +14576,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -14595,7 +14588,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14612,9 +14605,9 @@
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14629,11 +14622,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14656,10 +14649,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -14668,7 +14661,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14679,8 +14672,8 @@
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "^5.0.12",
+        "postcss-value-parser": "^3.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14695,11 +14688,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14722,10 +14715,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -14734,7 +14727,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14745,10 +14738,10 @@
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
       "dev": true,
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0",
-        "uniqs": "2.0.0"
+        "alphanum-sort": "^1.0.1",
+        "postcss": "^5.0.2",
+        "postcss-value-parser": "^3.0.2",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14763,11 +14756,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14790,10 +14783,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -14802,7 +14795,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14813,10 +14806,10 @@
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
       "dev": true,
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "has": "1.0.1",
-        "postcss": "5.2.18",
-        "postcss-selector-parser": "2.2.3"
+        "alphanum-sort": "^1.0.2",
+        "has": "^1.0.1",
+        "postcss": "^5.0.14",
+        "postcss-selector-parser": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14831,11 +14824,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14858,10 +14851,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -14870,7 +14863,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14881,7 +14874,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14"
+        "postcss": "^6.0.1"
       }
     },
     "postcss-modules-local-by-default": {
@@ -14890,8 +14883,8 @@
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "dev": true,
       "requires": {
-        "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.14"
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
       }
     },
     "postcss-modules-scope": {
@@ -14900,8 +14893,8 @@
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "dev": true,
       "requires": {
-        "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.14"
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
       }
     },
     "postcss-modules-values": {
@@ -14910,8 +14903,8 @@
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "dev": true,
       "requires": {
-        "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.14"
+        "icss-replace-symbols": "^1.1.0",
+        "postcss": "^6.0.1"
       }
     },
     "postcss-normalize-charset": {
@@ -14920,7 +14913,7 @@
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.5"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14935,11 +14928,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14962,10 +14955,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -14974,7 +14967,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14985,10 +14978,10 @@
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
       "dev": true,
       "requires": {
-        "is-absolute-url": "2.1.0",
-        "normalize-url": "1.9.1",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "is-absolute-url": "^2.0.0",
+        "normalize-url": "^1.4.0",
+        "postcss": "^5.0.14",
+        "postcss-value-parser": "^3.2.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15003,11 +14996,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -15030,10 +15023,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -15042,7 +15035,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -15053,8 +15046,8 @@
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15069,11 +15062,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -15096,10 +15089,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -15108,7 +15101,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -15119,8 +15112,8 @@
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15135,11 +15128,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -15162,10 +15155,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -15174,7 +15167,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -15185,7 +15178,7 @@
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15200,11 +15193,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -15227,10 +15220,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -15239,7 +15232,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -15250,9 +15243,9 @@
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "has": "^1.0.1",
+        "postcss": "^5.0.8",
+        "postcss-value-parser": "^3.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15267,11 +15260,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -15294,10 +15287,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -15306,7 +15299,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -15317,7 +15310,7 @@
       "integrity": "sha1-/0XPM1S4ee6JpOtoaA9GrJuxT5Q=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14"
+        "postcss": "^6.0.3"
       }
     },
     "postcss-selector-parser": {
@@ -15326,9 +15319,9 @@
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
       "dev": true,
       "requires": {
-        "flatten": "1.0.2",
-        "indexes-of": "1.0.1",
-        "uniq": "1.0.1"
+        "flatten": "^1.0.2",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
       }
     },
     "postcss-svgo": {
@@ -15337,10 +15330,10 @@
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
       "dev": true,
       "requires": {
-        "is-svg": "2.1.0",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0",
-        "svgo": "0.7.2"
+        "is-svg": "^2.0.0",
+        "postcss": "^5.0.14",
+        "postcss-value-parser": "^3.2.3",
+        "svgo": "^0.7.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15355,11 +15348,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -15382,10 +15375,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -15394,7 +15387,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -15405,9 +15398,9 @@
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
       "dev": true,
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "5.2.18",
-        "uniqs": "2.0.0"
+        "alphanum-sort": "^1.0.1",
+        "postcss": "^5.0.4",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15422,11 +15415,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -15449,10 +15442,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -15461,7 +15454,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -15478,9 +15471,9 @@
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "dev": true,
       "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.18",
-        "uniqs": "2.0.0"
+        "has": "^1.0.1",
+        "postcss": "^5.0.4",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15495,11 +15488,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -15522,10 +15515,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.0",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -15534,7 +15527,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -15563,8 +15556,8 @@
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "dev": true,
       "requires": {
-        "renderkid": "2.0.1",
-        "utila": "0.4.0"
+        "renderkid": "^2.0.1",
+        "utila": "~0.4"
       }
     },
     "pretty-format": {
@@ -15573,8 +15566,8 @@
       "integrity": "sha512-0HHR5hCmjDGU4sez3w5zRDAAwn7V0vT4SgPiYPZ1XDm5sT3Icb+Bh+fsOP3+Y3UwPjMr7TbRj+L7eQyMkPAxAw==",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0",
-        "ansi-styles": "3.2.0"
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -15591,8 +15584,8 @@
       "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
       "dev": true,
       "requires": {
-        "colors": "1.1.2",
-        "minimist": "1.2.0"
+        "colors": "^1.1.2",
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -15609,7 +15602,7 @@
       "integrity": "sha512-sa2s4m60bXs+kU3jcuUwx3ZCrUH7o0kuqnOOINbODqlRrDB7KY8SRx+xR/D7nHLlgfDdG7zXbRO8wJ+su5Ls0A==",
       "dev": true,
       "requires": {
-        "clipboard": "2.0.1"
+        "clipboard": "^2.0.0"
       }
     },
     "private": {
@@ -15627,8 +15620,7 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
       "version": "2.0.0",
@@ -15641,7 +15633,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "promise-inflight": {
@@ -15656,9 +15648,9 @@
       "integrity": "sha512-7p/K2f6dI+dM8yjRQEGrTQs5hTQixUAdOGpMEA3+pVxpX5oHKRSKAXyLw9Q9HUWDTdwtoo39dSHGQtN90HcEwQ==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.9.0",
+        "function-bind": "^1.1.1"
       }
     },
     "prop-types": {
@@ -15666,9 +15658,9 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
       "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "prop-types-exact": {
@@ -15676,8 +15668,8 @@
       "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.1.2.tgz",
       "integrity": "sha512-3x4BWv7w2luSStiHwSzrhK9U1sm+vHwSyg9le2RfY41pZyJdiPKDOKh6TCQywwl++SCr7MMKu7POp4LU/L/eIA==",
       "requires": {
-        "has": "1.0.1",
-        "object.assign": "4.1.0"
+        "has": "^1.0.1",
+        "object.assign": "^4.1.0"
       },
       "dependencies": {
         "object.assign": {
@@ -15685,10 +15677,10 @@
           "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
           "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
           "requires": {
-            "define-properties": "1.1.2",
-            "function-bind": "1.1.1",
-            "has-symbols": "1.0.0",
-            "object-keys": "1.0.11"
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "object-keys": "^1.0.11"
           }
         }
       }
@@ -15705,7 +15697,7 @@
       "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.5.2"
       }
     },
@@ -15727,11 +15719,11 @@
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "parse-asn1": "5.1.0",
-        "randombytes": "2.0.5"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "pump": {
@@ -15740,8 +15732,8 @@
       "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.0",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -15750,9 +15742,9 @@
       "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
       "dev": true,
       "requires": {
-        "duplexify": "3.5.1",
-        "inherits": "2.0.3",
-        "pump": "1.0.3"
+        "duplexify": "^3.1.2",
+        "inherits": "^2.0.1",
+        "pump": "^1.0.0"
       }
     },
     "punycode": {
@@ -15779,8 +15771,8 @@
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "querystring": {
@@ -15813,10 +15805,10 @@
       "integrity": "sha512-IABYntqCwYelUUIwA52maSCgJbqtJjHKIoD21wgpw3dGhIUbJ5chDShDGdaFiEzdF03hN9jfQqlmn0bF4YhfrQ==",
       "dev": true,
       "requires": {
-        "array-find": "1.0.0",
-        "exenv": "1.2.2",
-        "inline-style-prefixer": "2.0.5",
-        "prop-types": "15.6.0"
+        "array-find": "^1.0.0",
+        "exenv": "^1.2.1",
+        "inline-style-prefixer": "^2.0.5",
+        "prop-types": "^15.5.8"
       },
       "dependencies": {
         "inline-style-prefixer": {
@@ -15825,8 +15817,8 @@
           "integrity": "sha1-wVPH6I/YT+9cYC6VqBaLJ3BnH+c=",
           "dev": true,
           "requires": {
-            "bowser": "1.9.1",
-            "hyphenate-style-name": "1.0.2"
+            "bowser": "^1.0.0",
+            "hyphenate-style-name": "^1.0.1"
           }
         }
       }
@@ -15837,7 +15829,7 @@
       "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
       "dev": true,
       "requires": {
-        "performance-now": "2.1.0"
+        "performance-now": "^2.1.0"
       }
     },
     "railroad-diagrams": {
@@ -15853,7 +15845,7 @@
       "dev": true,
       "requires": {
         "discontinuous-range": "1.0.0",
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "randomatic": {
@@ -15862,8 +15854,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -15872,7 +15864,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -15881,7 +15873,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -15892,7 +15884,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -15903,7 +15895,7 @@
       "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -15912,8 +15904,8 @@
       "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.5",
-        "safe-buffer": "5.1.1"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -15940,10 +15932,10 @@
       "integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
       "dev": true,
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -15959,10 +15951,10 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
       "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "react-addons-create-fragment": {
@@ -15971,9 +15963,9 @@
       "integrity": "sha1-o5TefCx77Na1R1uhuXrEcs58dPg=",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.4",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.0"
       }
     },
     "react-docgen": {
@@ -15982,13 +15974,13 @@
       "integrity": "sha512-+fW1dthCr/cqrAreHTMk2Luzdb3I7xJishC/g4k+vIWiPj4/jM6Ij67WvUjXqio0/TRh7AQtRDYRwqNyinN0LA==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "babel-runtime": "6.26.0",
-        "babylon": "5.8.38",
-        "commander": "2.12.2",
-        "doctrine": "2.0.2",
-        "node-dir": "0.1.17",
-        "recast": "0.12.9"
+        "async": "^2.1.4",
+        "babel-runtime": "^6.9.2",
+        "babylon": "~5.8.3",
+        "commander": "^2.9.0",
+        "doctrine": "^2.0.0",
+        "node-dir": "^0.1.10",
+        "recast": "^0.12.6"
       },
       "dependencies": {
         "babylon": {
@@ -16004,10 +15996,10 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
       "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "react-element-proptypes": {
@@ -16021,10 +16013,10 @@
       "integrity": "sha512-m2QClpw+Z51m6oEpfznVr7CQ9zdUGQ7vvidv05+drt0c3UMkpOWqmB0fQhYJYP/5QNh7ojyMCgu99cxvFaya6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "classnames": "2.2.5",
-        "fuse.js": "3.2.0",
-        "prop-types": "15.6.0"
+        "babel-runtime": "^6.23.0",
+        "classnames": "^2.2.5",
+        "fuse.js": "^3.0.1",
+        "prop-types": "^15.5.9"
       }
     },
     "react-html-attributes": {
@@ -16033,7 +16025,7 @@
       "integrity": "sha1-l7XscQ2miDNZjIvm+JrENiFoQKU=",
       "dev": true,
       "requires": {
-        "html-element-attributes": "1.3.0"
+        "html-element-attributes": "^1.0.0"
       }
     },
     "react-icon-base": {
@@ -16057,8 +16049,8 @@
       "integrity": "sha512-SzkmYvVUJEmUBuFwGgaGOTGucUBnKXH2wWFdzatkCrawm4P85eqgYvqevHE3DGWpfXqE1pJO4d98TYUANQGCrg==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "is-dom": "1.0.9"
+        "babel-runtime": "^6.26.0",
+        "is-dom": "^1.0.9"
       }
     },
     "react-modal": {
@@ -16067,9 +16059,9 @@
       "integrity": "sha512-Pm4QAc+sWYrfRC+WRERV+JGeGZIfodZGdbvWmjPzeSWqP+EW5ATK4N1U/btNHZWFzKL1UOmkmNtozEQlEg7c+A==",
       "dev": true,
       "requires": {
-        "exenv": "1.2.2",
-        "prop-types": "15.6.0",
-        "warning": "3.0.0"
+        "exenv": "^1.2.0",
+        "prop-types": "^15.5.10",
+        "warning": "^3.0.0"
       }
     },
     "react-proptype-conditional-require": {
@@ -16083,10 +16075,31 @@
       "integrity": "sha512-50JwZ3yNyMS8fchN+jjWEJOH3Oze7UmhxeoJLn2j6f3NjpfCRbcmih83XTWmzqtar/ivd5f7tvQhvvhism2fgg==",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-responsive": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-4.1.0.tgz",
+      "integrity": "sha512-ZuDraf0qsJlyiTwzeva+foHx83IP6SIhru9o7BvMwQ4ZHjRIL5WjdgVNNrKSRbmeWO9rEJoMpabei/5lJn8KaA==",
+      "requires": {
+        "hyphenate-style-name": "^1.0.0",
+        "matchmediaquery": "^0.2.1",
+        "prop-types": "^15.6.1"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-router": {
@@ -16095,13 +16108,13 @@
       "integrity": "sha512-DY6pjwRhdARE4TDw7XjxjZsbx9lKmIcyZoZ+SDO7SBJ1KUeWNxT22Kara2AC7u6/c2SYEHlEDLnzBCcNhLE8Vg==",
       "dev": true,
       "requires": {
-        "history": "4.7.2",
-        "hoist-non-react-statics": "2.3.1",
-        "invariant": "2.2.2",
-        "loose-envify": "1.3.1",
-        "path-to-regexp": "1.7.0",
-        "prop-types": "15.6.0",
-        "warning": "3.0.0"
+        "history": "^4.7.2",
+        "hoist-non-react-statics": "^2.3.0",
+        "invariant": "^2.2.2",
+        "loose-envify": "^1.3.1",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.5.4",
+        "warning": "^3.0.0"
       },
       "dependencies": {
         "hoist-non-react-statics": {
@@ -16133,12 +16146,12 @@
       "integrity": "sha512-cHMFC1ZoLDfEaMFoKTjN7fry/oczMgRt5BKfMAkTu5zEuJvUiPp1J8d0eXSVTnBh6pxlbdqDhozunOOLtmKfPA==",
       "dev": true,
       "requires": {
-        "history": "4.7.2",
-        "invariant": "2.2.2",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.6.0",
-        "react-router": "4.2.0",
-        "warning": "3.0.0"
+        "history": "^4.7.2",
+        "invariant": "^2.2.2",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.5.4",
+        "react-router": "^4.2.0",
+        "warning": "^3.0.0"
       }
     },
     "react-split-pane": {
@@ -16147,11 +16160,11 @@
       "integrity": "sha512-2g5GD9fzKWwYLAhpL6uoGdYa8uxQs7Yyt3dE8pj991wmEKrUbpb2qxctp/kRv45W0KeIxicMIUEt1VVpHWV5gg==",
       "dev": true,
       "requires": {
-        "@types/inline-style-prefixer": "3.0.1",
-        "@types/react": "16.0.34",
-        "inline-style-prefixer": "3.0.8",
-        "prop-types": "15.6.0",
-        "react-style-proptype": "3.1.0"
+        "@types/inline-style-prefixer": "^3.0.0",
+        "@types/react": "^16.0.18",
+        "inline-style-prefixer": "^3.0.6",
+        "prop-types": "^15.5.10",
+        "react-style-proptype": "^3.0.0"
       }
     },
     "react-style-proptype": {
@@ -16160,7 +16173,7 @@
       "integrity": "sha512-e4lOMjF4f8Pp/jdO9myNzDvSAx1aG5r0olziD64Bgk40LN8LxidRCgnKeI2RiKrqYD6j2Z8ByXoUbwV+/mwpwg==",
       "dev": true,
       "requires": {
-        "prop-types": "15.6.0"
+        "prop-types": "^15.5.4"
       }
     },
     "react-test-renderer": {
@@ -16169,9 +16182,9 @@
       "integrity": "sha512-Kd4gJFtpNziR9ElOE/C23LeflKLZPRpNQYWP3nQBY43SJ5a+xyEGSeMrm2zxNKXcnCbBS/q1UpD9gqd5Dv+rew==",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "fbjs": "^0.8.16",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "react-transition-group": {
@@ -16180,11 +16193,11 @@
       "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
       "dev": true,
       "requires": {
-        "chain-function": "1.0.0",
-        "dom-helpers": "3.3.1",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.6.0",
-        "warning": "3.0.0"
+        "chain-function": "^1.0.0",
+        "dom-helpers": "^3.2.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.5.6",
+        "warning": "^3.0.0"
       }
     },
     "react-treebeard": {
@@ -16193,12 +16206,12 @@
       "integrity": "sha512-unoy8IJL1NR5jgTtK+CqOCZKZylh/Tlid0oYajW9bLZCbFelxzmCsF8Y2hyS6pvHqM4W501oOm5O/jvg3VZCrg==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "deep-equal": "1.0.1",
-        "prop-types": "15.6.0",
-        "radium": "0.19.6",
-        "shallowequal": "0.2.2",
-        "velocity-react": "1.3.3"
+        "babel-runtime": "^6.23.0",
+        "deep-equal": "^1.0.1",
+        "prop-types": "^15.5.8",
+        "radium": "^0.19.0",
+        "shallowequal": "^0.2.2",
+        "velocity-react": "^1.3.1"
       }
     },
     "read-pkg": {
@@ -16207,9 +16220,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -16218,8 +16231,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -16228,8 +16241,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         }
       }
@@ -16238,15 +16251,14 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -16255,10 +16267,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "readline2": {
@@ -16267,8 +16279,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -16278,7 +16290,7 @@
       "integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
       "dev": true,
       "requires": {
-        "util.promisify": "1.0.0"
+        "util.promisify": "^1.0.0"
       }
     },
     "recast": {
@@ -16288,10 +16300,10 @@
       "dev": true,
       "requires": {
         "ast-types": "0.10.1",
-        "core-js": "2.5.3",
-        "esprima": "4.0.0",
-        "private": "0.1.8",
-        "source-map": "0.6.1"
+        "core-js": "^2.4.1",
+        "esprima": "~4.0.0",
+        "private": "~0.1.5",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -16308,7 +16320,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.5.0"
+        "resolve": "^1.1.6"
       }
     },
     "redent": {
@@ -16317,8 +16329,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "redeyed": {
@@ -16327,7 +16339,7 @@
       "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
       "dev": true,
       "requires": {
-        "esprima": "3.0.0"
+        "esprima": "~3.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -16344,9 +16356,9 @@
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "dev": true,
       "requires": {
-        "balanced-match": "0.4.2",
-        "math-expression-evaluator": "1.2.17",
-        "reduce-function-call": "1.0.2"
+        "balanced-match": "^0.4.2",
+        "math-expression-evaluator": "^1.2.14",
+        "reduce-function-call": "^1.0.1"
       },
       "dependencies": {
         "balanced-match": {
@@ -16363,7 +16375,7 @@
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "dev": true,
       "requires": {
-        "balanced-match": "0.4.2"
+        "balanced-match": "^0.4.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -16380,10 +16392,10 @@
       "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
-        "loose-envify": "1.3.1",
-        "symbol-observable": "1.1.0"
+        "lodash": "^4.2.1",
+        "lodash-es": "^4.2.1",
+        "loose-envify": "^1.1.0",
+        "symbol-observable": "^1.0.3"
       }
     },
     "regenerate": {
@@ -16403,9 +16415,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -16414,7 +16426,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -16423,8 +16435,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexp.prototype.flags": {
@@ -16433,7 +16445,7 @@
       "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2"
+        "define-properties": "^1.1.2"
       }
     },
     "regexpu-core": {
@@ -16442,9 +16454,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "registry-auth-token": {
@@ -16453,8 +16465,8 @@
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "dev": true,
       "requires": {
-        "rc": "1.2.4",
-        "safe-buffer": "5.1.1"
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
@@ -16463,7 +16475,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.4"
+        "rc": "^1.0.1"
       }
     },
     "regjsgen": {
@@ -16478,7 +16490,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -16507,11 +16519,11 @@
       "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
       "dev": true,
       "requires": {
-        "css-select": "1.2.0",
-        "dom-converter": "0.1.4",
-        "htmlparser2": "3.3.0",
-        "strip-ansi": "3.0.1",
-        "utila": "0.3.3"
+        "css-select": "^1.1.0",
+        "dom-converter": "~0.1",
+        "htmlparser2": "~3.3.0",
+        "strip-ansi": "^3.0.0",
+        "utila": "~0.3"
       },
       "dependencies": {
         "domhandler": {
@@ -16520,7 +16532,7 @@
           "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
           "dev": true,
           "requires": {
-            "domelementtype": "1.3.0"
+            "domelementtype": "1"
           }
         },
         "domutils": {
@@ -16529,7 +16541,7 @@
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
           "dev": true,
           "requires": {
-            "domelementtype": "1.3.0"
+            "domelementtype": "1"
           }
         },
         "htmlparser2": {
@@ -16538,10 +16550,10 @@
           "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
           "dev": true,
           "requires": {
-            "domelementtype": "1.3.0",
-            "domhandler": "2.1.0",
-            "domutils": "1.1.6",
-            "readable-stream": "1.0.34"
+            "domelementtype": "1",
+            "domhandler": "2.1",
+            "domutils": "1.1",
+            "readable-stream": "1.0"
           }
         },
         "isarray": {
@@ -16556,10 +16568,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -16594,7 +16606,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -16603,28 +16615,28 @@
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "request-promise-core": {
@@ -16633,7 +16645,7 @@
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.13.1"
       }
     },
     "request-promise-native": {
@@ -16643,8 +16655,8 @@
       "dev": true,
       "requires": {
         "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.3"
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
       }
     },
     "require-directory": {
@@ -16677,8 +16689,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -16707,7 +16719,7 @@
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-cwd": {
@@ -16716,7 +16728,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -16739,7 +16751,7 @@
       "integrity": "sha1-j7As/Vt9sgEY6IYxHxWvlb0V+9k=",
       "dev": true,
       "requires": {
-        "global-dirs": "0.1.1"
+        "global-dirs": "^0.1.0"
       }
     },
     "resolve-pathname": {
@@ -16760,7 +16772,7 @@
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dev": true,
       "requires": {
-        "lowercase-keys": "1.0.1"
+        "lowercase-keys": "^1.0.0"
       }
     },
     "restore-cursor": {
@@ -16769,8 +16781,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "ret": {
@@ -16791,7 +16803,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -16800,7 +16812,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "ripemd160": {
@@ -16809,8 +16821,8 @@
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "dev": true,
       "requires": {
-        "hash-base": "2.0.2",
-        "inherits": "2.0.3"
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "rst-selector-parser": {
@@ -16819,8 +16831,8 @@
       "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
       "dev": true,
       "requires": {
-        "lodash.flattendeep": "4.4.0",
-        "nearley": "2.11.0"
+        "lodash.flattendeep": "^4.4.0",
+        "nearley": "^2.7.10"
       }
     },
     "run-async": {
@@ -16829,7 +16841,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "run-queue": {
@@ -16838,7 +16850,7 @@
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0"
+        "aproba": "^1.1.1"
       }
     },
     "rx": {
@@ -16859,14 +16871,13 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "3.1.2"
+        "rx-lite": "*"
       }
     },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -16874,7 +16885,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "sane": {
@@ -16883,14 +16894,14 @@
       "integrity": "sha512-OSJxhHO0CgPUw3lUm3GhfREAfza45smvEI9ozuFrxKG10GHVo0ryW9FK5VYlLvxj0SV7HVKHW0voYJIRu27GWg==",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "exec-sh": "0.2.1",
-        "fb-watchman": "2.0.0",
-        "fsevents": "1.1.3",
-        "minimatch": "3.0.4",
-        "minimist": "1.2.0",
-        "walker": "1.0.7",
-        "watch": "0.18.0"
+        "anymatch": "^1.3.0",
+        "exec-sh": "^0.2.0",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^1.1.1",
+        "minimatch": "^3.0.2",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5",
+        "watch": "~0.18.0"
       },
       "dependencies": {
         "minimist": {
@@ -16901,16 +16912,33 @@
         }
       }
     },
+    "sanitize-html": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.18.2.tgz",
+      "integrity": "sha512-52ThA+Z7h6BnvpSVbURwChl10XZrps5q7ytjTwWcIe9bmJwnVP6cpEVK2NvDOUhGupoqAvNbUz3cpnJDp4+/pg==",
+      "requires": {
+        "chalk": "^2.3.0",
+        "htmlparser2": "^3.9.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.mergewith": "^4.6.0",
+        "postcss": "^6.0.14",
+        "srcset": "^1.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
     "sass-graph": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "scss-tokenizer": "0.2.3",
-        "yargs": "7.1.0"
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^7.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -16925,9 +16953,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "os-locale": {
@@ -16936,7 +16964,7 @@
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "which-module": {
@@ -16951,19 +16979,19 @@
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
           }
         },
         "yargs-parser": {
@@ -16972,7 +17000,7 @@
           "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "^3.0.0"
           }
         }
       }
@@ -16983,11 +17011,11 @@
       "integrity": "sha512-c3/Zc+iW+qqDip6kXPYLEgsAu2lf4xz0EZDplB7EmSUMda12U1sGJPetH55B/j9eu0bTtKzKlNPWWyYC7wFNyQ==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "clone-deep": "0.3.0",
-        "loader-utils": "1.1.0",
-        "lodash.tail": "4.1.1",
-        "pify": "3.0.0"
+        "async": "^2.1.5",
+        "clone-deep": "^0.3.0",
+        "loader-utils": "^1.0.1",
+        "lodash.tail": "^4.1.1",
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -17010,7 +17038,7 @@
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2"
+        "ajv": "^5.0.0"
       }
     },
     "scss-tokenizer": {
@@ -17019,8 +17047,8 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.4.0",
-        "source-map": "0.4.4"
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
       },
       "dependencies": {
         "source-map": {
@@ -17029,7 +17057,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -17062,31 +17090,31 @@
       "integrity": "sha512-ovMwzP7dTL3r61xKJE6tY0PI+W/oPNyCzFdRkxk8ep4EVByOkRkycZ1A0XOEEEsqQKGAhNubt7fFwQG7G18yzg==",
       "dev": true,
       "requires": {
-        "@semantic-release/commit-analyzer": "5.0.3",
-        "@semantic-release/error": "2.2.0",
-        "@semantic-release/github": "4.2.11",
-        "@semantic-release/npm": "3.2.4",
-        "@semantic-release/release-notes-generator": "6.0.10",
-        "aggregate-error": "1.0.0",
-        "chalk": "2.3.0",
-        "cosmiconfig": "4.0.0",
-        "debug": "3.1.0",
-        "env-ci": "1.6.0",
-        "execa": "0.10.0",
-        "get-stream": "3.0.0",
-        "git-log-parser": "1.2.0",
-        "git-url-parse": "9.0.0",
-        "hook-std": "0.4.0",
-        "hosted-git-info": "2.6.0",
-        "lodash": "4.17.4",
-        "marked": "0.3.12",
-        "marked-terminal": "2.0.0",
-        "p-locate": "2.0.0",
-        "p-reduce": "1.0.0",
-        "read-pkg-up": "3.0.0",
-        "resolve-from": "4.0.0",
-        "semver": "5.4.1",
-        "yargs": "11.0.0"
+        "@semantic-release/commit-analyzer": "^5.0.0",
+        "@semantic-release/error": "^2.2.0",
+        "@semantic-release/github": "^4.1.0",
+        "@semantic-release/npm": "^3.2.0",
+        "@semantic-release/release-notes-generator": "^6.0.0",
+        "aggregate-error": "^1.0.0",
+        "chalk": "^2.3.0",
+        "cosmiconfig": "^4.0.0",
+        "debug": "^3.1.0",
+        "env-ci": "^1.0.0",
+        "execa": "^0.10.0",
+        "get-stream": "^3.0.0",
+        "git-log-parser": "^1.2.0",
+        "git-url-parse": "^9.0.0",
+        "hook-std": "^0.4.0",
+        "hosted-git-info": "^2.6.0",
+        "lodash": "^4.17.4",
+        "marked": "^0.3.9",
+        "marked-terminal": "^2.0.0",
+        "p-locate": "^2.0.0",
+        "p-reduce": "^1.0.0",
+        "read-pkg-up": "^3.0.0",
+        "resolve-from": "^4.0.0",
+        "semver": "^5.4.1",
+        "yargs": "^11.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -17107,9 +17135,9 @@
           "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "cosmiconfig": {
@@ -17118,10 +17146,10 @@
           "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
           "dev": true,
           "requires": {
-            "is-directory": "0.3.1",
-            "js-yaml": "3.10.0",
-            "parse-json": "4.0.0",
-            "require-from-string": "2.0.1"
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.9.0",
+            "parse-json": "^4.0.0",
+            "require-from-string": "^2.0.1"
           }
         },
         "debug": {
@@ -17139,8 +17167,8 @@
           "integrity": "sha512-zks1jS4ocMA/9WUx3C0nGIj/wBQjjIuktQ4KqKTyStMdEtnnFbZ4ZVKCvNeHwKh1COk/8sZaVTyvYj3paHI9Fg==",
           "dev": true,
           "requires": {
-            "git-up": "2.0.10",
-            "parse-domain": "2.0.0"
+            "git-up": "^2.0.0",
+            "parse-domain": "^2.0.0"
           }
         },
         "hosted-git-info": {
@@ -17161,10 +17189,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "parse-json": {
@@ -17173,8 +17201,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.1"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -17183,7 +17211,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -17198,9 +17226,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -17209,8 +17237,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "string-width": {
@@ -17219,8 +17247,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -17229,7 +17257,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "strip-bom": {
@@ -17244,18 +17272,18 @@
           "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
           "dev": true,
           "requires": {
-            "cliui": "4.0.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
           }
         },
         "yargs-parser": {
@@ -17264,7 +17292,7 @@
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -17281,7 +17309,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "5.4.1"
+        "semver": "^5.0.3"
       }
     },
     "send": {
@@ -17291,18 +17319,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.2",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
       }
     },
     "serialize-javascript": {
@@ -17317,10 +17345,10 @@
       "integrity": "sha512-s7F8h2NrslMkG50KxvlGdj+ApSwaLex0vexuJ9iFf3GLTIp1ph/l1qZvRe9T9TJEYZgmq72ZwJ2VYiAEtChknw==",
       "dev": true,
       "requires": {
-        "etag": "1.8.1",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
         "ms": "2.0.0",
-        "parseurl": "1.3.2",
+        "parseurl": "~1.3.2",
         "safe-buffer": "5.1.1"
       }
     },
@@ -17330,13 +17358,13 @@
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "~1.3.4",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "1.0.3",
-        "http-errors": "1.6.2",
-        "mime-types": "2.1.17",
-        "parseurl": "1.3.2"
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
       }
     },
     "serve-static": {
@@ -17345,9 +17373,9 @@
       "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.1"
       }
     },
@@ -17363,7 +17391,7 @@
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
       "dev": true,
       "requires": {
-        "to-object-path": "0.3.0"
+        "to-object-path": "^0.3.0"
       }
     },
     "set-immediate-shim": {
@@ -17378,10 +17406,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -17390,7 +17418,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -17412,8 +17440,8 @@
       "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shallow-clone": {
@@ -17422,10 +17450,10 @@
       "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
       "dev": true,
       "requires": {
-        "is-extendable": "0.1.1",
-        "kind-of": "2.0.1",
-        "lazy-cache": "0.2.7",
-        "mixin-object": "2.0.1"
+        "is-extendable": "^0.1.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "mixin-object": "^2.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -17434,7 +17462,7 @@
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.0.2"
           }
         },
         "lazy-cache": {
@@ -17451,7 +17479,7 @@
       "integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
       "dev": true,
       "requires": {
-        "lodash.keys": "3.1.2"
+        "lodash.keys": "^3.1.2"
       }
     },
     "shebang-command": {
@@ -17460,7 +17488,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -17475,9 +17503,9 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "shellwords": {
@@ -17504,7 +17532,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -17521,14 +17549,14 @@
       "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.1",
-        "use": "2.0.2"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
       },
       "dependencies": {
         "define-property": {
@@ -17537,7 +17565,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -17546,7 +17574,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -17555,7 +17583,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -17564,7 +17592,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -17575,7 +17603,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -17584,7 +17612,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -17595,9 +17623,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -17614,9 +17642,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -17625,7 +17653,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         }
       }
@@ -17636,7 +17664,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       }
     },
     "sntp": {
@@ -17645,7 +17673,7 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "sockjs": {
@@ -17654,8 +17682,8 @@
       "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
       "dev": true,
       "requires": {
-        "faye-websocket": "0.10.0",
-        "uuid": "3.1.0"
+        "faye-websocket": "^0.10.0",
+        "uuid": "^3.0.1"
       }
     },
     "sockjs-client": {
@@ -17664,12 +17692,12 @@
       "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
+        "debug": "^2.6.6",
         "eventsource": "0.1.6",
-        "faye-websocket": "0.11.1",
-        "inherits": "2.0.3",
-        "json3": "3.3.2",
-        "url-parse": "1.2.0"
+        "faye-websocket": "~0.11.0",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.1.8"
       },
       "dependencies": {
         "faye-websocket": {
@@ -17678,7 +17706,7 @@
           "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
           "dev": true,
           "requires": {
-            "websocket-driver": "0.7.0"
+            "websocket-driver": ">=0.5.1"
           }
         }
       }
@@ -17689,7 +17717,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "source-list-map": {
@@ -17710,9 +17738,9 @@
       "integrity": "sha512-MYbFX9DYxmTQFfy2v8FC1XZwpwHKYxg3SK8Wb7VPBKuhDjz8gi9re2819MsG4p49HDyiOSUKlmZ+nQBArW5CGw==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "loader-utils": "0.2.17",
-        "source-map": "0.6.1"
+        "async": "^2.5.0",
+        "loader-utils": "~0.2.2",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "loader-utils": {
@@ -17721,10 +17749,10 @@
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true,
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
           }
         },
         "source-map": {
@@ -17741,11 +17769,11 @@
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
-        "atob": "2.0.3",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.0.0",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-support": {
@@ -17754,7 +17782,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "source-map-url": {
@@ -17775,8 +17803,8 @@
       "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
-        "os-shim": "0.1.3"
+        "concat-stream": "^1.4.7",
+        "os-shim": "^0.1.2"
       }
     },
     "spdx-correct": {
@@ -17785,7 +17813,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -17806,12 +17834,12 @@
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "handle-thing": "1.2.5",
-        "http-deceiver": "1.2.7",
-        "safe-buffer": "5.1.1",
-        "select-hose": "2.0.0",
-        "spdy-transport": "2.0.20"
+        "debug": "^2.6.8",
+        "handle-thing": "^1.2.5",
+        "http-deceiver": "^1.2.7",
+        "safe-buffer": "^5.0.1",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.18"
       }
     },
     "spdy-transport": {
@@ -17820,13 +17848,13 @@
       "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "detect-node": "2.0.3",
-        "hpack.js": "2.1.6",
-        "obuf": "1.1.1",
-        "readable-stream": "2.3.3",
-        "safe-buffer": "5.1.1",
-        "wbuf": "1.7.2"
+        "debug": "^2.6.8",
+        "detect-node": "^2.0.3",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.1",
+        "readable-stream": "^2.2.9",
+        "safe-buffer": "^5.0.1",
+        "wbuf": "^1.7.2"
       }
     },
     "split": {
@@ -17835,7 +17863,7 @@
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split-string": {
@@ -17844,7 +17872,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "split2": {
@@ -17853,7 +17881,7 @@
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "dev": true,
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.2"
       }
     },
     "sprintf-js": {
@@ -17862,20 +17890,29 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "srcset": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
+      "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
+      "requires": {
+        "array-uniq": "^1.0.2",
+        "number-is-nan": "^1.0.0"
+      }
+    },
     "sshpk": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stack-trace": {
@@ -17896,8 +17933,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -17906,7 +17943,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -17915,7 +17952,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -17924,7 +17961,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -17935,7 +17972,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -17944,7 +17981,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -17955,9 +17992,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -17980,7 +18017,7 @@
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.1"
       }
     },
     "stealthy-require": {
@@ -17995,10 +18032,10 @@
       "integrity": "sha512-SxaprEbFxEcRwXLPWKvL8uD3/NL41qTabKtLpI7O4v6UMbgRMg3IqWkOBJazxNtKOlEw7i4CTY76OZ7jOqU0WA==",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "lodash": "4.17.4",
-        "prismjs": "1.14.0",
-        "string-raw": "1.0.1"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
+        "lodash": "^4.17.4",
+        "prismjs": "^1.9.0",
+        "string-raw": "^1.0.1"
       }
     },
     "stream-browserify": {
@@ -18007,8 +18044,8 @@
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-combiner2": {
@@ -18017,8 +18054,8 @@
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true,
       "requires": {
-        "duplexer2": "0.1.4",
-        "readable-stream": "2.3.3"
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-each": {
@@ -18027,8 +18064,8 @@
       "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.0",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "stream-http": {
@@ -18037,11 +18074,11 @@
       "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.2.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "stream-shift": {
@@ -18061,8 +18098,8 @@
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "requires": {
-        "astral-regex": "1.0.0",
-        "strip-ansi": "4.0.0"
+        "astral-regex": "^1.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -18077,7 +18114,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -18094,9 +18131,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string.prototype.matchall": {
@@ -18105,11 +18142,11 @@
       "integrity": "sha512-/g0YW/cEfXASRHAaLR7VZbTUlxgP14fmCsfSRFG2gvlG2S1q9rBpjYnEy/EIIzY+bjzs2nTfAHJYXmQ+zTnXSQ==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.12.0",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.0",
-        "regexp.prototype.flags": "1.2.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "regexp.prototype.flags": "^1.2.0"
       },
       "dependencies": {
         "es-abstract": {
@@ -18118,11 +18155,11 @@
           "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
           "dev": true,
           "requires": {
-            "es-to-primitive": "1.1.1",
-            "function-bind": "1.1.1",
-            "has": "1.0.1",
-            "is-callable": "1.1.3",
-            "is-regex": "1.0.4"
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
           }
         }
       }
@@ -18133,9 +18170,9 @@
       "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.4.3",
+        "function-bind": "^1.0.2"
       }
     },
     "string.prototype.padstart": {
@@ -18144,18 +18181,17 @@
       "integrity": "sha1-W8+tOfRkm7LQMSkuGbzwtRDUskI=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.4.3",
+        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -18170,7 +18206,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -18179,7 +18215,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-eof": {
@@ -18194,7 +18230,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       },
       "dependencies": {
         "get-stdin": {
@@ -18217,8 +18253,8 @@
       "integrity": "sha512-T+UNsAcl3Yg+BsPKs1vd22Fr8sVT+CJMtzqc6LEw9bbJZb43lm9GoeIfUcDEefBSWC0BhYbcdupV1GtI4DGzxg==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.4.5"
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^0.4.5"
       },
       "dependencies": {
         "ajv": {
@@ -18227,10 +18263,10 @@
           "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1",
-            "uri-js": "3.0.2"
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0",
+            "uri-js": "^3.0.2"
           }
         },
         "ajv-keywords": {
@@ -18245,8 +18281,8 @@
           "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
           "dev": true,
           "requires": {
-            "ajv": "6.4.0",
-            "ajv-keywords": "3.1.0"
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
           }
         }
       }
@@ -18255,9 +18291,8 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
       "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-      "dev": true,
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "svg-tag-names": {
@@ -18272,13 +18307,13 @@
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "dev": true,
       "requires": {
-        "coa": "1.0.4",
-        "colors": "1.1.2",
-        "csso": "2.3.2",
-        "js-yaml": "3.7.0",
-        "mkdirp": "0.5.1",
-        "sax": "1.2.4",
-        "whet.extend": "0.9.9"
+        "coa": "~1.0.1",
+        "colors": "~1.1.2",
+        "csso": "~2.3.1",
+        "js-yaml": "~3.7.0",
+        "mkdirp": "~0.5.1",
+        "sax": "~1.2.1",
+        "whet.extend": "~0.9.9"
       },
       "dependencies": {
         "esprima": {
@@ -18293,8 +18328,8 @@
           "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3"
+            "argparse": "^1.0.7",
+            "esprima": "^2.6.0"
           }
         }
       }
@@ -18317,7 +18352,7 @@
       "integrity": "sha512-I9mrbZ5M96s7QeJDv95toF1svkUjeBybe8ydhY7foPaBmr0SPJMFupArmMkDrOKTTj0sJVr+nvQNxWLziQ7nDQ==",
       "dev": true,
       "requires": {
-        "has-symbols": "1.0.0"
+        "has-symbols": "^1.0.0"
       }
     },
     "table": {
@@ -18326,12 +18361,12 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.3.0",
-        "lodash": "4.17.4",
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -18352,8 +18387,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -18362,7 +18397,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -18373,14 +18408,14 @@
       "integrity": "sha1-egR/FDsBC0y9MfhX6ClhUSy/ThQ=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "inquirer": "1.2.3",
-        "lodash.difference": "4.5.0",
-        "lodash.uniq": "4.5.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "npmlog": "2.0.4",
-        "object-assign": "4.1.1"
+        "debug": "^2.2.0",
+        "inquirer": "^1.0.2",
+        "lodash.difference": "^4.5.0",
+        "lodash.uniq": "^4.5.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "npmlog": "^2.0.3",
+        "object-assign": "^4.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -18395,11 +18430,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "cli-width": {
@@ -18414,9 +18449,9 @@
           "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
           "dev": true,
           "requires": {
-            "extend": "3.0.1",
-            "spawn-sync": "1.0.15",
-            "tmp": "0.0.29"
+            "extend": "^3.0.0",
+            "spawn-sync": "^1.0.15",
+            "tmp": "^0.0.29"
           }
         },
         "gauge": {
@@ -18425,11 +18460,11 @@
           "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
           "dev": true,
           "requires": {
-            "ansi": "0.3.1",
-            "has-unicode": "2.0.1",
-            "lodash.pad": "4.5.1",
-            "lodash.padend": "4.6.1",
-            "lodash.padstart": "4.6.1"
+            "ansi": "^0.3.0",
+            "has-unicode": "^2.0.0",
+            "lodash.pad": "^4.1.0",
+            "lodash.padend": "^4.1.0",
+            "lodash.padstart": "^4.1.0"
           }
         },
         "inquirer": {
@@ -18438,20 +18473,20 @@
           "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
           "dev": true,
           "requires": {
-            "ansi-escapes": "1.4.0",
-            "chalk": "1.1.3",
-            "cli-cursor": "1.0.2",
-            "cli-width": "2.2.0",
-            "external-editor": "1.1.1",
-            "figures": "1.7.0",
-            "lodash": "4.17.4",
+            "ansi-escapes": "^1.1.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "external-editor": "^1.1.0",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.6",
-            "pinkie-promise": "2.0.1",
-            "run-async": "2.3.0",
-            "rx": "4.1.0",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
+            "pinkie-promise": "^2.0.0",
+            "run-async": "^2.2.0",
+            "rx": "^4.1.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
           }
         },
         "minimist": {
@@ -18472,9 +18507,9 @@
           "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
           "dev": true,
           "requires": {
-            "ansi": "0.3.1",
-            "are-we-there-yet": "1.1.4",
-            "gauge": "1.2.7"
+            "ansi": "~0.3.1",
+            "are-we-there-yet": "~1.1.2",
+            "gauge": "~1.2.5"
           }
         },
         "run-async": {
@@ -18483,7 +18518,7 @@
           "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
           "dev": true,
           "requires": {
-            "is-promise": "2.1.0"
+            "is-promise": "^2.1.0"
           }
         },
         "supports-color": {
@@ -18498,7 +18533,7 @@
           "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2"
+            "os-tmpdir": "~1.0.1"
           }
         }
       }
@@ -18515,9 +18550,9 @@
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "term-size": {
@@ -18526,7 +18561,7 @@
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
-        "execa": "0.7.0"
+        "execa": "^0.7.0"
       },
       "dependencies": {
         "execa": {
@@ -18535,13 +18570,13 @@
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         }
       }
@@ -18552,11 +18587,11 @@
       "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "require-main-filename": "1.0.1"
+        "arrify": "^1.0.1",
+        "micromatch": "^2.3.11",
+        "object-assign": "^4.1.0",
+        "read-pkg-up": "^1.0.1",
+        "require-main-filename": "^1.0.1"
       }
     },
     "text-extensions": {
@@ -18589,8 +18624,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "thunky": {
@@ -18617,7 +18652,7 @@
       "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
       "dev": true,
       "requires": {
-        "setimmediate": "1.0.5"
+        "setimmediate": "^1.0.4"
       }
     },
     "tiny-emitter": {
@@ -18633,7 +18668,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "tmpl": {
@@ -18660,7 +18695,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "to-regex": {
@@ -18669,10 +18704,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -18681,8 +18716,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -18691,7 +18726,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         }
       }
@@ -18708,7 +18743,7 @@
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "traverse": {
@@ -18723,17 +18758,17 @@
       "integrity": "sha512-SUELtUqzseE0oKU9a1dwntytnudYcNX8v2lK3vdJw93ASqj7QRC+t+4Sx3lW9Jy9n3maXPHMQtsFkKw7XGG3/w==",
       "dev": true,
       "requires": {
-        "babel-polyfill": "6.26.0",
-        "babel-preset-env": "1.6.1",
-        "babel-register": "6.26.0",
-        "chalk": "2.3.0",
-        "execa": "0.10.0",
-        "got": "8.3.0",
-        "p-retry": "2.0.0",
-        "semver": "5.4.1",
-        "update-notifier": "2.5.0",
-        "url-join": "4.0.0",
-        "yargs": "11.0.0"
+        "babel-polyfill": "^6.26.0",
+        "babel-preset-env": "^1.6.1",
+        "babel-register": "^6.26.0",
+        "chalk": "^2.1.0",
+        "execa": "^0.10.0",
+        "got": "^8.0.1",
+        "p-retry": "^2.0.0",
+        "semver": "^5.4.1",
+        "update-notifier": "^2.3.0",
+        "url-join": "^4.0.0",
+        "yargs": "^11.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -18754,9 +18789,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -18771,7 +18806,7 @@
           "integrity": "sha512-ZbCuzAmiwJ45q4evp/IG9D+5MUllGSUeCWwPt3j/tdYSi1KPkSD+46uqmAA1LhccDhOXv8kYZKNb8x78VflzfA==",
           "dev": true,
           "requires": {
-            "retry": "0.12.0"
+            "retry": "^0.12.0"
           }
         },
         "retry": {
@@ -18786,8 +18821,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -18796,7 +18831,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "url-join": {
@@ -18811,18 +18846,18 @@
           "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
           "dev": true,
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
           }
         },
         "yargs-parser": {
@@ -18831,7 +18866,7 @@
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -18860,7 +18895,7 @@
       "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
       "dev": true,
       "requires": {
-        "glob": "6.0.4"
+        "glob": "^6.0.4"
       },
       "dependencies": {
         "glob": {
@@ -18869,11 +18904,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -18890,7 +18925,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -18906,7 +18941,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-is": {
@@ -18916,7 +18951,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
+        "mime-types": "~2.1.15"
       }
     },
     "typedarray": {
@@ -18936,9 +18971,9 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "camelcase": {
@@ -18953,9 +18988,9 @@
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -18974,14 +19009,14 @@
       "integrity": "sha512-XG8/QmR1pyPeE1kj2aigo5kos8umefB31zW+PMvAAytHSB0T/vQvN6sqt8+Sh+y0b0A7zlmxNi2dzRnj0wcqGA==",
       "dev": true,
       "requires": {
-        "cacache": "10.0.1",
-        "find-cache-dir": "1.0.0",
-        "schema-utils": "0.4.3",
-        "serialize-javascript": "1.4.0",
-        "source-map": "0.6.1",
-        "uglify-es": "3.3.9",
-        "webpack-sources": "1.1.0",
-        "worker-farm": "1.5.2"
+        "cacache": "^10.0.1",
+        "find-cache-dir": "^1.0.0",
+        "schema-utils": "^0.4.2",
+        "serialize-javascript": "^1.4.0",
+        "source-map": "^0.6.1",
+        "uglify-es": "^3.3.4",
+        "webpack-sources": "^1.1.0",
+        "worker-farm": "^1.5.2"
       },
       "dependencies": {
         "commander": {
@@ -18996,8 +19031,8 @@
           "integrity": "sha512-sgv/iF/T4/SewJkaVpldKC4WjSkz0JsOh2eKtxCPpCO1oR05+7MOF+H476HVRbLArkgA7j5TRJJ4p2jdFkUGQQ==",
           "dev": true,
           "requires": {
-            "ajv": "5.5.2",
-            "ajv-keywords": "2.1.1"
+            "ajv": "^5.0.0",
+            "ajv-keywords": "^2.1.0"
           }
         },
         "source-map": {
@@ -19012,8 +19047,8 @@
           "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
           "dev": true,
           "requires": {
-            "commander": "2.13.0",
-            "source-map": "0.6.1"
+            "commander": "~2.13.0",
+            "source-map": "~0.6.1"
           }
         }
       }
@@ -19030,10 +19065,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -19042,7 +19077,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "set-value": {
@@ -19051,10 +19086,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -19071,7 +19106,7 @@
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
       "dev": true,
       "requires": {
-        "macaddress": "0.2.8"
+        "macaddress": "^0.2.8"
       }
     },
     "uniqs": {
@@ -19086,7 +19121,7 @@
       "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
       "dev": true,
       "requires": {
-        "unique-slug": "2.0.0"
+        "unique-slug": "^2.0.0"
       }
     },
     "unique-slug": {
@@ -19095,7 +19130,7 @@
       "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
       "dev": true,
       "requires": {
-        "imurmurhash": "0.1.4"
+        "imurmurhash": "^0.1.4"
       }
     },
     "unique-string": {
@@ -19104,7 +19139,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "1.0.0"
+        "crypto-random-string": "^1.0.0"
       }
     },
     "universalify": {
@@ -19125,8 +19160,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -19135,9 +19170,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -19171,10 +19206,10 @@
       "integrity": "sha512-fCmij7T5LnwUme3dbnVSejvOHHlARjB3ikJFwgZfz386pHmf/gueuTLRFU94FZEaeCLlbQrweiUU700gG41tUw==",
       "dev": true,
       "requires": {
-        "lodash.endswith": "4.2.1",
-        "lodash.isfunction": "3.0.9",
-        "lodash.isstring": "4.0.1",
-        "lodash.startswith": "4.2.1"
+        "lodash.endswith": "^4.2.1",
+        "lodash.isfunction": "^3.0.8",
+        "lodash.isstring": "^4.0.1",
+        "lodash.startswith": "^4.2.1"
       }
     },
     "update-notifier": {
@@ -19183,16 +19218,16 @@
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "dev": true,
       "requires": {
-        "boxen": "1.3.0",
-        "chalk": "2.3.0",
-        "configstore": "3.1.1",
-        "import-lazy": "2.1.0",
-        "is-ci": "1.0.10",
-        "is-installed-globally": "0.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "upper-case": {
@@ -19207,7 +19242,7 @@
       "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
       "dev": true,
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -19254,9 +19289,9 @@
       "integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "mime": "1.4.1",
-        "schema-utils": "0.3.0"
+        "loader-utils": "^1.0.2",
+        "mime": "^1.4.1",
+        "schema-utils": "^0.3.0"
       }
     },
     "url-parse": {
@@ -19265,8 +19300,8 @@
       "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
       "dev": true,
       "requires": {
-        "querystringify": "1.0.0",
-        "requires-port": "1.0.0"
+        "querystringify": "~1.0.0",
+        "requires-port": "~1.0.0"
       },
       "dependencies": {
         "querystringify": {
@@ -19283,7 +19318,7 @@
       "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "dev": true,
       "requires": {
-        "prepend-http": "2.0.0"
+        "prepend-http": "^2.0.0"
       },
       "dependencies": {
         "prepend-http": {
@@ -19312,9 +19347,9 @@
       "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2"
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -19323,7 +19358,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -19332,7 +19367,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -19341,7 +19376,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -19352,7 +19387,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -19361,7 +19396,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -19372,9 +19407,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -19389,7 +19424,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -19420,8 +19455,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -19429,8 +19463,8 @@
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "object.getownpropertydescriptors": "2.0.3"
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
       }
     },
     "utila": {
@@ -19457,7 +19491,7 @@
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true,
       "requires": {
-        "user-home": "1.1.1"
+        "user-home": "^1.1.1"
       }
     },
     "validate-npm-package-license": {
@@ -19466,8 +19500,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "value-equal": {
@@ -19494,10 +19528,10 @@
       "integrity": "sha1-1tRyds/Ivip1Yjh5sgFArFjBuCs=",
       "dev": true,
       "requires": {
-        "lodash": "3.10.1",
-        "prop-types": "15.6.0",
-        "react-transition-group": "1.2.1",
-        "velocity-animate": "1.5.1"
+        "lodash": "^3.10.1",
+        "prop-types": "^15.5.8",
+        "react-transition-group": "^1.1.2",
+        "velocity-animate": "^1.4.0"
       },
       "dependencies": {
         "lodash": {
@@ -19520,9 +19554,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vm-browserify": {
@@ -19540,16 +19574,16 @@
       "integrity": "sha1-S+eypOSPj8/JzzZIxBnTEcUiFZ0=",
       "dev": true,
       "requires": {
-        "babel-polyfill": "6.26.0",
-        "chalk": "1.1.3",
-        "in-publish": "2.0.0",
+        "babel-polyfill": "^6.3.14",
+        "chalk": "^1.1.0",
+        "in-publish": "^2.0.0",
         "inquirer": "0.11.0",
-        "lodash": "4.17.4",
-        "log-update": "1.0.2",
-        "minimist": "1.2.0",
-        "node-localstorage": "0.6.0",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "lodash": "^4.5.1",
+        "log-update": "^1.0.2",
+        "minimist": "^1.2.0",
+        "node-localstorage": "^0.6.0",
+        "strip-ansi": "^3.0.0",
+        "wrap-ansi": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -19564,11 +19598,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "minimist": {
@@ -19591,7 +19625,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.11"
+        "makeerror": "1.0.x"
       }
     },
     "warning": {
@@ -19600,7 +19634,7 @@
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "watch": {
@@ -19609,8 +19643,8 @@
       "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
       "dev": true,
       "requires": {
-        "exec-sh": "0.2.1",
-        "minimist": "1.2.0"
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -19627,9 +19661,9 @@
       "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "chokidar": "1.7.0",
-        "graceful-fs": "4.1.11"
+        "async": "^2.1.2",
+        "chokidar": "^1.7.0",
+        "graceful-fs": "^4.1.2"
       }
     },
     "wbuf": {
@@ -19638,7 +19672,7 @@
       "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
       "dev": true,
       "requires": {
-        "minimalistic-assert": "1.0.0"
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "weak": {
@@ -19648,8 +19682,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.8.0"
+        "bindings": "^1.2.1",
+        "nan": "^2.0.5"
       }
     },
     "webidl-conversions": {
@@ -19664,28 +19698,28 @@
       "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
-        "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "async": "2.6.0",
-        "enhanced-resolve": "3.4.1",
-        "escope": "3.6.0",
-        "interpret": "1.1.0",
-        "json-loader": "0.5.7",
-        "json5": "0.5.1",
-        "loader-runner": "2.3.0",
-        "loader-utils": "1.1.0",
-        "memory-fs": "0.4.1",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "2.1.0",
-        "source-map": "0.5.7",
-        "supports-color": "4.5.0",
-        "tapable": "0.2.8",
-        "uglifyjs-webpack-plugin": "0.4.6",
-        "watchpack": "1.4.0",
-        "webpack-sources": "1.1.0",
-        "yargs": "8.0.2"
+        "acorn": "^5.0.0",
+        "acorn-dynamic-import": "^2.0.0",
+        "ajv": "^5.1.5",
+        "ajv-keywords": "^2.0.0",
+        "async": "^2.1.2",
+        "enhanced-resolve": "^3.4.0",
+        "escope": "^3.6.0",
+        "interpret": "^1.0.0",
+        "json-loader": "^0.5.4",
+        "json5": "^0.5.1",
+        "loader-runner": "^2.3.0",
+        "loader-utils": "^1.1.0",
+        "memory-fs": "~0.4.1",
+        "mkdirp": "~0.5.0",
+        "node-libs-browser": "^2.0.0",
+        "source-map": "^0.5.3",
+        "supports-color": "^4.2.1",
+        "tapable": "^0.2.7",
+        "uglifyjs-webpack-plugin": "^0.4.6",
+        "watchpack": "^1.4.0",
+        "webpack-sources": "^1.0.1",
+        "yargs": "^8.0.2"
       },
       "dependencies": {
         "uglifyjs-webpack-plugin": {
@@ -19694,9 +19728,9 @@
           "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-js": "2.8.29",
-            "webpack-sources": "1.1.0"
+            "source-map": "^0.5.6",
+            "uglify-js": "^2.8.29",
+            "webpack-sources": "^1.0.1"
           }
         }
       }
@@ -19707,9 +19741,9 @@
       "integrity": "sha512-sdEVRkTgdRYltxoHkfSW6ARvb3LjeMzxPe4oc8aAr3ZhyGPIEShqi237lnEXWg6SeGN674UCBXN34+kvos4WFw==",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1",
+        "ansi-regex": "^2.0.0",
         "node-notifier": "5.1.2",
-        "strip-ansi": "3.0.1"
+        "strip-ansi": "^3.0.1"
       }
     },
     "webpack-dev-middleware": {
@@ -19718,11 +19752,11 @@
       "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
       "dev": true,
       "requires": {
-        "memory-fs": "0.4.1",
-        "mime": "1.6.0",
-        "path-is-absolute": "1.0.1",
-        "range-parser": "1.2.0",
-        "time-stamp": "2.0.0"
+        "memory-fs": "~0.4.1",
+        "mime": "^1.5.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0"
       },
       "dependencies": {
         "mime": {
@@ -19740,30 +19774,30 @@
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
-        "array-includes": "3.0.3",
-        "bonjour": "3.5.0",
-        "chokidar": "2.0.2",
-        "compression": "1.7.2",
-        "connect-history-api-fallback": "1.5.0",
-        "debug": "3.1.0",
-        "del": "3.0.0",
-        "express": "4.16.2",
-        "html-entities": "1.2.1",
-        "http-proxy-middleware": "0.17.4",
-        "import-local": "1.0.0",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
         "internal-ip": "1.2.0",
-        "ip": "1.1.5",
-        "killable": "1.0.0",
-        "loglevel": "1.6.1",
-        "opn": "5.2.0",
-        "portfinder": "1.0.13",
-        "selfsigned": "1.10.2",
-        "serve-index": "1.9.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
         "sockjs": "0.3.19",
         "sockjs-client": "1.1.4",
-        "spdy": "3.4.7",
-        "strip-ansi": "3.0.1",
-        "supports-color": "5.2.0",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
         "webpack-dev-middleware": "2.0.6",
         "yargs": "9.0.1"
       },
@@ -19780,8 +19814,8 @@
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "micromatch": "3.1.9",
-            "normalize-path": "2.1.1"
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
           }
         },
         "arr-diff": {
@@ -19802,18 +19836,18 @@
           "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "kind-of": "6.0.2",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.1",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "kind-of": "^6.0.2",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -19822,7 +19856,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -19831,7 +19865,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -19848,18 +19882,18 @@
           "integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
           "dev": true,
           "requires": {
-            "anymatch": "2.0.0",
-            "async-each": "1.0.1",
-            "braces": "2.3.1",
-            "fsevents": "1.1.3",
-            "glob-parent": "3.1.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "4.0.0",
-            "normalize-path": "2.1.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0",
-            "upath": "1.0.2"
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.0",
+            "braces": "^2.3.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^2.1.1",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0",
+            "upath": "^1.0.0"
           }
         },
         "cliui": {
@@ -19868,9 +19902,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "string-width": {
@@ -19879,9 +19913,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -19901,12 +19935,12 @@
           "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
           "dev": true,
           "requires": {
-            "globby": "6.1.0",
-            "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.0",
-            "p-map": "1.2.0",
-            "pify": "3.0.0",
-            "rimraf": "2.6.2"
+            "globby": "^6.1.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "p-map": "^1.1.1",
+            "pify": "^3.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "expand-brackets": {
@@ -19915,13 +19949,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "debug": {
@@ -19939,7 +19973,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -19948,7 +19982,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-descriptor": {
@@ -19957,9 +19991,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -19976,14 +20010,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -19992,7 +20026,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -20001,7 +20035,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -20012,10 +20046,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -20024,7 +20058,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -20035,8 +20069,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           },
           "dependencies": {
             "is-glob": {
@@ -20045,7 +20079,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -20056,11 +20090,11 @@
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           },
           "dependencies": {
             "pify": {
@@ -20083,7 +20117,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -20092,7 +20126,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -20103,7 +20137,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -20112,7 +20146,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -20129,7 +20163,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.1"
           }
         },
         "is-number": {
@@ -20138,7 +20172,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -20147,7 +20181,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -20164,10 +20198,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
           },
           "dependencies": {
             "pify": {
@@ -20184,19 +20218,19 @@
           "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.1",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           }
         },
         "mime": {
@@ -20211,7 +20245,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "2.3.0"
+            "pify": "^2.0.0"
           },
           "dependencies": {
             "pify": {
@@ -20234,9 +20268,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
           }
         },
         "read-pkg-up": {
@@ -20245,8 +20279,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         },
         "string-width": {
@@ -20255,8 +20289,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -20271,7 +20305,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -20288,7 +20322,7 @@
           "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "webpack-dev-middleware": {
@@ -20297,13 +20331,13 @@
           "integrity": "sha512-tj5LLD9r4tDuRIDa5Mu9lnY2qBBehAITv6A9irqXhw/HQquZgTx3BCd57zYbU2gMDnncA49ufK2qVQSbaKJwOw==",
           "dev": true,
           "requires": {
-            "loud-rejection": "1.6.0",
-            "memory-fs": "0.4.1",
-            "mime": "2.2.0",
-            "path-is-absolute": "1.0.1",
-            "range-parser": "1.2.0",
-            "url-join": "2.0.5",
-            "webpack-log": "1.1.2"
+            "loud-rejection": "^1.6.0",
+            "memory-fs": "~0.4.1",
+            "mime": "^2.1.0",
+            "path-is-absolute": "^1.0.0",
+            "range-parser": "^1.0.3",
+            "url-join": "^2.0.2",
+            "webpack-log": "^1.0.1"
           }
         },
         "yargs": {
@@ -20312,19 +20346,19 @@
           "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
           }
         }
       }
@@ -20336,9 +20370,9 @@
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
-        "html-entities": "1.2.1",
-        "querystring": "0.2.0",
-        "strip-ansi": "3.0.1"
+        "html-entities": "^1.2.0",
+        "querystring": "^0.2.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "webpack-log": {
@@ -20347,10 +20381,10 @@
       "integrity": "sha512-B53SD4N4BHpZdUwZcj4st2QT7gVfqZtqHDruC1N+K2sciq0Rt/3F1Dx6RlylVkcrToMLTaiaeT48k9Lq4iDVDA==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "log-symbols": "2.2.0",
-        "loglevelnext": "1.0.3",
-        "uuid": "3.1.0"
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.1",
+        "uuid": "^3.1.0"
       }
     },
     "webpack-sources": {
@@ -20359,8 +20393,8 @@
       "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
       "dev": true,
       "requires": {
-        "source-list-map": "2.0.0",
-        "source-map": "0.6.1"
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -20377,8 +20411,8 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.10",
-        "websocket-extensions": "0.1.3"
+        "http-parser-js": ">=0.4.0",
+        "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
@@ -20413,7 +20447,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -20428,7 +20462,7 @@
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       }
     },
     "widest-line": {
@@ -20437,7 +20471,7 @@
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -20458,8 +20492,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -20468,7 +20502,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -20485,12 +20519,12 @@
       "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
       "dev": true,
       "requires": {
-        "async": "1.0.0",
-        "colors": "1.0.3",
-        "cycle": "1.0.3",
-        "eyes": "0.1.8",
-        "isstream": "0.1.2",
-        "stack-trace": "0.0.10"
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
       },
       "dependencies": {
         "async": {
@@ -20519,8 +20553,8 @@
       "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
       "dev": true,
       "requires": {
-        "errno": "0.1.6",
-        "xtend": "4.0.1"
+        "errno": "^0.1.4",
+        "xtend": "^4.0.1"
       }
     },
     "wrap-ansi": {
@@ -20529,8 +20563,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -20545,7 +20579,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
@@ -20554,9 +20588,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "xdg-basedir": {
@@ -20580,8 +20614,7 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",
@@ -20601,19 +20634,19 @@
       "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
+        "camelcase": "^4.1.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "read-pkg-up": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^7.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -20634,9 +20667,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "string-width": {
@@ -20645,9 +20678,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -20658,10 +20691,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "path-type": {
@@ -20670,7 +20703,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "2.3.0"
+            "pify": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -20679,9 +20712,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
           }
         },
         "read-pkg-up": {
@@ -20690,8 +20723,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         },
         "string-width": {
@@ -20700,8 +20733,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -20716,7 +20749,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -20735,7 +20768,7 @@
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       },
       "dependencies": {
         "camelcase": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "react": "^16.1.0",
     "react-dom": "^16.1.0",
     "react-element-proptypes": "^1.0.0",
-    "react-proptype-conditional-require": "^1.0.4"
+    "react-proptype-conditional-require": "^1.0.4",
+    "react-responsive": "^4.1.0",
+    "sanitize-html": "^1.18.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^6.0.2",
@@ -110,7 +112,8 @@
     "coveragePathIgnorePatterns": [
       "/.storybook/",
       "/node_modules/",
-      "(.stories)\\.(jsx)$"
+      "(.stories)\\.(jsx)$",
+      "\\.(mock.js)$"
     ],
     "transformIgnorePatterns": [
       "/node_modules/(?!lodash-es/.*)"

--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -63,8 +63,8 @@ class Button extends React.Component {
       <button
         {...other}
         className={classNames([
-          ...className,
           styles.btn,
+          ...className,
         ], {
           [styles[`btn-${buttonType}`]]: buttonType !== undefined,
         }, {

--- a/src/Pagination/Pagination.scss
+++ b/src/Pagination/Pagination.scss
@@ -1,0 +1,18 @@
+@import "~bootstrap/scss/_pagination";
+@import "~bootstrap/scss/_buttons";
+@import "~bootstrap/scss/_variables";
+@import "~bootstrap/scss/utilities/_spacing";
+@import "~bootstrap/scss/utilities/_borders";
+
+.page-link {
+    border-color: $pagination-border-color !important;
+    border-radius: 0 !important;
+    
+    div {
+        display: inline-block;
+    }
+}
+
+.page-item > .btn {
+    transition: none;
+}

--- a/src/Pagination/Pagination.stories.jsx
+++ b/src/Pagination/Pagination.stories.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import centered from '@storybook/addon-centered';
+import { checkA11y } from '@storybook/addon-a11y';
+import { action } from '@storybook/addon-actions';
+import { withInfo } from '@storybook/addon-info';
+import { withReadme } from 'storybook-readme';
+
+import Pagination from './index';
+import README from './README.md';
+
+storiesOf('Pagination', module)
+  .addDecorator((story, context) => withInfo()(story)(context))
+  .addDecorator(centered)
+  .addDecorator(checkA11y)
+  .addDecorator(withReadme(README))
+  .add('basic usage', () => (
+    <Pagination
+      paginationLabel="pagination navigation"
+      pageCount={20}
+      onPageSelect={action('page-selected')}
+    />
+  ))
+  .add('with initial page selected', () => (
+    <Pagination
+      paginationLabel="pagination navigation"
+      pageCount={20}
+      currentPage={15}
+      onPageSelect={action('page-selected')}
+    />
+  ))
+  .add('with max pages displayed', () => (
+    <Pagination
+      paginationLabel="pagination navigation"
+      pageCount={20}
+      onPageSelect={action('page-selected')}
+      maxPagesDisplayed={9}
+    />
+  ))
+  .add('with custom string labels', () => (
+    <Pagination
+      paginationLabel="pagination navigation"
+      pageCount={20}
+      onPageSelect={action('page-selected')}
+      buttonLabels={{
+        previous: 'Anterior',
+        next: 'Siguiente',
+        page: 'Página',
+        currentPage: 'Página actual',
+        pageOfCount: 'de',
+      }}
+    />
+  ))
+  .add('with custom element labels', () => (
+    <Pagination
+      paginationLabel="pagination navigation"
+      pageCount={20}
+      onPageSelect={action('page-selected')}
+      buttonLabels={{
+        previous: <span>Anterior</span>,
+        next: <span>Siguiente</span>,
+        page: <span>Página</span>,
+        currentPage: <span>Página actual</span>,
+        pageOfCount: <span>de</span>,
+      }}
+    />
+  ));

--- a/src/Pagination/Pagination.test.jsx
+++ b/src/Pagination/Pagination.test.jsx
@@ -1,0 +1,239 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import '../utils/reactResponsive.mock';
+import { breakpoints } from '../Responsive';
+
+import Pagination from './index';
+
+const baseProps = {
+  paginationLabel: 'pagination navigation',
+  pageCount: 5,
+  onPageSelect: () => {},
+};
+
+describe('<Pagination />', () => {
+  it('renders', () => {
+    const props = {
+      ...baseProps,
+    };
+    const wrapper = mount(<Pagination {...props} />);
+    expect(wrapper.exists()).toEqual(true);
+  });
+
+  describe('handles currentPage props properly', () => {
+    it('overrides state currentPage when props currentPage changes', () => {
+      const initialPage = 1;
+      const newPage = 2;
+      const props = {
+        ...baseProps,
+        currentPage: initialPage,
+      };
+      const wrapper = mount(<Pagination {...props} />);
+      expect(wrapper.state('currentPage')).toEqual(initialPage);
+      wrapper.setProps({
+        currentPage: newPage,
+      });
+      expect(wrapper.state('currentPage')).toEqual(newPage);
+    });
+
+    it('does not override state currentPage when props currentPage changes with existing value', () => {
+      const currentPage = 2;
+      const props = {
+        ...baseProps,
+        currentPage,
+      };
+      const wrapper = mount(<Pagination {...props} />);
+      expect(wrapper.state('currentPage')).toEqual(currentPage);
+      wrapper.setProps({
+        currentPage,
+      });
+      expect(wrapper.state('currentPage')).toEqual(currentPage);
+    });
+  });
+
+  describe('handles focus properly', () => {
+    it('should change focus to next button if previous page is first page', () => {
+      const props = {
+        ...baseProps,
+        currentPage: 2,
+      };
+      const wrapper = mount(<Pagination {...props} />);
+      wrapper.find('.previous').simulate('click');
+      expect(wrapper.find('.next').instance()).toEqual(document.activeElement);
+    });
+
+    it('should change focus to previous button if next page is last page', () => {
+      const props = {
+        ...baseProps,
+        currentPage: baseProps.pageCount - 1,
+      };
+      const wrapper = mount(<Pagination {...props} />);
+      wrapper.find('.next').simulate('click');
+      expect(wrapper.find('.previous').instance()).toEqual(document.activeElement);
+    });
+  });
+
+  describe('renders required props', () => {
+    it('should use correct paginationLabel', () => {
+      const paginationLabel = 'pagination navigation';
+      const props = {
+        ...baseProps,
+        paginationLabel,
+      };
+      const wrapper = mount(<Pagination {...props} />);
+      expect(wrapper.find('nav').prop('aria-label')).toEqual(paginationLabel);
+    });
+
+    describe('should use correct number of pages', () => {
+      it('should show 5 buttons on desktop', () => {
+        const wrapper = mount(<Pagination {...baseProps} />);
+        expect(wrapper.findWhere((node) => {
+          const isPrevOrNext = node.hasClass('previous') || node.hasClass('next');
+          return node.name() === 'button' && !isPrevOrNext;
+        })).toHaveLength(5);
+      });
+
+      it('should show 1 button on mobile', () => {
+        // Use extra small window size to display the mobile version of `Pagination`.
+        global.innerWidth = breakpoints.extraSmall.maxWidth;
+
+        const wrapper = mount(<Pagination {...baseProps} />);
+        expect(wrapper.findWhere((node) => {
+          const name = node.name();
+          const isPrevOrNext = node.hasClass('previous') || node.hasClass('next');
+          return name === 'span' && node.hasClass('btn') && !isPrevOrNext;
+        })).toHaveLength(1);
+
+        // Reset window size back to extra large display
+        global.innerWidth = breakpoints.extraLarge.minWidth;
+      });
+    });
+
+    describe('should fire callbacks properly', () => {
+      it('should not fire onPageSelect when selecting current page', () => {
+        const spy = jest.fn();
+        const props = {
+          ...baseProps,
+          onPageSelect: spy,
+        };
+        const wrapper = mount(<Pagination {...props} />);
+
+        wrapper.find('.btn').at(1).simulate('click');
+        expect(spy).toHaveBeenCalledTimes(0);
+      });
+
+      it('should fire onPageSelect callback when selecting new page', () => {
+        const spy = jest.fn();
+        const props = {
+          ...baseProps,
+          onPageSelect: spy,
+        };
+        const wrapper = mount(<Pagination {...props} />);
+
+        wrapper.find('.btn').at(2).simulate('click');
+        expect(wrapper.state('currentPage')).toEqual(2);
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        wrapper.find('.btn').at(3).simulate('click');
+        expect(wrapper.state('currentPage')).toEqual(3);
+        expect(spy).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('fires previous and next button click handlers', () => {
+    it('previous button onClick', () => {
+      const spy = jest.fn();
+      const props = {
+        ...baseProps,
+        onPageSelect: spy,
+      };
+      const wrapper = mount(<Pagination {...props} />);
+      wrapper.setProps({ currentPage: 2 });
+      wrapper.find('.previous').simulate('click');
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('next button onClick', () => {
+      const spy = jest.fn();
+      const props = {
+        ...baseProps,
+        onPageSelect: spy,
+      };
+      const wrapper = mount(<Pagination {...props} />);
+      wrapper.find('.next').simulate('click');
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('renders button label props', () => {
+    const buttonLabels = {
+      previous: 'Anterior',
+      next: 'Siguiente',
+      page: 'Página',
+      currentPage: 'Página actual',
+      pageOfCount: 'de',
+    };
+
+    let wrapper;
+    let props;
+
+    beforeEach(() => {
+      // Reset window size to extra large display
+      global.innerWidth = breakpoints.extraLarge.minWidth;
+
+      props = {
+        ...baseProps,
+        buttonLabels,
+      };
+      wrapper = mount(<Pagination {...props} />);
+    });
+
+    it('uses passed in previous button label', () => {
+      expect(wrapper.findWhere(node => (
+        node.name() === 'button' && node.hasClass('previous')
+      )).prop('aria-label')).toEqual(buttonLabels.previous);
+
+      wrapper.setProps({ currentPage: baseProps.pageCount });
+
+      expect(wrapper.findWhere(node => (
+        node.name() === 'button' && node.hasClass('previous')
+      )).prop('aria-label')).toEqual(`${buttonLabels.previous}, ${buttonLabels.page} 4`);
+    });
+
+    it('uses passed in next button label', () => {
+      expect(wrapper.findWhere(node => (
+        node.name() === 'button' && node.hasClass('next')
+      )).prop('aria-label')).toEqual(`${buttonLabels.next}, ${buttonLabels.page} 2`);
+
+      wrapper.setProps({ currentPage: baseProps.pageCount });
+
+      expect(wrapper.findWhere(node => (
+        node.name() === 'button' && node.hasClass('next')
+      )).prop('aria-label')).toEqual(buttonLabels.next);
+    });
+
+    it('uses passed in page button label', () => {
+      expect(wrapper.state('currentPage')).toEqual(1);
+      expect(wrapper.find('.btn').at(1).prop('aria-label'))
+        .toEqual(`${buttonLabels.page} 1, ${buttonLabels.currentPage}`);
+
+      wrapper.setProps({ currentPage: 2 });
+      expect(wrapper.state('currentPage')).toEqual(2);
+
+      expect(wrapper.find('.btn').at(1).prop('aria-label'))
+        .toEqual(`${buttonLabels.page} 1`);
+
+      // Reset window size to extra small display
+      global.innerWidth = breakpoints.extraSmall.maxWidth;
+      wrapper = mount(<Pagination {...props} />);
+
+      expect(wrapper.find('.btn').at(1).prop('aria-label'))
+        .toEqual(`${buttonLabels.page} 1, ${buttonLabels.currentPage}, ${buttonLabels.pageOfCount} 5`);
+
+      // Reset window size back to extra large display
+      global.innerWidth = breakpoints.extraLarge.minWidth;
+    });
+  });
+});

--- a/src/Pagination/README.md
+++ b/src/Pagination/README.md
@@ -1,0 +1,60 @@
+# Pagination
+
+Provides a responsive pagination component with `Previous`/`Next` buttons. On larger screen sizes, it displays a full pagination UI that dynamically collapses the page buttons using ellipses; the first and last pages are always shown. On smaller screen sizes (e.g., mobile devices), a simplified UI is displayed following a convention of page "X of Y":
+
+#### Desktop
+![Desktop Pagination](https://user-images.githubusercontent.com/2828721/41666898-99227722-7479-11e8-87e7-e8400994d4f1.png)
+
+#### Mobile
+![Mobile Pagination](https://user-images.githubusercontent.com/2828721/41666899-995084d2-7479-11e8-8061-a5e4965ea965.png)
+
+## Accessibility
+The `Pagination` component dynamically generates an `aria-label` for all buttons to ensure users with screen readers are aware of which page is currently selected. For example, when tabbing between pages, if the user focuses on a currently selected page, the screen reader would read `Page 1, Current Page` whereas a page not currently selected would read `Page 2`.
+
+To ensure users with screen readers are aware of the currently selected page when using the `Previous`/ `Next` buttons, a `div` with an [`aria-live="polite"`](https://www.w3.org/TR/wai-aria/#aria-live) attribute - visible only to screen readers - updates accordingly (e.g., `Page 5, Current Page, of 20`). The contents will be read by the screen reader with each update.
+
+Additionally, to avoid losing focus when the `Previous`/`Next` buttons become disabled, the focus is explicitly set. When the user selects the `Next` button where the next page is the last page, focus is set on the `Previous` button. Likewise, when the user selects the `Previous` button where the previous page is the first page, focus is set on the `Next` button.
+
+## API
+
+### `onPageSelect` (function; required)
+`onPageSelect` specifies a callback function that is executed when the user selects a page button or the `Previous`/`Next` buttons. For example:
+
+```jsx
+<Pagination onPageSelect={(pageNumber) => { console.log(pageNumber); } />
+```
+
+### `pageCount` (number; required)
+`pageCount` specifies the total number of pages in the `Pagination` component.
+
+### `paginationLabel` (string; required)
+`paginationLabel` specifies the `aria-label` for the `<nav>` element that wraps the pagination button list.
+
+### `buttonLabels` (object; optional)
+`buttonLabels` specifies the labels to use for the `Previous`/`Next` buttons as well as the various parts of `aria-label` on the page buttons for accessibility. All button labels accept both string or elements. The button label options are as follows:
+
+* `previous`: Text for the `Previous` button;
+* `next`: Text for the `Next` button;
+* `page`: Text in the `aria-label` on page buttons to describe the button (e.g., "**Page** 1");
+* `currentPage`: Text to depict the selected page in the `aria-label` on page buttons (e.g., "Page 1, **Current Page**");
+* `pageOfCount`: Text that separates the current page and total page count for the mobile UI (e.g., "Page 1 **of** 20").
+
+The default is:
+```javascript
+{
+    previous: 'Previous',
+    next: 'Next',
+    page: 'Page',
+    currentPage: 'Current Page',
+    pageOfCount: 'of',
+}
+```
+
+### `className` (string; optional)
+`className` specifies any class name(s) for the `Pagination` component. The default is an empty string.
+
+### `currentPage` (number; optional)
+`currentPage` specifies the page that the `Pagination` component will automatically select. The default is `1`.
+
+### `maxPagesDisplayed` (number; optional)
+`maxPagesDisplayed` specifies the number of page buttons to display in between the `Previous` and `Next` buttons. This number also includes any ellipses in the total count. Also, to ensure that at least one clickable page button is shown when both ellipses are displayed, this value must be greater than `4`.  The default is `7`.

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -1,0 +1,409 @@
+import { between } from 'airbnb-prop-types';
+import classNames from 'classnames';
+import FontAwesomeStyles from 'font-awesome/css/font-awesome.min.css';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Button from '../Button';
+import { ExtraSmall, LargerThanExtraSmall } from '../Responsive';
+import getTextFromElement from '../utils/getTextFromElement';
+import Icon from '../Icon';
+import newId from '../utils/newId';
+
+import styles from './Pagination.scss';
+
+class Pagination extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.previousButtonRef = null;
+    this.nextButtonRef = null;
+
+    this.pageRefs = {};
+
+    this.state = {
+      currentPage: this.props.currentPage,
+      previousNextButtonClicked: false,
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (
+      nextProps.currentPage !== this.props.currentPage ||
+      nextProps.currentPage !== this.state.currentPage
+    ) {
+      this.setState({
+        currentPage: nextProps.currentPage,
+      });
+    }
+  }
+
+  componentDidUpdate() {
+    const { currentPage, previousNextButtonClicked } = this.state;
+    const currentPageRef = this.pageRefs[currentPage];
+
+    if (currentPageRef && !previousNextButtonClicked) {
+      currentPageRef.focus();
+    }
+  }
+
+  handlePageSelect(page) {
+    if (page !== this.state.currentPage) {
+      this.setState({
+        currentPage: page,
+        previousNextButtonClicked: false,
+      });
+      this.props.onPageSelect(page);
+    }
+  }
+
+  handlePreviousNextButtonClick(page) {
+    const { pageCount } = this.props;
+
+    this.setState({
+      currentPage: page,
+      previousNextButtonClicked: true,
+    });
+
+    if (page === 1) {
+      this.nextButtonRef.focus();
+    } else if (page === pageCount) {
+      this.previousButtonRef.focus();
+    }
+
+    this.props.onPageSelect(page);
+  }
+
+  renderEllipsisButton() {
+    return (
+      <li
+        className={classNames([styles['page-item'], styles.disabled])}
+        key={newId('pagination-ellipsis-')}
+      >
+        <span
+          className={classNames([
+            styles.btn,
+            styles['page-link'],
+            styles['ml-0'],
+            styles['border-0'],
+          ])}
+        >
+          ...
+        </span>
+      </li>
+    );
+  }
+
+  renderPageButton(page) {
+    const { buttonLabels } = this.props;
+    const active = page === this.state.currentPage || null;
+
+    const ariaLabel = getTextFromElement((
+      <div>
+        {buttonLabels.page}
+        {` ${page}`}
+        {active &&
+          <span>
+            {', '}
+            {buttonLabels.currentPage}
+          </span>
+        }
+      </div>
+    ));
+
+    return (
+      <li
+        className={classNames([
+          styles['page-item'],
+          {
+            [styles.active]: active,
+          },
+        ])}
+        key={page}
+      >
+        <Button
+          className={[styles['page-link']]}
+          aria-label={ariaLabel}
+          label={page.toString()}
+          inputRef={(element) => { this.pageRefs[page] = element; }}
+          onClick={() => { this.handlePageSelect(page); }}
+        />
+      </li>
+    );
+  }
+
+  renderPageOfCountButton() {
+    const { currentPage } = this.state;
+    const { pageCount, buttonLabels } = this.props;
+
+    const ariaLabel = getTextFromElement((
+      <div>
+        {buttonLabels.page}
+        {` ${currentPage}, `}
+        {buttonLabels.currentPage}
+        {', '}
+        {buttonLabels.pageOfCount}
+        {` ${pageCount}`}
+      </div>
+    ));
+
+    const label = (
+      <span>
+        {`${currentPage} `}
+        {buttonLabels.pageOfCount}
+        {` ${pageCount}`}
+      </span>
+    );
+
+    return (
+      <li
+        className={classNames([styles['page-item'], styles.disabled])}
+        key={currentPage}
+      >
+        <span
+          className={classNames([
+            styles.btn,
+            styles['page-link'],
+            styles['mx-2'],
+            styles['border-0'],
+          ])}
+          aria-label={ariaLabel}
+        >
+          {label}
+        </span>
+      </li>
+    );
+  }
+
+  renderPreviousButton() {
+    const { buttonLabels } = this.props;
+    const { currentPage } = this.state;
+    const isFirstPage = currentPage === 1;
+    const previousPage = isFirstPage ? null : currentPage - 1;
+
+    const ariaLabel = getTextFromElement((
+      <div>
+        {buttonLabels.previous}
+        {previousPage &&
+          <span>
+            {', '}
+            {buttonLabels.page}
+            {` ${previousPage}`}
+          </span>
+        }
+      </div>
+    ));
+
+    return (
+      <li
+        className={classNames(
+          'page-item',
+          {
+            [styles.disabled]: isFirstPage,
+          },
+        )}
+      >
+        <Button
+          className={['previous', styles['page-link']]}
+          aria-label={ariaLabel}
+          label={
+            <div>
+              <Icon
+                id={newId('pagination-')}
+                className={[
+                  FontAwesomeStyles.fa,
+                  FontAwesomeStyles['fa-chevron-left'],
+                  styles['mr-2'],
+                ]}
+              />
+              {buttonLabels.previous}
+            </div>
+          }
+          tabIndex={isFirstPage ? '-1' : undefined}
+          onClick={() => { this.handlePreviousNextButtonClick(previousPage); }}
+          inputRef={(element) => { this.previousButtonRef = element; }}
+          disabled={isFirstPage}
+        />
+      </li>
+    );
+  }
+
+  renderNextButton() {
+    const { buttonLabels, pageCount } = this.props;
+    const { currentPage } = this.state;
+    const isLastPage = currentPage === pageCount;
+    const nextPage = isLastPage ? null : currentPage + 1;
+
+    const ariaLabel = getTextFromElement((
+      <div>
+        {buttonLabels.next}
+        {nextPage &&
+          <span>
+            {', '}
+            {buttonLabels.page}
+            {` ${nextPage}`}
+          </span>
+        }
+      </div>
+    ));
+
+    return (
+      <li
+        className={classNames(
+          styles['page-item'],
+          {
+            disabled: isLastPage,
+          },
+        )}
+      >
+        <Button
+          className={['next', styles['page-link']]}
+          aria-label={ariaLabel}
+          label={
+            <div>
+              {buttonLabels.next}
+              <Icon
+                id={newId('pagination-')}
+                className={[
+                  FontAwesomeStyles.fa,
+                  FontAwesomeStyles['fa-chevron-right'],
+                  styles['ml-2'],
+                ]}
+              />
+            </div>
+          }
+          tabIndex={isLastPage ? '-1' : undefined}
+          onClick={() => { this.handlePreviousNextButtonClick(nextPage); }}
+          inputRef={(element) => { this.nextButtonRef = element; }}
+          disabled={isLastPage}
+        />
+      </li>
+    );
+  }
+
+  renderScreenReaderSection() {
+    const { currentPage } = this.state;
+    const { buttonLabels, pageCount } = this.props;
+    return (
+      <div
+        className="sr-only"
+        aria-live="polite"
+        aria-relevant="text"
+        aria-atomic
+      >
+        {
+          getTextFromElement((
+            <div>
+              {buttonLabels.page}
+              {` ${currentPage}, `}
+              {buttonLabels.currentPage}
+              {', '}
+              {buttonLabels.pageOfCount}
+              {` ${pageCount}`}
+            </div>
+          ))
+        }
+      </div>
+    );
+  }
+
+  /*
+   * Uses recursion to generate an array of the buttons to display (i.e., page/ellipsis
+   * buttons) given the currently selected page, the max number of buttons to display, and
+   * the total number of pages.
+   */
+  renderPageButtons(range) {
+    const { currentPage } = this.state;
+    const { pageCount, maxPagesDisplayed } = this.props;
+
+    const pageRange = range || [...Array(pageCount).keys()].map(page => page + 1);
+    const currentIndex = pageRange.indexOf(currentPage);
+    const middleIndex = parseInt(pageRange.length / 2, 10) - 1;
+    const lastIndex = pageRange.length - 1;
+    const hasLeftEllipsis = pageRange[1] - pageRange[0] > 1;
+    const hasRightEllipsis = pageRange[lastIndex] - pageRange[lastIndex - 1] > 1;
+
+    let ellipsisCount = 0;
+
+    ellipsisCount += hasLeftEllipsis;
+    ellipsisCount += hasRightEllipsis;
+
+    if (pageRange.length <= maxPagesDisplayed - ellipsisCount) {
+      return pageRange.map((page) => {
+        const pageButtons = [this.renderPageButton(page)];
+
+        if (page === 1 && hasLeftEllipsis) {
+          pageButtons.push(this.renderEllipsisButton());
+        } else if (page === pageCount && hasRightEllipsis) {
+          pageButtons.unshift(this.renderEllipsisButton());
+        }
+
+        return pageButtons;
+      });
+    }
+
+    if (currentIndex > middleIndex) {
+      const first = pageRange.shift();
+      pageRange.shift();
+      pageRange.unshift(first);
+    } else {
+      const last = pageRange.pop();
+      pageRange.pop();
+      pageRange.push(last);
+    }
+
+    return this.renderPageButtons(pageRange);
+  }
+
+  render() {
+    return (
+      <nav
+        aria-label={this.props.paginationLabel}
+        className={this.props.className}
+      >
+        {this.renderScreenReaderSection()}
+        <ul className={styles.pagination}>
+          {this.renderPreviousButton()}
+          <ExtraSmall>
+            {this.renderPageOfCountButton()}
+          </ExtraSmall>
+          <LargerThanExtraSmall>
+            {this.renderPageButtons()}
+          </LargerThanExtraSmall>
+          {this.renderNextButton()}
+        </ul>
+      </nav>
+    );
+  }
+}
+
+Pagination.defaultProps = {
+  buttonLabels: {
+    previous: 'Previous',
+    next: 'Next',
+    page: 'Page',
+    currentPage: 'Current Page',
+    pageOfCount: 'of',
+  },
+  className: '',
+  currentPage: 1,
+  maxPagesDisplayed: 7,
+};
+
+Pagination.propTypes = {
+  onPageSelect: PropTypes.func.isRequired,
+  pageCount: PropTypes.number.isRequired,
+  paginationLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  buttonLabels: PropTypes.shape({
+    previous: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    next: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    page: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    currentPage: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    pageOfCount: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  }),
+  className: PropTypes.string,
+  currentPage: PropTypes.number,
+  maxPagesDisplayed: between({ gt: 4 }),
+};
+
+export default Pagination;

--- a/src/Responsive/README.md
+++ b/src/Responsive/README.md
@@ -1,0 +1,28 @@
+# Responsive
+
+Provides several wrapper components that support hiding/showing components for specific screen sizes based on [Bootstrap's responsive breakpoints](https://getbootstrap.com/docs/4.0/layout/overview/#responsive-breakpoints). This enables `Paragon` components to create mobile-specific UIs (e.g., simplifying the UX of `Pagination` for mobile devices).
+
+The following responsive components are available:
+
+1. `ExtraSmall` (max-width: 575)
+2. `Small` (min-width: 576; max-width: 767)
+3. `Medium` (min-width: 768; max-width: 991)
+4. `Large` (min-width: 992; max-width: 1199)
+5. `ExtraLarge` (min-width: 1200)
+6. `LargerThanExtraSmall` (min-width: 576)
+
+## Example Usage
+
+```jsx
+<ExtraSmall>
+    <p>This text will only show on extra small screens.</p>
+</ExtraSmall>
+
+<Large>
+    <p>This text will only show on large screens.</p>
+</Large>
+
+<LargerThanExtraSmall>
+    <p>This text will only show on screens larger than extra small.</p>
+</LargerThanExtraSmall>
+```

--- a/src/Responsive/Responsive.test.jsx
+++ b/src/Responsive/Responsive.test.jsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import '../utils/reactResponsive.mock';
+
+import {
+  breakpoints,
+  ExtraSmall,
+  Small,
+  Medium,
+  Large,
+  ExtraLarge,
+  LargerThanExtraSmall,
+} from './index';
+
+describe('<ExtraSmall />', () => {
+  it('should render children for extra small displays', () => {
+    global.innerWidth = breakpoints.extraSmall.maxWidth;
+
+    const wrapper = mount((
+      <ExtraSmall>
+        <p>Hello world</p>
+      </ExtraSmall>
+    ));
+    expect(wrapper.find('p')).toHaveLength(1);
+  });
+
+  it('should not render children for larger than extra small displays', () => {
+    global.innerWidth = breakpoints.small.minWidth;
+
+    const wrapper = mount((
+      <ExtraSmall>
+        <p>Hello world</p>
+      </ExtraSmall>
+    ));
+    expect(wrapper.find('p')).toHaveLength(0);
+  });
+});
+
+describe('<Small />', () => {
+  it('should render children for small displays', () => {
+    global.innerWidth = breakpoints.small.maxWidth;
+
+    const wrapper = mount((
+      <Small>
+        <p>Hello world</p>
+      </Small>
+    ));
+    expect(wrapper.find('p')).toHaveLength(1);
+  });
+
+  it('should not render children for smaller than small displays', () => {
+    global.innerWidth = breakpoints.extraSmall.maxWidth;
+
+    const wrapper = mount((
+      <Small>
+        <p>Hello world</p>
+      </Small>
+    ));
+    expect(wrapper.find('p')).toHaveLength(0);
+  });
+
+  it('should not render children for larger than small displays', () => {
+    global.innerWidth = breakpoints.medium.minWidth;
+
+    const wrapper = mount((
+      <Small>
+        <p>Hello world</p>
+      </Small>
+    ));
+    expect(wrapper.find('p')).toHaveLength(0);
+  });
+});
+
+describe('<Medium />', () => {
+  it('should render children for medium displays', () => {
+    global.innerWidth = breakpoints.medium.maxWidth;
+
+    const wrapper = mount((
+      <Medium>
+        <p>Hello world</p>
+      </Medium>
+    ));
+    expect(wrapper.find('p')).toHaveLength(1);
+  });
+
+  it('should not render children for smaller than medium displays', () => {
+    global.innerWidth = breakpoints.small.maxWidth;
+
+    const wrapper = mount((
+      <Medium>
+        <p>Hello world</p>
+      </Medium>
+    ));
+    expect(wrapper.find('p')).toHaveLength(0);
+  });
+
+  it('should not render children for larger than medium displays', () => {
+    global.innerWidth = breakpoints.large.minWidth;
+
+    const wrapper = mount((
+      <Medium>
+        <p>Hello world</p>
+      </Medium>
+    ));
+    expect(wrapper.find('p')).toHaveLength(0);
+  });
+});
+
+describe('<Large />', () => {
+  it('should render children for large displays', () => {
+    global.innerWidth = breakpoints.large.maxWidth;
+
+    const wrapper = mount((
+      <Large>
+        <p>Hello world</p>
+      </Large>
+    ));
+    expect(wrapper.find('p')).toHaveLength(1);
+  });
+
+  it('should not render children for smaller than large displays', () => {
+    global.innerWidth = breakpoints.medium.maxWidth;
+
+    const wrapper = mount((
+      <Large>
+        <p>Hello world</p>
+      </Large>
+    ));
+    expect(wrapper.find('p')).toHaveLength(0);
+  });
+
+  it('should not render children for larger than large displays', () => {
+    global.innerWidth = breakpoints.extraLarge.minWidth;
+
+    const wrapper = mount((
+      <Large>
+        <p>Hello world</p>
+      </Large>
+    ));
+    expect(wrapper.find('p')).toHaveLength(0);
+  });
+});
+
+describe('<ExtraLarge />', () => {
+  it('should render children for extra large displays', () => {
+    global.innerWidth = breakpoints.extraLarge.minWidth;
+
+    const wrapper = mount((
+      <ExtraLarge>
+        <p>Hello world</p>
+      </ExtraLarge>
+    ));
+    expect(wrapper.find('p')).toHaveLength(1);
+  });
+
+  it('should not render children for smaller than extra large displays', () => {
+    global.innerWidth = breakpoints.large.maxWidth;
+
+    const wrapper = mount((
+      <ExtraLarge>
+        <p>Hello world</p>
+      </ExtraLarge>
+    ));
+    expect(wrapper.find('p')).toHaveLength(0);
+  });
+});
+
+describe('<ExtraLarge />', () => {
+  it('should render children for larger than extra small displays', () => {
+    global.innerWidth = breakpoints.small.minWidth;
+
+    const wrapper = mount((
+      <LargerThanExtraSmall>
+        <p>Hello world</p>
+      </LargerThanExtraSmall>
+    ));
+    expect(wrapper.find('p')).toHaveLength(1);
+  });
+
+  it('should not render children for extra small displays', () => {
+    global.innerWidth = breakpoints.extraSmall.maxWidth;
+
+    const wrapper = mount((
+      <LargerThanExtraSmall>
+        <p>Hello world</p>
+      </LargerThanExtraSmall>
+    ));
+    expect(wrapper.find('p')).toHaveLength(0);
+  });
+});

--- a/src/Responsive/index.jsx
+++ b/src/Responsive/index.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import Responsive from 'react-responsive';
+
+// NOTE: These are the breakpoints used in Bootstrap v4.0.0 as seen in
+// the documentation (https://getbootstrap.com/docs/4.0/layout/overview/#responsive-breakpoints)
+const breakpoints = {
+  extraSmall: {
+    maxWidth: 575.98,
+  },
+  small: {
+    minWidth: 576,
+    maxWidth: 767.98,
+  },
+  medium: {
+    minWidth: 768,
+    maxWidth: 991.98,
+  },
+  large: {
+    minWidth: 992,
+    maxWidth: 1199.98,
+  },
+  extraLarge: {
+    minWidth: 1200,
+  },
+};
+
+// Extra small devices (portrait phones)
+const ExtraSmall = props => (
+  <Responsive
+    {...props}
+    maxWidth={breakpoints.extraSmall.maxWidth}
+  />
+);
+
+// Small devices (landscape phones)
+const Small = props => (
+  <Responsive
+    {...props}
+    minWidth={breakpoints.small.minWidth}
+    maxWidth={breakpoints.small.maxWidth}
+  />
+);
+
+// Medium devices (tablets)
+const Medium = props => (
+  <Responsive
+    {...props}
+    minWidth={breakpoints.medium.minWidth}
+    maxWidth={breakpoints.medium.maxWidth}
+  />
+);
+
+// Large devices (desktops)
+const Large = props => (
+  <Responsive
+    {...props}
+    minWidth={breakpoints.large.minWidth}
+    maxWidth={breakpoints.large.maxWidth}
+  />
+);
+
+// Extra large devices (large desktops)
+const ExtraLarge = props => (
+  <Responsive
+    {...props}
+    minWidth={breakpoints.extraLarge.minWidth}
+  />
+);
+
+const LargerThanExtraSmall = props => (
+  <Responsive
+    {...props}
+    minWidth={breakpoints.small.minWidth}
+  />
+);
+
+export {
+  breakpoints,
+  ExtraSmall,
+  Small,
+  Medium,
+  Large,
+  ExtraLarge,
+  LargerThanExtraSmall,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,16 @@ import ListBox from './ListBox';
 import ListBoxOption from './ListBoxOption';
 import MailtoLink from './MailtoLink';
 import Modal from './Modal';
+import Pagination from './Pagination';
 import RadioButtonGroup, { RadioButton } from './RadioButtonGroup';
+import {
+  ExtraSmall,
+  Small,
+  Medium,
+  Large,
+  ExtraLarge,
+  LargerThanExtraSmall,
+} from './Responsive';
 import SearchField from './SearchField';
 import StatusAlert from './StatusAlert';
 import Table from './Table';
@@ -26,18 +35,25 @@ export {
   CheckBox,
   CheckBoxGroup,
   Dropdown,
+  ExtraLarge,
+  ExtraSmall,
   Fieldset,
   Hyperlink,
   Icon,
   InputSelect,
   InputText,
+  Large,
+  LargerThanExtraSmall,
   ListBox,
   ListBoxOption,
   MailtoLink,
+  Medium,
   Modal,
+  Pagination,
   RadioButtonGroup,
   RadioButton,
   SearchField,
+  Small,
   StatusAlert,
   Table,
   Tabs,

--- a/src/utils/getTextFromElement.js
+++ b/src/utils/getTextFromElement.js
@@ -1,0 +1,12 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import sanitizeHtml from 'sanitize-html';
+
+const getTextFromElement = element => sanitizeHtml(
+  renderToStaticMarkup(element),
+  {
+    allowedTags: [],
+    allowedAttributes: [],
+  },
+);
+
+export default getTextFromElement;

--- a/src/utils/reactResponsive.mock.js
+++ b/src/utils/reactResponsive.mock.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { MediaQueryProps } from 'react-responsive';
+
+// We have to rename the below variables to start with `mock` so
+// that `jest.mock` doesn't complain.
+const mockWindow = window;
+const mockReact = React;
+const mockMediaQueryProps = MediaQueryProps;
+
+// Because some Paragon components (e.g., `Pagination`) render a different UI depending on screen
+// size using the `Responsive` components, we must mock the window size in our tests. To change
+// the window size for a specific test, include `global.innerWidth = <width>`.
+jest.mock('react-responsive', () => {
+  const MediaQuery = require.requireActual('react-responsive').default;
+
+  const MockMediaQuery = (props = mockMediaQueryProps) => {
+    const defaultWidth = mockWindow.innerWidth;
+    const defaultHeight = mockWindow.innerHeight;
+    const values = Object.assign({}, { width: defaultWidth, height: defaultHeight }, props.values);
+    const newProps = Object.assign({}, props, { values });
+
+    return mockReact.createElement(MediaQuery, newProps);
+  };
+
+  return MockMediaQuery;
+});

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,9 +1,0 @@
-import newId from './newId';
-
-describe('newId', () => {
-  it('increments on each call', () => {
-    expect(newId()).toEqual('id1');
-    expect(newId('foo-')).toEqual('foo-2');
-    expect(newId('bar-')).toEqual('bar-3');
-  });
-});

--- a/src/utils/utils.test.jsx
+++ b/src/utils/utils.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import newId from './newId';
+import getTextFromElement from './getTextFromElement';
+
+describe('newId', () => {
+  it('increments on each call', () => {
+    expect(newId()).toEqual('id1');
+    expect(newId('foo-')).toEqual('foo-2');
+    expect(newId('bar-')).toEqual('bar-3');
+  });
+});
+
+describe('getTextFromElement', () => {
+  it('should return text from element', () => {
+    const element = (
+      <div>
+        <h1>Foo</h1>
+        <span>bar</span>
+      </div>
+    );
+    expect(getTextFromElement(element)).toEqual('Foobar');
+  });
+});


### PR DESCRIPTION
This PR adds an accessible and responsive `Pagination` component ([view demo](http://stale-cause.surge.sh/?selectedKind=Pagination)):

#### Desktop
![image](https://user-images.githubusercontent.com/2828721/41522823-b2a0501e-72a5-11e8-95a1-633259ab5fdd.png)

#### Mobile
![image](https://user-images.githubusercontent.com/2828721/41522829-b8cb264e-72a5-11e8-80c5-e85e00fb151a.png)

To make the `Pagination` component responsive, I am using [`react-responsive`](https://github.com/contra/react-responsive) to create several wrapper components that render its children depending on window size, according to the [Bootstrap-defined breakpoints](https://getbootstrap.com/docs/4.0/layout/overview/#responsive-breakpoints) (e.g., `<ExtraSmall>` will only render its children for window sizes less than `576px`).

Another thing to note is that the `aria-label` attribute on buttons is dynamically created to be more understandable and descriptive for screen readers. For example, when tabbing between pages, the `aria-label` for a currently selected page would be `Page 1, Current Page` whereas the `aria-label` for a page not currently selected would read `Page 2`.

Unfortunately, a simple string is not sufficient for these dynamic `aria-label`s due to i18n support (e.g., using an element for the labels as in the case of the [`WrappedMessage` component](https://github.com/edx/studio-frontend/blob/master/src/utils/i18n/formattedMessageWrapper.jsx) in studio-frontend). 

By default, when trying to output an element as a string, it will return as an object and not a human-readable string of the element's text. As a result, I introduce a utility function `getTextFromElement` which accepts an element and returns the raw text of the element through the use of [`renderToStaticMarkup`](https://reactjs.org/docs/react-dom-server.html#rendertostaticmarkup) and [`sanitize-html`](https://github.com/punkave/sanitize-html).