### PR TITLE
Add sort button refs to Table

### DIFF
--- a/src/Table/index.jsx
+++ b/src/Table/index.jsx
@@ -11,6 +11,8 @@ class Table extends React.Component {
   constructor(props) {
     super(props);
 
+    this.sortButtonRefs = {};
+
     this.state = {
       sortedColumn: props.tableSortable ? this.props.defaultSortedColumn : '',
       sortDirection: props.tableSortable ? this.props.defaultSortDirection : '',
@@ -78,6 +80,7 @@ class Table extends React.Component {
             {this.getSortIcon(column.key === this.state.sortedColumn ? this.state.sortDirection : '')}
           </span>}
         onClick={() => this.onSortClick(column.key)}
+        ref={(element) => { this.sortButtonRefs[column.key] = element; }}
       />);
     } else if (column.hideHeader) {
       heading = (<span className={classNames(styles['sr-only'])}>{column.label}</span>);


### PR DESCRIPTION
Creates `refs` for the sort `Button` components within the `Table` column headers. 

The reason for this functionality is something I've run into when retrieving new data from the API (i.e., after clicking on one of the sort buttons in the column headers), the `Table` component is re-rendered due to containing new data. The user's focus _should_ remain on the column header, but the re-rendering causes the user's focus to disappear from the column header.

In order to put focus back on the column header, the parent component (i.e., the one that uses the `Table` component) needs access to the sort button `ref`.

With the `refs`, the parent component can then call `buttonRef.focus()` on the appropriate sort button once the parent component is re-rendered to put the focus back on the column header sort button.

Example usage from parent component:
```jsx
<Table
  ...
  ref={(element) => { this.tableRef = element; }}
/>
```

```javascript
const { sortedColumn } = this.tableRef.state;
const sortedColumnButtonRef = this.tableRef.sortButtonRefs[sortedColumn].buttonRef;
sortedColumnButtonRef.focus();
```

_**Note:** This was just the first idea I had that seems to work. If you have any other suggestions, please let me know!_ 😄