### PR TITLE
ADR for Prop Naming and change classNames to strings

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -3192,7 +3192,6 @@ exports[`Storyshots MailtoLink with subject and body 1`] = `
 exports[`Storyshots Pagination basic usage 1`] = `
 <nav
   aria-label="pagination navigation"
-  className=""
 >
   <div
     aria-atomic={true}
@@ -3257,7 +3256,6 @@ exports[`Storyshots Pagination basic usage 1`] = `
 exports[`Storyshots Pagination with custom element labels 1`] = `
 <nav
   aria-label="pagination navigation"
-  className=""
 >
   <div
     aria-atomic={true}
@@ -3326,7 +3324,6 @@ exports[`Storyshots Pagination with custom element labels 1`] = `
 exports[`Storyshots Pagination with custom string labels 1`] = `
 <nav
   aria-label="pagination navigation"
-  className=""
 >
   <div
     aria-atomic={true}
@@ -3391,7 +3388,6 @@ exports[`Storyshots Pagination with custom string labels 1`] = `
 exports[`Storyshots Pagination with initial page selected 1`] = `
 <nav
   aria-label="pagination navigation"
-  className=""
 >
   <div
     aria-atomic={true}
@@ -3455,7 +3451,6 @@ exports[`Storyshots Pagination with initial page selected 1`] = `
 exports[`Storyshots Pagination with max pages displayed 1`] = `
 <nav
   aria-label="pagination navigation"
-  className=""
 >
   <div
     aria-atomic={true}

--- a/docs/decisions/0007-component-api-guidelines.rst
+++ b/docs/decisions/0007-component-api-guidelines.rst
@@ -4,7 +4,7 @@
 Status
 ------
 
-Proposed with this PR
+Accepted
 
 Context
 -------

