### PR TITLE
(docs): initial ADR about using ADRs

### DIFF
--- a/docs/decisions/0001-record-architecture-decisions.rst
+++ b/docs/decisions/0001-record-architecture-decisions.rst
@@ -1,0 +1,32 @@
+1. Record Architecture Decisions
+--------------------------------
+
+Status
+------
+
+Accepted
+
+Context
+-------
+
+We would like to keep a historical record on the architectural
+decisions we make with this app as it evolves over time.
+
+Decision
+--------
+
+We will use Architecture Decision Records, as described by 
+Michael Nygard in `Documenting Architecture Decisions`_
+
+.. _Documenting Architecture Decisions: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+
+Consequences
+------------
+
+See Michael Nygard's article, linked above.
+
+References
+----------
+
+* https://resources.sei.cmu.edu/asset_files/Presentation/2017_017_001_497746.pdf
+* https://github.com/npryce/adr-tools/tree/master/doc/adr


### PR DESCRIPTION
We'd like to use Architectural Decision Records to document decisions
made about the future direction of the paragon pattern library. This
was approved by a voice vote at a meeting of the FedX group on
Thursday, 10/18/18.

Would love to see thumbs all around once more on this PR from @edx/fedx-team! 

Pushing this up to get the ball rolling w.r.t. ADRs, another one incoming directly after this! Just also wanted to see whether semantic release/our CI more generally will treat it how I think it ought to be treated.