### PR TITLE
docs(hyperlinkicon): update HyperLink story to include example with Icon

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -14214,9 +14214,18 @@ exports[`Storyshots HyperLink with icon as content 1`] = `
           onClick={[Function]}
           target="_self"
         >
-          <span
-            className="fa fa-book"
-          />
+          <span>
+            <span
+              aria-hidden={true}
+              className="fa fa-book"
+              id="SampleIcon"
+            />
+            <span
+              className="sr-only"
+            >
+              Visit edX Home
+            </span>
+          </span>
         </a>
       </div>
       <button
@@ -14419,7 +14428,7 @@ exports[`Storyshots HyperLink with icon as content 1`] = `
                                   }
                                 }
                               >
-                                &lt;span /&gt;
+                                &lt;Icon /&gt;
                               </span>
                               }
                             </span>

--- a/src/Hyperlink/Hyperlink.stories.jsx
+++ b/src/Hyperlink/Hyperlink.stories.jsx
@@ -13,6 +13,7 @@ import 'font-awesome/css/font-awesome.min.css';
 import README from './README.md';
 
 import Hyperlink from './index';
+import Icon from '../Icon/index';
 
 setConsoleOptions({
   panelExclude: ['warn', 'error'],
@@ -48,6 +49,11 @@ storiesOf('HyperLink', module)
   .add('with icon as content', () => (
     <Hyperlink
       destination="https://www.edx.org"
-      content={(<span className="fa fa-book" />)}
+      content={(
+        <Icon
+          id="SampleIcon"
+          className={['fa', 'fa-book']}
+          screenReaderText="Visit edX Home"
+        />)}
     />
   ));

--- a/src/Icon/README.md
+++ b/src/Icon/README.md
@@ -16,5 +16,5 @@ Provides the ability to have a basic accessibility friendly Icon. The Icon has `
 ### `hidden` (boolean; optional)
 `hidden` is a boolean that determines the value of `aria-hidden` attribute on the Icon span, this value is `true` by default.
 
-### `screenReaderText` (string; optional)
-`screenReaderText` is a string that will be used on a secondary span leveraging the `sr-only` style for screenreader only text, this value is `undefined` by default.
+### `screenReaderText` (string; optional, but recommended)
+`screenReaderText` is a string that will be used on a secondary span leveraging the `sr-only` style for screenreader only text, this value is `undefined` by default. This value is recommended for use unless the Icon is being used in a way that is purely decorative or provides no additional context for screen reader users. This field should be thought of the same way an `alt` attribute would be used for `image` tags.


### PR DESCRIPTION
Update HyperLink story to use Icon component instead of inline span

Help to clarify https://github.com/edx/paragon/issues/325

FYI @edx/fedx-team 