### PR TITLE
fix(dropdown): fixed DropDown focus on page load

### DIFF
--- a/src/Dropdown/Dropdown.test.jsx
+++ b/src/Dropdown/Dropdown.test.jsx
@@ -22,7 +22,7 @@ const menuOpen = (isOpen, wrapper) => {
 
 describe('<Dropdown />', () => {
   describe('renders', () => {
-    const wrapper = shallow(<Dropdown {...props} />);
+    const wrapper = mount(<Dropdown {...props} />);
     const menu = wrapper.find('.dropdown-menu');
     const button = wrapper.find('Button');
 
@@ -35,6 +35,12 @@ describe('<Dropdown />', () => {
 
     it('with menu closed', () => {
       menuOpen(false, wrapper);
+    });
+
+    it('does not get focus when updated', () => {
+      const activeElementHtml = document.activeElement.outerHTML;
+      wrapper.instance().forceUpdate();
+      expect(activeElementHtml).toEqual(document.activeElement.outerHTML);
     });
   });
 
@@ -168,6 +174,8 @@ describe('<Dropdown />', () => {
 
       it('does not toggle with invalid key', () => {
         wrapper = mount(<Dropdown {...props} />);
+        // resetting focus
+        wrapper.find('Button').getDOMNode().focus();
 
         menuOpen(false, wrapper);
         // open and close button to get focus on button

--- a/src/Dropdown/index.jsx
+++ b/src/Dropdown/index.jsx
@@ -43,10 +43,10 @@ class Dropdown extends React.Component {
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps, prevState) {
     if (this.state.open) {
       this.menuItems[this.state.focusIndex].focus();
-    } else if (this.toggleElem) {
+    } else if (prevState.open && this.toggleElem) {
       this.toggleElem.focus();
     }
   }


### PR DESCRIPTION
DropDown was getting **focused** for some unwanted scenarios, 
For example: on page load, if any parent component of DropDown updated, DropDown was getting focus,  as updates of DropDown was also getting called that was causing DropDown to get focus.  

Issue reference: [Story](https://openedx.atlassian.net/browse/WL-1828)