### PR TITLE
fix(pagination): make styles consistently scoped

### DIFF
--- a/src/Pagination/Pagination.scss
+++ b/src/Pagination/Pagination.scss
@@ -1,6 +1,7 @@
 @import "~bootstrap/scss/_pagination";
 @import "~bootstrap/scss/_buttons";
 @import "~bootstrap/scss/_variables";
+@import "~bootstrap/scss/utilities/_screenreaders.scss";
 @import "~bootstrap/scss/utilities/_spacing";
 @import "~bootstrap/scss/utilities/_borders";
 

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -203,7 +203,7 @@ class Pagination extends React.Component {
     return (
       <li
         className={classNames(
-          'page-item',
+          styles['page-item'],
           {
             [styles.disabled]: isFirstPage,
           },
@@ -258,7 +258,7 @@ class Pagination extends React.Component {
         className={classNames(
           styles['page-item'],
           {
-            disabled: isLastPage,
+            [styles.disabled]: isLastPage,
           },
         )}
       >
@@ -292,7 +292,7 @@ class Pagination extends React.Component {
     const { buttonLabels, pageCount } = this.props;
     return (
       <div
-        className="sr-only"
+        className={classNames(styles['sr-only'])}
         aria-live="polite"
         aria-relevant="text"
         aria-atomic


### PR DESCRIPTION
The `.disabled` class in [renderPreviousButton()](https://github.com/edx/paragon/blob/master/src/Pagination/index.jsx#L208) works, whereas the one in renderNextButton() is not scoped correctly. This effects people using the static stylesheet who are trying to target those elements for custom styling, e.g. the back arrow will grey out, but the forward one won't. This PR makes them consistent and also adds scoping to `.sr-only` in the Pagination component similar to how it is in the Icon component.

**Dependencies**: None

**Merge deadline**: None

**Testing instructions**:

1. `npm run test` verifies that this PR does not change any rendered component.

**Reviewers**
- [ ] @mtyaka
- [ ] edX reviewer[s] TBD