--- a/docs/decisions/0007-component-api-guidelines.rst
+++ b/docs/decisions/0007-component-api-guidelines.rst
@@ -1,0 +1,41 @@
+7. Component API Guidelines
+---------------------------
+
+Status
+------
+
+Proposed with this PR
+
+Context
+-------
+
+Paragon components have very different interfaces and inconsistencies with how they handle common attributes. This cause friction when using the library, causing developers to use documentation more often ultimately slowing them down.
+
+Decision
+--------
+
+We should think of Paragon components as a set, they should behave and be used in consistent ways. This will decrease developer reliance on documentation over time increasing productivity. Here are a some guidelines in no particular order:
+
+**children**
+When creating a component that should have content use children instead of a prop (such as content, or label) unless there is a compelling reason not to do so.
+
+**className**
+Whenever we wish to allow consumers of a component to add a class name, the prop should be named className (not classNames) and should expect a string (not an array).
+
+**Other considerations**
+
+- Name props from the perspective of the component (not the component's parent or consumer).
+- "Mirror the DOM wherever possible" `React Prop Type Best Practices <https://davidwells.io/blog/react-prop-type-best-practices/>`_
+
+Consequences
+------------
+
+We will need to deprecate currently used props and consuming applications of Paragon will need to update their usage.
+
+Over time Paragon component prop names and types will be easier guess making Paragon easier to use.
+
+References
+----------
+
+* https://dlinau.wordpress.com/2016/02/22/how-to-name-props-for-react-components/
+* https://davidwells.io/blog/react-prop-type-best-practices/

--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -100,7 +100,7 @@ Button.propTypes = buttonPropTypes;
 
 Button.defaultProps = {
   buttonType: undefined,
-  className: null,
+  className: undefined,
   inputRef: () => {},
   isClose: false,
   onBlur: () => {},

--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
+import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
+
 
 class Button extends React.Component {
   constructor(props) {
@@ -63,7 +65,7 @@ class Button extends React.Component {
         {...other}
         className={classNames([
           'btn',
-          ...className,
+          className,
         ], {
           [`btn-${buttonType}`]: buttonType !== undefined,
         }, {
@@ -84,7 +86,7 @@ class Button extends React.Component {
 
 export const buttonPropTypes = {
   buttonType: PropTypes.string,
-  className: PropTypes.arrayOf(PropTypes.string),
+  className: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   inputRef: PropTypes.func,
   isClose: PropTypes.bool,
@@ -98,7 +100,7 @@ Button.propTypes = buttonPropTypes;
 
 Button.defaultProps = {
   buttonType: undefined,
-  className: [],
+  className: null,
   inputRef: () => {},
   isClose: false,
   onBlur: () => {},
@@ -107,4 +109,11 @@ Button.defaultProps = {
   type: 'button',
 };
 
-export default Button;
+export default withDeprecatedProps(Button, {
+  className: {
+    deprType: DEPR_TYPES.FORMAT,
+    expect: value => typeof value === 'string',
+    transform: value => (Array.isArray(value) ? value.join(' ') : value),
+    message: 'It should be a string.',
+  },
+});

--- a/src/Fieldset/index.jsx
+++ b/src/Fieldset/index.jsx
@@ -23,7 +23,7 @@ const inputProps = {
 
 const defaultProps = {
   children: null,
-  className: '',
+  className: undefined,
   id: '',
   isValid: true,
   invalidMessage: '',

--- a/src/Icon/index.jsx
+++ b/src/Icon/index.jsx
@@ -3,13 +3,15 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 import newId from '../utils/newId';
+import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
+
 
 function Icon(props) {
   return (
     <React.Fragment>
       <span
         id={props.id ? props.id : newId('Icon')}
-        className={classNames(props.className)}
+        className={props.className}
         aria-hidden={props.hidden}
       />
       { props.screenReaderText &&
@@ -23,7 +25,7 @@ function Icon(props) {
 
 Icon.propTypes = {
   id: PropTypes.string,
-  className: PropTypes.arrayOf(PropTypes.string).isRequired,
+  className: PropTypes.string.isRequired,
   hidden: PropTypes.bool,
   screenReaderText: PropTypes.string,
 };
@@ -34,4 +36,11 @@ Icon.defaultProps = {
   screenReaderText: undefined,
 };
 
-export default Icon;
+export default withDeprecatedProps(Icon, {
+  className: {
+    deprType: DEPR_TYPES.FORMAT,
+    expect: value => typeof value === 'string',
+    transform: value => (Array.isArray(value) ? value.join(' ') : value),
+    message: 'It should be a string.',
+  },
+});

--- a/src/InputSelect/index.jsx
+++ b/src/InputSelect/index.jsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 import asInput, { inputProps } from '../asInput';
+import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
 
 class Select extends React.Component {
   static getOption(option, i) {
@@ -75,11 +76,19 @@ Select.propTypes = {
   ]).isRequired,
 };
 
-const InputSelect = asInput(Select);
+const InputSelect = asInput(withDeprecatedProps(Select, {
+  className: {
+    deprType: DEPR_TYPES.FORMAT,
+    expect: value => typeof value === 'string',
+    transform: value => (Array.isArray(value) ? value.join(' ') : value),
+    message: 'It should be a string.',
+  },
+}));
 
 InputSelect.propTypes = {
   ...InputSelect.propTypes,
   ...Select.propTypes,
 };
+
 
 export default InputSelect;

--- a/src/InputText/index.jsx
+++ b/src/InputText/index.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 
 
 import asInput, { inputProps, defaultProps } from '../asInput';
+import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
+
 
 function Text(props) {
   return (
@@ -50,6 +52,13 @@ const textDefaultProps = {
 Text.propTypes = { ...textPropTypes, ...inputProps };
 Text.defaultProps = { ...textDefaultProps, ...defaultProps };
 
-const InputText = asInput(Text);
+const InputText = asInput(withDeprecatedProps(Text, {
+  className: {
+    deprType: DEPR_TYPES.FORMAT,
+    expect: value => typeof value === 'string',
+    transform: value => (Array.isArray(value) ? value.join(' ') : value),
+    message: 'It should be a string.',
+  },
+}));
 
 export default InputText;

--- a/src/ListBox/index.jsx
+++ b/src/ListBox/index.jsx
@@ -109,7 +109,7 @@ ListBox.propTypes = {
 };
 
 ListBox.defaultProps = {
-  className: '',
+  className: undefined,
   selectedOptionIndex: undefined,
   tag: 'div',
 };

--- a/src/ListBoxOption/index.jsx
+++ b/src/ListBoxOption/index.jsx
@@ -71,7 +71,7 @@ ListBoxOption.propTypes = {
 };
 
 ListBoxOption.defaultProps = {
-  className: '',
+  className: undefined,
   index: undefined,
   isSelected: false,
   tag: 'div',

--- a/src/Pagination/Pagination.test.jsx
+++ b/src/Pagination/Pagination.test.jsx
@@ -59,8 +59,8 @@ describe('<Pagination />', () => {
         currentPage: 2,
       };
       const wrapper = mount(<Pagination {...props} />);
-      wrapper.find('.previous').simulate('click');
-      expect(wrapper.find('.next').instance()).toEqual(document.activeElement);
+      wrapper.find('button.previous').simulate('click');
+      expect(wrapper.find('button.next').instance()).toEqual(document.activeElement);
     });
 
     it('should change focus to previous button if next page is last page', () => {
@@ -69,8 +69,8 @@ describe('<Pagination />', () => {
         currentPage: baseProps.pageCount - 1,
       };
       const wrapper = mount(<Pagination {...props} />);
-      wrapper.find('.next').simulate('click');
-      expect(wrapper.find('.previous').instance()).toEqual(document.activeElement);
+      wrapper.find('button.next').simulate('click');
+      expect(wrapper.find('button.previous').instance()).toEqual(document.activeElement);
     });
   });
 
@@ -151,7 +151,7 @@ describe('<Pagination />', () => {
       };
       const wrapper = mount(<Pagination {...props} />);
       wrapper.setProps({ currentPage: 2 });
-      wrapper.find('.previous').simulate('click');
+      wrapper.find('button.previous').simulate('click');
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
@@ -162,7 +162,7 @@ describe('<Pagination />', () => {
         onPageSelect: spy,
       };
       const wrapper = mount(<Pagination {...props} />);
-      wrapper.find('.next').simulate('click');
+      wrapper.find('button.next').simulate('click');
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -388,7 +388,7 @@ Pagination.defaultProps = {
     currentPage: 'Current Page',
     pageOfCount: 'of',
   },
-  className: '',
+  className: undefined,
   currentPage: 1,
   maxPagesDisplayed: 7,
 };

--- a/src/StatusAlert/StatusAlert.test.jsx
+++ b/src/StatusAlert/StatusAlert.test.jsx
@@ -5,8 +5,9 @@ import StatusAlert from './index';
 import Button from '../Button';
 
 const statusAlertOpen = (isOpen, wrapper) => {
-  expect(wrapper.childAt(0).hasClass('show')).toEqual(isOpen);
-  expect(wrapper.state('open')).toEqual(isOpen);
+  // console.log(wrapper.debug())
+  expect(wrapper.find('.alert').hasClass('show')).toEqual(isOpen);
+  expect(wrapper.find('StatusAlert').state('open')).toEqual(isOpen);
 };
 const dialog = 'Status Alert dialog';
 const defaultProps = {

--- a/src/StatusAlert/StatusAlert.test.jsx
+++ b/src/StatusAlert/StatusAlert.test.jsx
@@ -5,7 +5,6 @@ import StatusAlert from './index';
 import Button from '../Button';
 
 const statusAlertOpen = (isOpen, wrapper) => {
-  // console.log(wrapper.debug())
   expect(wrapper.find('.alert').hasClass('show')).toEqual(isOpen);
   expect(wrapper.find('StatusAlert').state('open')).toEqual(isOpen);
 };

--- a/src/StatusAlert/index.jsx
+++ b/src/StatusAlert/index.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import isRequiredIf from 'react-proptype-conditional-require';
 
 import Button from '../Button';
+import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
+
 
 class StatusAlert extends React.Component {
   constructor(props) {
@@ -83,7 +85,7 @@ class StatusAlert extends React.Component {
     return (
       <div
         className={classNames([
-          ...className,
+          className,
           'alert',
           'fade',
         ], {
@@ -105,7 +107,7 @@ class StatusAlert extends React.Component {
 
 StatusAlert.propTypes = {
   alertType: PropTypes.string,
-  className: PropTypes.arrayOf(PropTypes.string),
+  className: PropTypes.string,
   dialog: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   dismissible: PropTypes.bool,
   /* eslint-disable react/require-default-props */
@@ -116,10 +118,17 @@ StatusAlert.propTypes = {
 
 StatusAlert.defaultProps = {
   alertType: 'warning',
-  className: [],
+  className: null,
   closeButtonAriaLabel: 'Close',
   dismissible: true,
   open: false,
 };
 
-export default StatusAlert;
+export default withDeprecatedProps(StatusAlert, {
+  className: {
+    deprType: DEPR_TYPES.FORMAT,
+    expect: value => typeof value === 'string',
+    transform: value => (Array.isArray(value) ? value.join(' ') : value),
+    message: 'It should be a string.',
+  },
+});

--- a/src/StatusAlert/index.jsx
+++ b/src/StatusAlert/index.jsx
@@ -118,7 +118,7 @@ StatusAlert.propTypes = {
 
 StatusAlert.defaultProps = {
   alertType: 'warning',
-  className: null,
+  className: undefined,
   closeButtonAriaLabel: 'Close',
   dismissible: true,
   open: false,

--- a/src/Table/Table.test.jsx
+++ b/src/Table/Table.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 
 import Table from './index';
 
@@ -79,7 +79,7 @@ const propsWithColWidths = {
 
 describe('<Table />', () => {
   describe('renders', () => {
-    const wrapper = shallow(<Table {...props} />);
+    const wrapper = mount(<Table {...props} />).find('Table');
 
     it('with display columns in the right order', () => {
       wrapper.find('th').forEach((th, i) => {
@@ -102,10 +102,11 @@ describe('<Table />', () => {
   });
 
   describe('that is non-sortable renders', () => {
-    const wrapper = mount(<Table {...sortableProps} tableSortable={false} />);
+    const wrapper = mount(<Table {...sortableProps} tableSortable={false} />).find('Table');
 
     it('it sets column headers correctly even with hidden prop', () => {
       const tableHeadings = wrapper.find('th');
+
       let hiddenHeader;
 
       tableHeadings.forEach((th, i) => {
@@ -137,7 +138,7 @@ describe('<Table />', () => {
   });
 
   describe('that is sortable and has mixed columns renders', () => {
-    let wrapper = shallow(<Table {...sortableProps} />);
+    let wrapper = mount(<Table {...sortableProps} />).find('Table');
 
     it('with sortable classname on correct headings', () => {
       const tableHeadings = wrapper.find('th');
@@ -164,8 +165,8 @@ describe('<Table />', () => {
     });
 
     it('with correct initial state', () => {
-      expect(wrapper.state('sortedColumn')).toEqual(sortableProps.defaultSortedColumn);
-      expect(wrapper.state('sortDirection')).toEqual(sortableProps.defaultSortDirection);
+      expect(wrapper.find('Table').state('sortedColumn')).toEqual(sortableProps.defaultSortedColumn);
+      expect(wrapper.find('Table').state('sortDirection')).toEqual(sortableProps.defaultSortDirection);
     });
 
     wrapper = mount(<Table {...sortableProps} />);
@@ -250,20 +251,20 @@ describe('<Table />', () => {
       buttons.at(0).simulate('click');
       buttons = wrapper.find('button');
 
-      expect(wrapper.state('sortedColumn')).toEqual(sortableProps.defaultSortedColumn);
-      expect(wrapper.state('sortDirection')).toEqual('asc');
+      expect(wrapper.find('Table').state('sortedColumn')).toEqual(sortableProps.defaultSortedColumn);
+      expect(wrapper.find('Table').state('sortDirection')).toEqual('asc');
 
       buttons.at(0).simulate('click');
       buttons = wrapper.find('button');
 
-      expect(wrapper.state('sortedColumn')).toEqual(sortableProps.defaultSortedColumn);
-      expect(wrapper.state('sortDirection')).toEqual('desc');
+      expect(wrapper.find('Table').state('sortedColumn')).toEqual(sortableProps.defaultSortedColumn);
+      expect(wrapper.find('Table').state('sortDirection')).toEqual('desc');
 
       buttons.at(1).simulate('click');
       buttons = wrapper.find('button');
 
-      expect(wrapper.state('sortedColumn')).toEqual(sortableProps.columns[1].key);
-      expect(wrapper.state('sortDirection')).toEqual('desc');
+      expect(wrapper.find('Table').state('sortedColumn')).toEqual(sortableProps.columns[1].key);
+      expect(wrapper.find('Table').state('sortDirection')).toEqual('desc');
     });
 
     it('calls onSort function correctly on click', () => {
@@ -296,7 +297,7 @@ describe('<Table />', () => {
     });
   });
   describe('that is fixed', () => {
-    const wrapper = shallow(<Table {...fixedProps} />);
+    const wrapper = mount(<Table {...fixedProps} />);
 
     it('with col width classnames on headings', () => {
       const tableHeadings = wrapper.find('th');
@@ -326,7 +327,7 @@ describe('<Table />', () => {
     });
   });
   describe('that is not fixed with col widths', () => {
-    const wrapper = shallow(<Table {...propsWithColWidths} />);
+    const wrapper = mount(<Table {...propsWithColWidths} />);
 
     it('with no col width classnames on headings', () => {
       const tableHeadings = wrapper.find('th');
@@ -356,7 +357,7 @@ describe('<Table />', () => {
     });
   });
   describe('renders row headers', () => {
-    const wrapper = shallow(<Table {...props} rowHeaderColumnKey="num" />);
+    const wrapper = mount(<Table {...props} rowHeaderColumnKey="num" />);
 
     it('with the row header as th with row scope', () => {
       wrapper.find('tbody').at(0).find('th').forEach((th) => {

--- a/src/Table/index.jsx
+++ b/src/Table/index.jsx
@@ -190,7 +190,7 @@ Table.propTypes = {
 
 Table.defaultProps = {
   caption: null,
-  className: null,
+  className: undefined,
   headingClassName: [],
   tableSortable: false,
   hasFixedColumnWidths: false,

--- a/src/Table/index.jsx
+++ b/src/Table/index.jsx
@@ -4,6 +4,8 @@ import isRequiredIf from 'react-proptype-conditional-require';
 import PropTypes from 'prop-types';
 
 import Button from '../Button';
+import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
+
 
 class Table extends React.Component {
   constructor(props) {
@@ -139,7 +141,7 @@ class Table extends React.Component {
     return (
       <table className={classNames(
         'table',
-        ...this.props.className,
+        this.props.className,
       )}
       >
         {this.getCaption()}
@@ -155,7 +157,7 @@ Table.propTypes = {
     PropTypes.string,
     PropTypes.element,
   ]),
-  className: PropTypes.arrayOf(PropTypes.string),
+  className: PropTypes.string,
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
   columns: PropTypes.arrayOf(PropTypes.shape({
     key: PropTypes.string.isRequired,
@@ -188,7 +190,7 @@ Table.propTypes = {
 
 Table.defaultProps = {
   caption: null,
-  className: [],
+  className: null,
   headingClassName: [],
   tableSortable: false,
   hasFixedColumnWidths: false,
@@ -199,4 +201,12 @@ Table.defaultProps = {
   },
 };
 
-export default Table;
+
+export default withDeprecatedProps(Table, {
+  className: {
+    deprType: DEPR_TYPES.FORMAT,
+    expect: value => typeof value === 'string',
+    transform: value => (Array.isArray(value) ? value.join(' ') : value),
+    message: 'It should be a string.',
+  },
+});

--- a/src/TextArea/index.jsx
+++ b/src/TextArea/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 import asInput, { inputProps } from '../asInput';
+import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
 
 function Text(props) {
   return (
@@ -25,6 +26,13 @@ function Text(props) {
 
 Text.propTypes = inputProps;
 
-const TextArea = asInput(Text);
+const TextArea = asInput(withDeprecatedProps(Text, {
+  className: {
+    deprType: DEPR_TYPES.FORMAT,
+    expect: value => typeof value === 'string',
+    transform: value => (Array.isArray(value) ? value.join(' ') : value),
+    message: 'It should be a string.',
+  },
+}));
 
 export default TextArea;

--- a/src/ValidationMessage/index.jsx
+++ b/src/ValidationMessage/index.jsx
@@ -17,7 +17,7 @@ const inputProps = {
 };
 
 const defaultProps = {
-  className: '',
+  className: undefined,
   isValid: true,
   invalidMessage: '',
   variant: {

--- a/src/asInput/asInput.test.jsx
+++ b/src/asInput/asInput.test.jsx
@@ -49,7 +49,7 @@ describe('asInput()', () => {
       ...baseProps,
     };
     const wrapper = mount(<InputTestComponent {...props} />);
-    expect(wrapper.state('id')).toContain('asInput');
+    expect(wrapper.find('asInput(testComponent)').state('id')).toContain('asInput');
     expect(wrapper.find('label').prop('id')).toContain('asInput');
     expect(wrapper.find('input').prop('id')).toContain('asInput');
     expect(wrapper.find('small').prop('id')).toContain('asInput');
@@ -62,7 +62,7 @@ describe('asInput()', () => {
       id: testId,
     };
     const wrapper = mount(<InputTestComponent {...props} />);
-    expect(wrapper.state('id')).toContain('asInput');
+    expect(wrapper.find('asInput(testComponent)').state('id')).toContain('asInput');
     expect(wrapper.find('label').prop('id')).toContain('asInput');
     expect(wrapper.find('input').prop('id')).toContain('asInput');
     expect(wrapper.find('small').prop('id')).toContain('asInput');
@@ -75,7 +75,7 @@ describe('asInput()', () => {
       id: testId,
     };
     const wrapper = mount(<InputTestComponent {...props} />);
-    expect(wrapper.state('id')).toEqual(testId);
+    expect(wrapper.find('asInput(testComponent)').state('id')).toEqual(testId);
     expect(wrapper.find('label').prop('id')).toEqual(`label-${testId}`);
     expect(wrapper.find('input').prop('id')).toEqual(testId);
     expect(wrapper.find('small').prop('id')).toEqual(`description-${testId}`);
@@ -101,11 +101,11 @@ describe('asInput()', () => {
       value: initValue,
     };
     const wrapper = mount(<InputTestComponent {...props} />);
-    expect(wrapper.state('value')).toEqual(initValue);
+    expect(wrapper.find('asInput(testComponent)').state('value')).toEqual(initValue);
     wrapper.setProps({
       value: newValue,
     });
-    expect(wrapper.state('value')).toEqual(newValue);
+    expect(wrapper.find('asInput(testComponent)').state('value')).toEqual(newValue);
   });
 
   describe('fires', () => {
@@ -152,14 +152,14 @@ describe('asInput()', () => {
           isValid: false,
         };
         const wrapper = mount(<InputTestComponent {...props} />);
-        expect(wrapper.state('isValid')).toEqual(true); // default is true, ignoring our prop
+        expect(wrapper.find('asInput(testComponent)').state('isValid')).toEqual(true); // default is true, ignoring our prop
 
         wrapper.setProps({ isValid: true });
         wrapper.find('input').simulate('blur'); // trigger validation
-        expect(wrapper.state('isValid')).toEqual(false); // validator set false, ignoring our prop
+        expect(wrapper.find('asInput(testComponent)').state('isValid')).toEqual(false); // validator set false, ignoring our prop
 
         wrapper.setProps({ isValid: true });
-        expect(wrapper.state('isValid')).toEqual(false); // resetting prop changes nothing
+        expect(wrapper.find('asInput(testComponent)').state('isValid')).toEqual(false); // resetting prop changes nothing
       });
 
       it('ignores validationMessage prop if validator is defined', () => {
@@ -171,13 +171,13 @@ describe('asInput()', () => {
           validationMessage: 'Prop',
         };
         const wrapper = mount(<InputTestComponent {...props} />);
-        expect(wrapper.state('validationMessage')).toEqual(''); // default is '', ignoring our prop
+        expect(wrapper.find('asInput(testComponent)').state('validationMessage')).toEqual(''); // default is '', ignoring our prop
 
         wrapper.find('input').simulate('blur'); // trigger validation
-        expect(wrapper.state('validationMessage')).toEqual('Spy'); // validator set Spy, ignoring our prop
+        expect(wrapper.find('asInput(testComponent)').state('validationMessage')).toEqual('Spy'); // validator set Spy, ignoring our prop
 
         wrapper.setProps({ validationMessage: 'Reset' });
-        expect(wrapper.state('validationMessage')).toEqual('Spy'); // resetting prop changes nothing
+        expect(wrapper.find('asInput(testComponent)').state('validationMessage')).toEqual('Spy'); // resetting prop changes nothing
       });
 
       it('ignores dangerIconDescription prop if validator is defined', () => {
@@ -189,13 +189,13 @@ describe('asInput()', () => {
           dangerIconDescription: 'Prop',
         };
         const wrapper = mount(<InputTestComponent {...props} />);
-        expect(wrapper.state('dangerIconDescription')).toEqual(''); // default is '', ignoring our prop
+        expect(wrapper.find('asInput(testComponent)').state('dangerIconDescription')).toEqual(''); // default is '', ignoring our prop
 
         wrapper.find('input').simulate('blur'); // trigger validation
-        expect(wrapper.state('dangerIconDescription')).toEqual('Spy'); // validator set Spy, ignoring our prop
+        expect(wrapper.find('asInput(testComponent)').state('dangerIconDescription')).toEqual('Spy'); // validator set Spy, ignoring our prop
 
         wrapper.setProps({ dangerIconDescription: 'Reset' });
-        expect(wrapper.state('dangerIconDescription')).toEqual('Spy'); // resetting prop changes nothing
+        expect(wrapper.find('asInput(testComponent)').state('dangerIconDescription')).toEqual('Spy'); // resetting prop changes nothing
       });
 
       it('uses props if validator becomes undefined', () => {
@@ -209,12 +209,12 @@ describe('asInput()', () => {
           dangerIconDescription: 'Prop',
         };
         const wrapper = mount(<InputTestComponent {...props} />);
-        expect(wrapper.state('validationMessage')).toEqual('');
-        expect(wrapper.state('dangerIconDescription')).toEqual('');
+        expect(wrapper.find('asInput(testComponent)').state('validationMessage')).toEqual('');
+        expect(wrapper.find('asInput(testComponent)').state('dangerIconDescription')).toEqual('');
 
         wrapper.setProps({ validator: null });
-        expect(wrapper.state('validationMessage')).toEqual('Prop');
-        expect(wrapper.state('dangerIconDescription')).toEqual('Prop');
+        expect(wrapper.find('asInput(testComponent)').state('validationMessage')).toEqual('Prop');
+        expect(wrapper.find('asInput(testComponent)').state('dangerIconDescription')).toEqual('Prop');
       });
 
       it('uses validationMessage as element type', () => {
@@ -225,7 +225,7 @@ describe('asInput()', () => {
           validationMessage: testMessage,
         };
         const wrapper = mount(<InputTestComponent {...props} />);
-        expect(wrapper.state('validationMessage')).toEqual(testMessage);
+        expect(wrapper.find('asInput(testComponent)').state('validationMessage')).toEqual(testMessage);
       });
 
       it('uses isValid to display validation message', () => {

--- a/src/asInput/index.jsx
+++ b/src/asInput/index.jsx
@@ -6,6 +6,8 @@ import classNames from 'classnames';
 import newId from '../utils/newId';
 import ValidationMessage from '../ValidationMessage/index';
 import Variant from '../utils/constants';
+import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
+
 
 export const getDisplayName = WrappedComponent =>
   WrappedComponent.displayName || WrappedComponent.name || 'Component';
@@ -28,7 +30,7 @@ export const inputProps = {
   validator: PropTypes.func,
   isValid: PropTypes.bool,
   validationMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-  className: PropTypes.arrayOf(PropTypes.string),
+  className: PropTypes.string,
   themes: PropTypes.arrayOf(PropTypes.string),
   inline: PropTypes.bool,
   inputGroupPrepend: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.element), PropTypes.element]),
@@ -48,7 +50,7 @@ export const defaultProps = {
   validator: undefined,
   isValid: true,
   validationMessage: '',
-  className: [],
+  className: undefined,
   themes: [],
   inline: false,
   inputGroupPrepend: undefined,
@@ -273,7 +275,14 @@ const asInput = (WrappedComponent, inputType = undefined, labelFirst = true) => 
 
   NewComponent.defaultProps = defaultProps;
 
-  return NewComponent;
+  return withDeprecatedProps(NewComponent, {
+    className: {
+      deprType: DEPR_TYPES.FORMAT,
+      expect: value => typeof value === 'string',
+      transform: value => (Array.isArray(value) ? value.join(' ') : value),
+      message: 'It should be a string.',
+    },
+  });
 };
 
 export default asInput;

--- a/src/withDeprecatedProps.jsx
+++ b/src/withDeprecatedProps.jsx
@@ -59,13 +59,9 @@ function withDeprecatedProps(WrappedComponent, deprecatedProps) {
       return acc;
     }
     render() {
-      const transformedProps = Object
+      const { children, ...transformedProps } = Object
         .keys(this.props)
         .reduce(this.transformProps, {});
-
-      // eslint-disable-next-line react/prop-types
-      const children = this.props.children || transformedProps.children;
-      delete transformedProps.children;
 
       return (
         <WrappedComponent {...transformedProps}>

--- a/src/withDeprecatedProps.jsx
+++ b/src/withDeprecatedProps.jsx
@@ -65,7 +65,7 @@ function withDeprecatedProps(WrappedComponent, deprecatedProps) {
 
       return (
         <WrappedComponent {...transformedProps}>
-          {children}
+          {this.props.children || children /* eslint-disable-line react/prop-types */}
         </WrappedComponent>
       );
     }

--- a/src/withDeprecatedProps.jsx
+++ b/src/withDeprecatedProps.jsx
@@ -1,0 +1,83 @@
+/* eslint no-console: 0 */
+import React from 'react';
+
+
+export const DEPR_TYPES = {
+  MOVED: 'MOVED',
+  FORMAT: 'FORMAT',
+};
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+}
+
+
+function withDeprecatedProps(WrappedComponent, deprecatedProps) {
+  class WithDeprecatedProps extends React.Component {
+    constructor(props) {
+      super(props);
+      this.transformProps = this.transformProps.bind(this);
+    }
+
+    warn(message) {
+      if (process.env.NODE_ENV !== 'development') return;
+      console.warn(`[Deprecated] ${message}`);
+    }
+
+    transformProps(acc, propName) {
+      if (deprecatedProps[propName] === undefined) {
+        acc[propName] = this.props[propName];
+        return acc;
+      }
+
+      const {
+        deprType,
+        newName,
+        expect,
+        transform,
+        message,
+      } = deprecatedProps[propName];
+
+      switch (deprType) {
+        case DEPR_TYPES.MOVED:
+          this.warn(`${getDisplayName(WrappedComponent)}: The prop '${propName}' has been moved to '${newName}'.`);
+          acc[newName] = this.props[propName];
+          break;
+        case DEPR_TYPES.FORMAT:
+          if (!expect(this.props[propName])) {
+            this.warn(`${getDisplayName(WrappedComponent)}: The prop '${propName}' expects a new format. ${message}`);
+            acc[propName] = transform(this.props[propName]);
+          } else {
+            acc[propName] = this.props[propName];
+          }
+          break;
+        default:
+          acc[propName] = this.props[propName];
+          break;
+      }
+
+      return acc;
+    }
+    render() {
+      const transformedProps = Object
+        .keys(this.props)
+        .reduce(this.transformProps, {});
+
+      // eslint-disable-next-line react/prop-types
+      const children = this.props.children || transformedProps.children;
+      delete transformedProps.children;
+
+      return (
+        <WrappedComponent {...transformedProps}>
+          {children}
+        </WrappedComponent>
+      );
+    }
+  }
+
+  WithDeprecatedProps.displayName = `WithDeprecatedProps(${getDisplayName(WrappedComponent)})`;
+
+  return WithDeprecatedProps;
+}
+
+export default withDeprecatedProps;


### PR DESCRIPTION
### This PR contains an ADR Component API Guidelines:
https://github.com/edx/paragon/blob/0ed00616ced96a194783199021a4053037482149/docs/decisions/0007-component-api-guidelines.rst

### Change all className props to expect PropTypes.string 
It also replaces all instances of className props that expected an array to expect a string. All component className props should be specified like this `<Button className="class-1 class-2" />`.

### classNames is changed in a backward compatible way
Done using a higher order component `withDeprecatedProps(Component, deprecatePropsObject)`. See here: https://github.com/edx/paragon/compare/abutterworth/change-classname-prop?expand=1#diff-ae4333267b91c362443ba82a15031f3a