### PR TITLE
Creation of three new ADRs for paragon

### DIFF
--- a/docs/decisions/0003-repository-ownership.rst
+++ b/docs/decisions/0003-repository-ownership.rst
@@ -1,0 +1,38 @@
+3. Repository Ownership
+--------------------
+
+Status
+------
+
+Proposed
+
+Context
+-------
+
+Paragon components are currently in use in a variety of production IDAs and continue to be updated, improved, and extended by engineers throughout the organization. At the same time, the repository itself lacks explicit ownership and review processes from potential stakeholders, such as architecture, product, accessibility, and user experience. This combination of a frequently updated, mission critical library without consistent oversight is potentially a significant risk to the stability of our front ends.
+
+Meanwhile, the architecture team has been tasked with improving our codebase's overall approachability and extensibility, as well as our time-to-market for new features and applications, and has been explicitly looking at Paragon and our usage of bootstrap with respect to creating a comprehensive design system for the organization.
+
+Decision
+--------
+
+The architecture team will own Paragon to the extent that it will:
+
+- With the help of UX, accessibility, and product, document the requirements and best practices for updates and additions to Paragon's reusable components. ("I want to help you help me help you.")
+- Ensure that UX, accessibility, and product are given the opportunity to vett and sign off on changes to the library. ("Going once, going twice...")
+- Review Paragon pull requests with an eye toward ensuring that Paragon continues to be a flexible, consistent library of reusable components that fulfill our needs across the organization. ("Have you considered...")
+- Lead the charge on improving and fleshing out Paragon with the above goals in mind. ("Here, use this!")
+
+Consequences
+------------
+
+Establishing clear ownership roles and review criteria for Paragon should help ensure that code quality remains high, and that changes to the library are less likely to result in bugs and unexpected breaking changes. In addition, this ownership structure dovetails well with the architecture team's stated goal of improving our front end systems' approachability, extensibility, and the time to market of IDAs built on Paragon.
+
+This ownership will, of course, take up some of the architecture team's time above and beyond their current responsibilities. That said, documenting and disseminating the process and considerations for updating Paragon should help alleviate some of that strain by allowing pull request authors to do much of the due diligence themselves.
+
+References
+----------
+
+* https://github.com/edx/paragon/graphs/code-frequency (Paragon is in active development)
+* https://openedx.atlassian.net/wiki/spaces/AC/pages/787087363/Architecture+Roadmap+2018-19#ArchitectureRoadmap,2018-19-ArchitectureOGSP
+* https://www.designbetter.co/design-systems-handbook

--- a/docs/decisions/0003-repository-ownership.rst
+++ b/docs/decisions/0003-repository-ownership.rst
@@ -18,8 +18,8 @@ Decision
 
 The architecture team will own Paragon to the extent that it will:
 
-- With the help of UX, accessibility, and product, document the requirements and best practices for updates and additions to Paragon's reusable components. ("I want to help you help me help you.")
-- Ensure that UX, accessibility, and product are given the opportunity to vett and sign off on changes to the library. ("Going once, going twice...")
+- With the help of UX, Accessibility, and Product, document the requirements and best practices for updates and additions to Paragon's reusable components. ("I want to help you help me help you.")
+- Ensure that UX, Accessibility, and Product are given the opportunity to vet and sign off on changes to the library. ("Going once, going twice...")
 - Review Paragon pull requests with an eye toward ensuring that Paragon continues to be a flexible, consistent library of reusable components that fulfill our needs across the organization. ("Have you considered...")
 - Lead the charge on improving and fleshing out Paragon with the above goals in mind. ("Here, use this!")
 

--- a/docs/decisions/0003-repository-ownership.rst
+++ b/docs/decisions/0003-repository-ownership.rst
@@ -4,7 +4,7 @@
 Status
 ------
 
-Proposed
+Accepted
 
 Context
 -------
@@ -16,7 +16,7 @@ Meanwhile, the architecture team has been tasked with improving our codebase's o
 Decision
 --------
 
-The architecture team will own Paragon to the extent that it will:
+The architecture team (`Arch Team Homepage <https://openedx.atlassian.net/wiki/spaces/AC/pages/439353453/Architecture%2BTeam>`_) will own Paragon to the extent that it will:
 
 - With the help of UX, Accessibility, and Product, document the requirements and best practices for updates and additions to Paragon's reusable components. ("I want to help you help me help you.")
 - Ensure that UX, Accessibility, and Product are given the opportunity to vet and sign off on changes to the library. ("Going once, going twice...")
