### PR TITLE
feat: remove static build output

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,3 @@
 coverage/*
 dist/
-themeable/
-static/
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ node_modules
 npm-debug.log
 coverage
 jest*
-static
-themeable
+dist

--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ Paragon requires React 16 or higher. To install Paragon into your project:
 npm i --save @edx/paragon
 ```
 
+In your JSX files:
+```
+import { ComponentName } from '@edx/paragon';
+```
+
 Since Paragon is a React library, components must be rendered with React and ReactDOM. This doesn't mean the entire page has to be rendered with React. You can read up about rendering React into a page within the [official ReactDOM documentation](https://reactjs.org/docs/react-dom.html).
 
-### Export Targets
 
-Paragon's production build ships with two different export targets:
+### Legacy Export Target [Removed]
 
-**`themeable`**: This is the default export intended for use within Bootstrap 4 pages. Components ship with stock Bootstrap classnames and can accept Bootstrap themes. This build assumes Bootstrap/Font Awesome are already available on the consuming page. You should not need to add any additional stylesheets -- just plug and go. Import syntax is as follows:
-
-`import { ComponentName } from '@edx/paragon';`
-
-**`static`**: The static build is intended for use within legacy pages not styled with Bootstrap 4. Component classnames are namespaced with the `paragon__` prefix so as not to conflict with existing classnames defined elsewhere on the page. Be cognizant of poorly scoped legacy rules (e.g. a rule for all `input` or `h1` tags), which can still affect Paragon components. This build comes with its own stylesheet, available at `/static/paragon.min.css`. You must include this stylesheet on any page that uses Paragon components. Components can be imported thus:
+**`static [Removed in version 4.0]`**: The static build is intended for use within legacy pages not styled with Bootstrap 4. Component classnames are namespaced with the `paragon__` prefix so as not to conflict with existing classnames defined elsewhere on the page. Be cognizant of poorly scoped legacy rules (e.g. a rule for all `input` or `h1` tags), which can still affect Paragon components. This build comes with its own stylesheet, available at `/static/paragon.min.css`. You must include this stylesheet on any page that uses Paragon components. Components can be imported thus:
 
 `import { ComponentName } from '@edx/paragon/static';`
 

--- a/package.json
+++ b/package.json
@@ -2,15 +2,13 @@
   "name": "@edx/paragon",
   "version": "0.0.0-development",
   "description": "Accessible, responsive UI component library based on Bootstrap.",
-  "main": "themeable/index.js",
+  "main": "dist/paragon.js",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/edx/paragon.git"
   },
   "files": [
-    "/static",
-    "/themeable",
     "/dist",
     "/src"
   ],
@@ -22,7 +20,7 @@
     "debug-test": "node --inspect-brk node_modules/.bin/jest --runInBand --coverage",
     "deploy-storybook": "storybook-to-ghpages",
     "deploy-storybook-ci": "storybook-to-ghpages --ci",
-    "is-es5": "es-check es5 ./themeable/*.js ./static/*.js",
+    "is-es5": "es-check es5 ./dist/*.js",
     "lint": "eslint --ext .js --ext .jsx .",
     "prepublishOnly": "npm run build",
     "semantic-release": "semantic-release",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,32 +4,15 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 
 
-// we build the library for two different build targets:
-// static (with scoped styles) and themeable (with stock,
-// overrideable classnames)
-const targetProperties = [{
-  baseDirectory: 'static',
-  localIdentName: 'paragon__[local]',
-},
-{
-  baseDirectory: 'themeable',
-  localIdentName: '[local]',
-}];
-
-module.exports = targetProperties.map(config => ({
+module.exports = {
   entry: './src/index.js',
   output: {
-    filename: `${config.baseDirectory}/index.js`,
+    filename: 'paragon.js',
     library: 'paragon',
     libraryTarget: 'umd',
-    path: __dirname,
   },
   resolve: {
     extensions: ['.js', '.jsx'],
-    alias: {
-      react: path.resolve(__dirname, './node_modules/react'),
-      'react-dom': path.resolve(__dirname, './node_modules/react-dom'),
-    },
   },
   externals: {
     react: {
@@ -48,14 +31,12 @@ module.exports = targetProperties.map(config => ({
   plugins: [
     new UglifyJsPlugin(),
     new MiniCssExtractPlugin({
-      filename: `${config.baseDirectory}/paragon.min.css`,
+      filename: 'paragon.min.css',
     }),
     // Be careful here. Our output path is the root of this project
     // so without this config, CleanWebpackPlugin will destroy the project
     // We should change the output path to dist/ in the next major version.
-    new CleanWebpackPlugin({
-      cleanOnceBeforeBuildPatterns: ['themeable/**/*', 'static/**/*'],
-    }),
+    new CleanWebpackPlugin(),
   ],
   module: {
     rules: [
@@ -74,7 +55,7 @@ module.exports = targetProperties.map(config => ({
             loader: 'css-loader',
             options: {
               modules: true,
-              localIdentName: config.localIdentName,
+              localIdentName: '[local]',
             },
           },
           {
@@ -93,9 +74,9 @@ module.exports = targetProperties.map(config => ({
         test: /\.(woff2?|ttf|svg|eot)(\?v=\d+\.\d+\.\d+)?$/,
         loader: 'file-loader',
         options: {
-          outputPath: config.baseDirectory,
+          outputPath: 'assets',
         },
       },
     ],
   },
-}));
+};


### PR DESCRIPTION
Eliminating the static build target provides us a simpler project setup and sets the stage to eliminate css modules and some of the problems caused by its current implementation.

The static build is used only in some places in edx-platform:
https://github.com/search?q=org%3Aedx+%22paragon%2Fstatic%22&type=Code

