### PR TITLE
fix(searchfield): .search-field.focused style fix

### DIFF
--- a/src/SearchField/SearchField.scss
+++ b/src/SearchField/SearchField.scss
@@ -31,7 +31,7 @@ $search-field-border-radius: 30px;
     }
 
     &.focused {
-        border-color: $blue;
+        border-color: $blue !important;
         box-shadow: $input-focus-box-shadow;
     }
     


### PR DESCRIPTION
One last style fix for the `SearchField` component. The `.focused` class `border-color` property requires `!important` to take precedence over Bootstrap.