@@ -28,7 +28,7 @@ Consequences
 
 Establishing clear ownership roles and review criteria for Paragon should help ensure that code quality remains high, and that changes to the library are less likely to result in bugs and unexpected breaking changes. In addition, this ownership structure dovetails well with the architecture team's stated goal of improving our front end systems' approachability, extensibility, and the time to market of IDAs built on Paragon.
 
-This ownership will, of course, take up some of the architecture team's time above and beyond their current responsibilities. That said, documenting and disseminating the process and considerations for updating Paragon should help alleviate some of that strain by allowing pull request authors to do much of the due diligence themselves.
+This ownership will, of course, take up some of the architecture team's time to coordinate. That said, documenting and disseminating the process and considerations for updating Paragon should help alleviate some of that strain by allowing pull request authors to do much of the due diligence themselves.
 
 References
 ----------

--- a/docs/decisions/0004-usage-of-bootstrap.rst
+++ b/docs/decisions/0004-usage-of-bootstrap.rst
@@ -4,7 +4,7 @@
 Status
 ------
 
-Proposed
+Accepted
 
 Context
 -------
@@ -18,7 +18,7 @@ Furthermore, Paragon makes use of Bootstrap utility class names for its styling.
 Decision
 --------
 
-Paragon will formally be backed by Bootstrap, which is mostly just an affirmation of what's already happening. The exact import/module relationship between Paragon and Bootstrap can be handled in a separate ADR. More specifically, Paragon will be backed by edx-bootstrap, which has already been updated with input from the UX team.  Paragon components should make use of Bootstrap's utility classes wherever possible, rather than creating custom styling.
+Paragon will formally be backed by Bootstrap, which is mostly just an affirmation of what's already happening. The exact import/module relationship between Paragon and Bootstrap can be handled in a separate ADR. More specifically, Paragon will be backed by edx-bootstrap, which has already been updated with input from the UX team. Paragon components should make use of Bootstrap's utility classes wherever possible, rather than creating custom styling.
 
 Consequences
 ------------

--- a/docs/decisions/0004-usage-of-bootstrap.rst
+++ b/docs/decisions/0004-usage-of-bootstrap.rst
@@ -1,0 +1,36 @@
+4. Usage of Bootstrap
+----------------------
+
+Status
+------
+
+Proposed
+
+Context
+-------
+
+Our current understanding (though it was not documented as an ADR) is that Paragon was created with the assumption that its codebase could be separable from Bootstrap, in the sense that a consumer may wish to use Paragon without backing it with Bootstrap.
+
+Practically speaking, many Paragon components directly import styles from Bootstrap. The code will not compile in webpack unless Bootstrap is present in node_modules. Bootstrap is not listed as a dependency in @edx/paragon's package.json file - it is, however, a dependency of @edx/edx-bootstrap, which Paragon itself depends on. Currently the paragon-reset.scss imports the edx-bootstrap theme.
+
+Furthermore, Paragon makes use of Bootstrap utility class names for its styling. Technically one could use these names without using Bootstrap itself, but any stylesheet besides Bootstrap's that were used to back Paragon's reusable components would have to conform to Bootstrap's class names anyway.
+
+Decision
+--------
+
+Paragon will formally be backed by Bootstrap, which is mostly just an affirmation of what's already happening. The exact import/module relationship between Paragon and Bootstrap can be handled in a separate ADR. More specifically, Paragon will be backed by edx-bootstrap, which has already been updated with input from the UX team.  Paragon components should make use of Bootstrap's utility classes wherever possible, rather than creating custom styling.
+
+Consequences
+------------
+
+This decision will simplify conversations about Paragon and edx-bootstrap by taking talk of a "Bootstrap-less" Paragon off the table. This will allow us to make decisions about the relationship between Paragon, edx-bootstrap, and our codebase that are best for developers using the libraries.
+
+It frees us up to couple Paragon and edx-bootstrap as tightly (or loosely) as necessary to simplify the use of Paragon and the extension/theming of edx-bootstrap.
+
+Given that Paragon already has a relatively strong dependency on Bootstrap in the codebase, this is highly unlikely to affect any current consumers of Paragon.
+
+References
+----------
+
+* https://github.com/edx/paragon
+* https://github.com/edx/edx-bootstrap

--- a/docs/decisions/0005-usage-of-reactstrap.rst
+++ b/docs/decisions/0005-usage-of-reactstrap.rst
@@ -11,9 +11,9 @@ Context
 
 Paragon components exist for a variety of use cases, are React-based, and are currently styled using Bootstrap-compatible CSS class names. All known usages of Paragon are backed by Bootstrap. Reactstrap is a React-based component library that provides implementations of Bootstrap's components.
 
