### PR TITLE
Remove sole reference to edx-bootstrap

### DIFF
--- a/src/utils/paragon-reset.scss
+++ b/src/utils/paragon-reset.scss
@@ -1,4 +1,3 @@
-@import '~@edx/edx-bootstrap/sass/open-edx/theme';
 @import "~bootstrap/scss/variables";
 @import "~bootstrap/scss/mixins";
 


### PR DESCRIPTION
**This removes the sole reference to edx-bootstrap in Paragon giving us the freedom to change edx-bootstrap's folder structure.**

Important note: For now, applications that use this file (not all users of Paragon do) the open-edx theme needs to be included before this file. From something like:
```
@import "@edx/paragon/src/utils/paragon-reset";
```
to this:
```
@import '~@edx/edx-bootstrap/sass/open-edx/theme';
@import "@edx/paragon/src/utils/paragon-reset";
```

Visually, this is a breaking change and would affect [edx-platform here](https://github.com/edx/edx-platform/blob/a6ff120f8f6f65a3dcf6f4fcd1d51a1bed028073/webpack.dev.config.js) if no action is taken.

Aside, this is mentioned in [the recent Paragon ADR](https://github.com/edx/paragon/blob/9c1baa8e52de94a84aa37aa28a4f434ee557d21b/docs/decisions/0004-usage-of-bootstrap.rst):

> Bootstrap is not listed as a dependency in @edx/paragon's package.json file - it is, however, a dependency of @edx/edx-bootstrap, which Paragon itself depends on. **Currently the paragon-reset.scss imports the edx-bootstrap theme**.

A question for you all: Should we let this PR sit and be part of a major version bump to avoid complications?