### PR TITLE
fix(pagination): set focus only for explicitly clicked pages

### DIFF
--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -23,7 +23,7 @@ class Pagination extends React.Component {
 
     this.state = {
       currentPage: this.props.currentPage,
-      previousNextButtonClicked: false,
+      pageButtonSelected: false,
     };
   }
 
@@ -39,19 +39,24 @@ class Pagination extends React.Component {
   }
 
   componentDidUpdate() {
-    const { currentPage, previousNextButtonClicked } = this.state;
+    const { currentPage, pageButtonSelected } = this.state;
     const currentPageRef = this.pageRefs[currentPage];
 
-    if (currentPageRef && !previousNextButtonClicked) {
+    if (currentPageRef && pageButtonSelected) {
       currentPageRef.focus();
+      this.setPageButtonSelectedState(false);
     }
+  }
+
+  setPageButtonSelectedState(value) {
+    this.setState({ pageButtonSelected: value });
   }
 
   handlePageSelect(page) {
     if (page !== this.state.currentPage) {
       this.setState({
         currentPage: page,
-        previousNextButtonClicked: false,
+        pageButtonSelected: true,
       });
       this.props.onPageSelect(page);
     }
@@ -60,17 +65,12 @@ class Pagination extends React.Component {
   handlePreviousNextButtonClick(page) {
     const { pageCount } = this.props;
 
-    this.setState({
-      currentPage: page,
-      previousNextButtonClicked: true,
-    });
-
     if (page === 1) {
       this.nextButtonRef.focus();
     } else if (page === pageCount) {
       this.previousButtonRef.focus();
     }
-
+    this.setState({ currentPage: page });
     this.props.onPageSelect(page);
   }
 


### PR DESCRIPTION
Settings the focus in `componentDidUpdate` is for when a page button is clicked when there are ellipses included in the pagination. The buttons are re-rendered so the originally clicked button element no longer exists in the DOM, so the focus is lost. The logic in `componentDidUpdate` puts the focus back on the appropriate button.

However, the current logic puts the focus on the current page button when the `currentPage` prop is changed, which causes the `Pagination` component to "steal" the focus on the page incorrectly.

As such, this PR updates the `componentDidUpdate` logic to only set focus if a page button was explicitly clicked.