-Paragon's strength is found in its ability to be modifyied to meet our accessibility and functionality requirements above and beyond what any third-party component library might contain.  In addition, Paragon is the home for  edX-specific reusable components that would never be found in a generic component library.
+Paragon's strength is found in its ability to be modified to meet our accessibility and functionality requirements above and beyond what any third-party component library might contain.  In addition, Paragon is the home for  edX-specific reusable components that would never be found in a generic component library.
 
-Reactstrap's strength is found in its consistent, flexible, and comprehensive components (it's API, effectively) and its more-or-less complete set of implementations of Bootstrap's various 'component' styles.
+Reactstrap's strength is found in its consistent, flexible, and comprehensive components (its API, effectively) and its more-or-less complete set of implementations of Bootstrap's various 'component' styles.
 
 Both have something to offer us.
 
@@ -26,7 +26,7 @@ This will be accomplished via one of several methods depending on the nature and
 
 For Reactstrap components:
 
-- Reactstrap components which are deemed production-ready will be exposed as an export of Paragon as-is, making them immediately available as "paragon components" in consuming front-ends.
+- Reactstrap components which are deemed production-ready will be exposed as an export of Paragon as-is, making them immediately available as "Paragon components" in consuming front-ends.
 - Reactstrap components that do not conform to our UX guidelines can be excluded from the Paragon exports, effectively hiding them so they're not erroneously used.
 - Reactstrap components that have significant deficiencies that prevent them from being production-ready, but would otherwise be desirable, can be handled in one of two ways:
   - They can be augmented via a custom wrapper in Paragon, improving their functionality and making them production-ready and exportable.

--- a/docs/decisions/0005-usage-of-reactstrap.rst
+++ b/docs/decisions/0005-usage-of-reactstrap.rst
@@ -1,0 +1,55 @@
+5. Usage of Reactstrap
+----------------------
+
+Status
+------
+
+Proposed
+
+Context
+-------
+
+Paragon components exist for a variety of use cases, are React-based, and are currently styled using Bootstrap-compatible CSS class names. All known usages of Paragon are backed by Bootstrap. Reactstrap is a React-based component library that provides implementations of Bootstrap's components.
+
+Paragon's strength is found in its ability to be modifyied to meet our accessibility and functionality requirements above and beyond what any third-party component library might contain.  In addition, Paragon is the home for  edX-specific reusable components that would never be found in a generic component library.
+
+Reactstrap's strength is found in its consistent, flexible, and comprehensive components (it's API, effectively) and its more-or-less complete set of implementations of Bootstrap's various 'component' styles.
+
+Both have something to offer us.
+
+Decision
+--------
+
+We will use Reactstrap to opportunistically extend and improve the functionality of Paragon.  This implies that some existing Reactstrap components will be exposed via Paragon directly if they meet our needs, effectively extending Paragon's component library with minimal effort.
+
+This will be accomplished via one of several methods depending on the nature and utility of particular components. For the purposes of this list, 'production-ready' means a component that would pass stakeholder review as described in ADR 0003 - Repository Ownership.
+
+For Reactstrap components:
+
+- Reactstrap components which are deemed production-ready will be exposed as an export of Paragon as-is, making them immediately available as "paragon components" in consuming front-ends.
+- Reactstrap components that do not conform to our UX guidelines can be excluded from the Paragon exports, effectively hiding them so they're not erroneously used.
+- Reactstrap components that have significant deficiencies that prevent them from being production-ready, but would otherwise be desirable, can be handled in one of two ways:
+  - They can be augmented via a custom wrapper in Paragon, improving their functionality and making them production-ready and exportable.
+  - They can be improved via a pull request to Reactstrap - more likely if straightforward accessibility bugs are found, for instance - and included once Reactstrap updates. Obviously, this approach can be done in parallel with using a custom wrapper in some cases.
+
+For existing Paragon components:
+
+- Paragon components that are deemed to be production-ready can be left as-is for now without backing or replacing them with Reactstrap implementations. No need to change a tire that isn't flat.
+- Paragon components with accessibility, flexibility, or consistency issues that could be mitigated by backing them with Reactstrap can be opportunistically updated. The extent of this change - and whether it results in a major, minor, or patch version update, largely depends on how different the Paragon/Reactstrap components are.  Where possible, we will favor the best practices and functionality of the Reactstrap components, under the assumption that they are generally more flexible and consistent than our own home-grown components.
+
+For new Paragon components:
+
+- New Paragon components will ideally make use of Reactstrap components where possible to take advantage of Reactstrap's strengths.
+
+Consequences
+------------
+
+Opportunistically following the above guidelines should result in Paragon becoming a more comprehensive, consistent, flexible component library, furthering the architecture team's goals of approachability, extensibility, and improving the organization's time to market for new features. Using Reactstrap for new components will improve the ease of implementation for new Paragon components as well.
+
+Breaking changes to Paragon components will ideally, but not necessarily, result in updates to Paragon's consuming IDAs to bring them in line with the latest version.  This will take a little time, but result in a more consistent usage pattern across the organization.
+
+References
+----------
+
+* https://github.com/edx/paragon
+* https://reactstrap.github.io/

