### PR TITLE
fix(dropdown): select menu item by keyboard, menu items as elements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,12 @@
   },
   "rules": {
     "react/no-array-index-key": "off",
-    "compat/compat": "error"
+    "compat/compat": "error",
+    "jsx-a11y/anchor-is-valid": [ "error", {
+      "components": [ "a" ],
+      "specialLink": [ "hrefLeft", "hrefRight" ],
+      "aspects": [ "noHref", "invalidHref", "preferButton" ]
+    }]
   },
   "settings": {
     "import/resolver": {

--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -7084,6 +7084,523 @@ exports[`Storyshots Dropdown basic usage 1`] = `
 </div>
 `;
 
+exports[`Storyshots Dropdown menu items as elements 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": 0,
+      "display": "flex",
+      "justifyContent": "center",
+      "left": 0,
+      "overflow": "auto",
+      "position": "fixed",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+      }
+    }
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          className="dropdown"
+        >
+          <button
+            aria-expanded={false}
+            aria-haspopup="true"
+            className="btn dropdown-toggle btn-light"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            type="button"
+          >
+            Search Engines
+          </button>
+          <div
+            aria-hidden={true}
+            aria-label="Search Engines"
+            className="dropdown-menu"
+            role="menu"
+          >
+            <a
+              className="dropdown-item"
+              href="http://www.google.com"
+              onKeyDown={[Function]}
+            >
+              Google
+            </a>
+            <a
+              className="dropdown-item"
+              href="http://www.duckduckgo.com"
+              onKeyDown={[Function]}
+            >
+              DuckDuckGo
+            </a>
+            <a
+              className="dropdown-item"
+              href="http://www.yahoo.com"
+              onKeyDown={[Function]}
+            >
+              Yahoo
+            </a>
+          </div>
+        </div>
+      </div>
+      <button
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#28c",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+      <div
+        style={
+          Object {
+            "background": "white",
+            "bottom": 0,
+            "display": "none",
+            "left": 0,
+            "overflow": "auto",
+            "padding": "0 40px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+            "zIndex": 99999,
+          }
+        }
+      >
+        <button
+          onClick={[Function]}
+          style={
+            Object {
+              "background": "#28c",
+              "border": "none",
+              "borderRadius": "0 0 0 5px",
+              "color": "#fff",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "sans-serif",
+              "fontSize": "12px",
+              "padding": "5px 15px",
+              "position": "fixed",
+              "right": 0,
+              "top": 0,
+            }
+          }
+          type="button"
+        >
+          ×
+        </button>
+        <div
+          style={undefined}
+        >
+          <div
+            style={
+              Object {
+                "WebkitFontSmoothing": "antialiased",
+                "backgroundColor": "#fff",
+                "border": "1px solid #eee",
+                "borderRadius": "2px",
+                "boxShadow": "0px 2px 3px rgba(0, 0, 0, 0.05)",
+                "color": "#444",
+                "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+                "fontSize": "15px",
+                "fontWeight": 300,
+                "lineHeight": 1.45,
+                "marginBottom": "20px",
+                "marginTop": "20px",
+                "padding": "20px 40px 40px",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "borderBottom": "1px solid #eee",
+                  "marginBottom": 10,
+                  "paddingTop": 10,
+                }
+              }
+            >
+              <h1
+                style={
+                  Object {
+                    "fontSize": "35px",
+                    "margin": 0,
+                    "padding": 0,
+                  }
+                }
+              >
+                Dropdown
+              </h1>
+              <h2
+                style={
+                  Object {
+                    "fontSize": "22px",
+                    "fontWeight": 400,
+                    "margin": "0 0 10px 0",
+                    "padding": 0,
+                  }
+                }
+              >
+                menu items as elements
+              </h2>
+            </div>
+            
+            <div>
+              <h1
+                style={
+                  Object {
+                    "borderBottom": "1px solid #EEE",
+                    "fontSize": "25px",
+                    "margin": "20px 0 0 0",
+                    "padding": "0 0 5px 0",
+                  }
+                }
+              >
+                Story Source
+              </h1>
+              <pre
+                className="css-4akams"
+              >
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "paddingLeft": 18,
+                        "paddingRight": 3,
+                      }
+                    }
+                  >
+                    <span
+                      style={
+                        Object {
+                          "color": "#777",
+                        }
+                      }
+                    >
+                      &lt;
+                      Dropdown
+                    </span>
+                    <span>
+                      <span>
+                         
+                        <span
+                          style={Object {}}
+                        >
+                          title
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Search Engines
+                              "
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span>
+                         
+                        <span
+                          style={Object {}}
+                        >
+                          menuItems
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                [
+                                <span>
+                                  {
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    &lt;a /&gt;
+                                  </span>
+                                  }
+                                </span>
+                                , 
+                                <span>
+                                  {
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    &lt;a /&gt;
+                                  </span>
+                                  }
+                                </span>
+                                , 
+                                <span>
+                                  {
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    &lt;a /&gt;
+                                  </span>
+                                  }
+                                </span>
+                                ]
+                              </span>
+                              }
+                            </span>
+                          </span>
+                        </span>
+                         
+                      </span>
+                    </span>
+                    <span
+                      style={
+                        Object {
+                          "color": "#777",
+                        }
+                      }
+                    >
+                      /&gt;
+                    </span>
+                  </div>
+                </div>
+                <button
+                  className="css-gydez8"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="css-kv47nt"
+                  >
+                    <div
+                      style={
+                        Object {
+                          "marginBottom": 6,
+                        }
+                      }
+                    >
+                      Copied!
+                    </div>
+                    <div>
+                      Copy
+                    </div>
+                  </div>
+                </button>
+              </pre>
+            </div>
+            <div>
+              <h1
+                style={
+                  Object {
+                    "borderBottom": "1px solid #EEE",
+                    "fontSize": "25px",
+                    "margin": "20px 0 0 0",
+                    "padding": "0 0 5px 0",
+                  }
+                }
+              >
+                Prop Types
+              </h1>
+              <div>
+                <h2
+                  style={
+                    Object {
+                      "margin": "20px 0 0 0",
+                    }
+                  }
+                >
+                  "
+                  Dropdown
+                  " Component
+                </h2>
+                <table
+                  className="css-1ytzlk7"
+                >
+                  <thead>
+                    <tr>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        property
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        propType
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        required
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        default
+                      </th>
+                      <th
+                        className="css-d52hbj"
+                      >
+                        description
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        buttonType
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#22a",
+                              "wordBreak": "break-word",
+                            }
+                          }
+                        >
+                          "
+                          light
+                          "
+                        </span>
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        menuItems
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                    <tr>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        title
+                      </td>
+                      <td
+                        className="css-1ygfcef"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        yes
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      >
+                        -
+                      </td>
+                      <td
+                        className="css-d52hbj"
+                      />
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Fieldset basic usage 1`] = `
 <div
   style={

--- a/src/Dropdown/Dropdown.stories.jsx
+++ b/src/Dropdown/Dropdown.stories.jsx
@@ -32,4 +32,14 @@ storiesOf('Dropdown', module)
         },
       ]}
     />
+  ))
+  .add('menu items as elements', () => (
+    <Dropdown
+      title="Search Engines"
+      menuItems={[
+        <a href="http://www.google.com">Google</a>,
+        <a href="http://www.duckduckgo.com">DuckDuckGo</a>,
+        <a href="http://www.yahoo.com">Yahoo</a>,
+      ]}
+    />
   ));

--- a/src/Dropdown/Dropdown.test.jsx
+++ b/src/Dropdown/Dropdown.test.jsx
@@ -1,8 +1,33 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { mount, shallow } from 'enzyme';
 
 import Dropdown, { triggerKeys } from './index';
+
+class Link extends React.Component {
+  render() {
+    const { to, children, innerRef } = this.props;
+    return (
+      <a
+        ref={innerRef}
+        href={to}
+      >
+        {children}
+      </a>
+    );
+  }
+}
+
+Link.propTypes = {
+  to: PropTypes.string.isRequired,
+  innerRef: PropTypes.func,
+  children: PropTypes.node.isRequired,
+};
+
+Link.defaultProps = {
+  innerRef: null,
+};
 
 const props = {
   title: 'Example',
@@ -82,6 +107,13 @@ describe('<Dropdown />', () => {
         menuOpen(false, wrapper);
       });
 
+      it(`on menu item ${key}`, () => {
+        wrapper.find('a').at(0).simulate('keyDown', { key });
+        menuOpen(false, wrapper);
+      });
+    });
+
+    triggerKeys.SELECT_MENU_ITEM.forEach((key) => {
       it(`on menu item ${key}`, () => {
         wrapper.find('a').at(0).simulate('keyDown', { key });
         menuOpen(false, wrapper);
@@ -176,5 +208,23 @@ describe('<Dropdown />', () => {
         expect(wrapper.find('Button').html()).toEqual(document.activeElement.outerHTML);
       });
     });
+  });
+
+  it('accepts menuItems prop with array of elements', () => {
+    const wrapper = mount((
+      <Dropdown
+        {...props}
+        menuItems={[
+          <Link to="http://www.google.com">Google</Link>,
+          <Link to="http://www.duckduckgo.com">DuckDuckGo</Link>,
+          <Link to="http://www.yahoo.com">Yahoo</Link>,
+        ]}
+      />
+    ));
+
+    menuOpen(false, wrapper);
+    wrapper.find('Button').simulate('click');
+    menuOpen(true, wrapper);
+    expect(wrapper.find('a')).toHaveLength(3);
   });
 });

--- a/src/Dropdown/README.md
+++ b/src/Dropdown/README.md
@@ -7,8 +7,8 @@ Provides a dropdown component that will maintain focus and keyboard navigation o
 ### `buttonType` (string; optional)
 `buttonType` is used to determine the type of button to be rendered.  See [Bootstrap's buttons documentation](https://getbootstrap.com/docs/4.0/components/buttons/) for a list of applicable button types. The default is `buttonType="light"`.
 
-### `menuItems` (shape array; required)
-`menuItems` specifies the list of items that will be rendered within the dropdown for selection.  It takes in the type `shape` that appears a Javascript object containing the menu item `label` and the `href` properties as strings.
+### `menuItems` (shape array or element array; required)
+`menuItems` specifies the list of items that will be rendered within the dropdown for selection.  It accepts an array of either: 1) Javascript objects containing the menu item `label` and the `href` properties as strings; or 2) React/HTML elements.
 
 ### `title` (string; required)
 `title` specifies the text that is displayed within the original dropdown button.


### PR DESCRIPTION
Allows the user to pass in an array of elements to the `menuItems` prop. The use case for this is using the `Dropdown` component for navigation within a single-page application that uses `react-router` where the menu item should be a `Link` component, not an anchor tag.

Additionally, this makes it so that the user can trigger a click on a focused menu item (i.e., to actually be able to click the anchor tag/element).