### PR TITLE
fix(tests): tests modal error throwing in a supported way

### DIFF
--- a/src/Modal/Modal.test.jsx
+++ b/src/Modal/Modal.test.jsx
@@ -1,48 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
-import PropTypes from 'prop-types';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 import Modal from './index';
 import Button from '../Button';
 import Variant from '../utils/constants';
-
-class ErrorBoundary extends React.Component {
-  // Used to test Errors thrown during invalid props tests
-  constructor(props) {
-    super(props);
-    this.state = { hasError: false };
-  }
-
-  componentDidCatch(error, info) {
-    // Display fallback UI
-    this.setState({ hasError: true, error, info });
-  }
-
-  render() {
-    if (this.state.hasError && this.state.error && this.state.info) {
-      // You can render any custom fallback UI
-      return (
-        <h1 className="error-occured">
-          An Error Occurred.
-        </h1>
-      );
-    }
-    return this.props.children;
-  }
-}
-ErrorBoundary.propTypes = {
-  children: PropTypes.node,
-};
-ErrorBoundary.defaultProps = {
-  children: null,
-};
-
-const ErrorWrappedModal = props => (
-  <ErrorBoundary>
-    <Modal {...props} />
-  </ErrorBoundary>
-);
 
 const modalOpen = (isOpen, wrapper) => {
   expect(wrapper.find('.modal').hasClass('d-block')).toEqual(isOpen);
@@ -210,11 +172,12 @@ describe('<Modal />', () => {
     });
 
     it('throws an error when an invalid parentSelector prop is passed', () => {
-      wrapper = mount(<ErrorWrappedModal
-        {...defaultProps}
-        parentSelector="this-selector-does-not-exist"
-      />);
-      expect(wrapper.find('.error-occured')).toHaveLength(1);
+      expect(() => {
+        wrapper = shallow(<Modal
+          {...defaultProps}
+          parentSelector="this-selector-does-not-exist"
+        />);
+      }).toThrow('Modal received invalid parentSelector: this-selector-does-not-exist, no matching element found');
     });
   });
 


### PR DESCRIPTION
No need for an error boundary component.  Uses “shallow” to avoid full mounting in jsdom, which is what spits out an error to the console.