--- a/docs/decisions/0005-usage-of-reactstrap.rst
+++ b/docs/decisions/0005-usage-of-reactstrap.rst
@@ -4,14 +4,14 @@
 Status
 ------
 
-Proposed
+Accepted
 
 Context
 -------
 
 Paragon components exist for a variety of use cases, are React-based, and are currently styled using Bootstrap-compatible CSS class names. All known usages of Paragon are backed by Bootstrap. Reactstrap is a React-based component library that provides implementations of Bootstrap's components.
 
-Paragon's strength is found in its ability to be modified to meet our accessibility and functionality requirements above and beyond what any third-party component library might contain.  In addition, Paragon is the home for  edX-specific reusable components that would never be found in a generic component library.
+Paragon's strength is found in its ability to be modified to meet our accessibility and functionality requirements above and beyond what any third-party component library might contain. In addition, Paragon is the home for any reusable components we create that we haven't found in any generic component library.
 
 Reactstrap's strength is found in its consistent, flexible, and comprehensive components (its API, effectively) and its more-or-less complete set of implementations of Bootstrap's various 'component' styles.
 
@@ -20,7 +20,7 @@ Both have something to offer us.
 Decision
 --------
 
-We will use Reactstrap to opportunistically extend and improve the functionality of Paragon.  This implies that some existing Reactstrap components will be exposed via Paragon directly if they meet our needs, effectively extending Paragon's component library with minimal effort.
+We will use Reactstrap to opportunistically extend and improve the functionality of Paragon. This implies that some existing Reactstrap components will be exposed via Paragon directly if they meet our needs, effectively extending Paragon's component library with minimal effort.
 
 This will be accomplished via one of several methods depending on the nature and utility of particular components. For the purposes of this list, 'production-ready' means a component that would pass stakeholder review as described in ADR 0003 - Repository Ownership.
 
@@ -35,7 +35,7 @@ For Reactstrap components:
 For existing Paragon components:
 
 - Paragon components that are deemed to be production-ready can be left as-is for now without backing or replacing them with Reactstrap implementations. No need to change a tire that isn't flat.
-- Paragon components with accessibility, flexibility, or consistency issues that could be mitigated by backing them with Reactstrap can be opportunistically updated. The extent of this change - and whether it results in a major, minor, or patch version update, largely depends on how different the Paragon/Reactstrap components are.  Where possible, we will favor the best practices and functionality of the Reactstrap components, under the assumption that they are generally more flexible and consistent than our own home-grown components.
+- Paragon components with accessibility, flexibility, or consistency issues that could be mitigated by backing them with Reactstrap can be opportunistically updated. The extent of this change - and whether it results in a major, minor, or patch version update, largely depends on how different the Paragon/Reactstrap components are. Where possible, we will favor the best practices and functionality of the Reactstrap components, under the assumption that they are generally more flexible and consistent than our own home-grown components.
 
 For new Paragon components:
 
@@ -46,7 +46,7 @@ Consequences
 
 Opportunistically following the above guidelines should result in Paragon becoming a more comprehensive, consistent, flexible component library, furthering the architecture team's goals of approachability, extensibility, and improving the organization's time to market for new features. Using Reactstrap for new components will improve the ease of implementation for new Paragon components as well.
 
-Breaking changes to Paragon components will ideally, but not necessarily, result in updates to Paragon's consuming IDAs to bring them in line with the latest version.  This will take a little time, but result in a more consistent usage pattern across the organization.
+Breaking changes to Paragon components will ideally, but not necessarily, result in updates to Paragon's consuming IDAs to bring them in line with the latest version. This will take a little time, but result in a more consistent usage pattern across the organization.
 
 References
 ----------


### PR DESCRIPTION
tl;dr -

1. Arch team will take "ownership" of Paragon.  (this is more an offer of coordination than anything else)
2. We use Bootstrap.
3. We will start using Reactstrap.

All three are obviously proposals - exact details are up for discussion.  None of this is expected to be controversial or ruffle any feathers - if it does, let's talk!  I must not have talked to you about it yet.

I intend to bring this up for discussion at the next Fedx meeting to solicit feedback.