### PR TITLE
fix(webpack): pass process.env.NODE_ENV to DefinePlugin for prod builds

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
@@ -32,6 +33,9 @@ module.exports = targetProperties.map(config => ({
       sourceMap: true,
     }),
     new ExtractTextPlugin(`${config.baseDirectory}/paragon.min.css`),
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+    }),
   ],
   module: {
     rules: [


### PR DESCRIPTION
To support production builds you must pass 'production' as the process.env.NODE_ENV variable to webpack modules through DefinePlugin. This allows modules like react-dom to know they are building in a production environment.  This is outlined in the react documentation here: https://reactjs.org/docs/optimizing-performance.html#webpack

While we were setting the NODE_ENV when building in the package.json file, we weren't passing it through DefinePlugin.

This was resulting in bundles that included unexpected libraries such as react-dom, even though they were included as externals (react-dom-server.browser.development.js):

#### Before
![screen shot 2018-08-06 at 2 42 19 pm](https://user-images.githubusercontent.com/1643389/43736118-851e94b4-998a-11e8-97a8-a0e01fd1cb91.png)

#### After
![screen shot 2018-08-06 at 2 54 02 pm](https://user-images.githubusercontent.com/1643389/43736777-deb73376-998c-11e8-9ea6-cddf84e85681.png)


~~By fixing this, we are no longer including react-dom in our bundle.~~ Spoke too soon, looks like react-dom is still here, but at least its the production version. Still not sure why this isn't being excluded since it's listed in externals. This also decreased the bundle size of the minified javascript from 583092 bytes to 465799 bytes.

React-dom in particular was causing an issue when paragon was included in another projects production build. If renderToStaticMarkup() was called the error `Cannot set property 'getCurrentStack' of undefined` was thrown due to the mix of production react and development react-dom. We encountered this in the edx-portal project. A similar issue was mentioned here https://github.com/facebook/react/issues/13276#issuecomment-408232369