### PR TITLE
Prefer children over props

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -3134,6 +3134,7 @@ exports[`Storyshots MailtoLink with blank target 1`] = `
      
     <span
       aria-hidden={false}
+      aria-label="Opens in a new window"
       className="fa fa-external-link"
       title="Opens in a new window"
     />
@@ -3172,6 +3173,7 @@ exports[`Storyshots MailtoLink with onClick 1`] = `
      
     <span
       aria-hidden={false}
+      aria-label="Opens in a new window"
       className="fa fa-external-link"
       title="Opens in a new window"
     />

--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -49,7 +49,7 @@ class Button extends React.Component {
     const {
       buttonType,
       className,
-      label,
+      children,
       isClose,
       type,
       /* inputRef is not used directly in the render, but it needs to be assigned
@@ -78,7 +78,7 @@ class Button extends React.Component {
         ref={this.setRefs}
 
       >
-        {this.props.label}
+        {children}
       </button>
     );
   }
@@ -87,7 +87,7 @@ class Button extends React.Component {
 export const buttonPropTypes = {
   buttonType: PropTypes.string,
   className: PropTypes.string,
-  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  children: PropTypes.node.isRequired,
   inputRef: PropTypes.func,
   isClose: PropTypes.bool,
   onBlur: PropTypes.func,
@@ -110,6 +110,10 @@ Button.defaultProps = {
 };
 
 export default withDeprecatedProps(Button, {
+  label: {
+    deprType: DEPR_TYPES.MOVED,
+    newName: 'children',
+  },
   className: {
     deprType: DEPR_TYPES.FORMAT,
     expect: value => typeof value === 'string',

--- a/src/Hyperlink/Hyperlink.test.jsx
+++ b/src/Hyperlink/Hyperlink.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import classNames from 'classnames';
 
 import Hyperlink from './index';
@@ -23,8 +23,7 @@ const externalLinkProps = {
 
 describe('correct rendering', () => {
   it('renders Hyperlink', () => {
-    const wrapper = shallow(<Hyperlink {...props} />);
-    expect(wrapper.type()).toEqual('a');
+    const wrapper = mount(<Hyperlink {...props} />).find('a');
     expect(wrapper).toHaveLength(1);
 
     expect(wrapper.prop('children')).toEqual([content, undefined]);

--- a/src/Hyperlink/index.jsx
+++ b/src/Hyperlink/index.jsx
@@ -3,10 +3,13 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import isRequiredIf from 'react-proptype-conditional-require';
 
+import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
+
+
 function Hyperlink(props) {
   const {
     destination,
-    content,
+    children,
     target,
     onClick,
     externalLinkAlternativeText,
@@ -36,7 +39,7 @@ function Hyperlink(props) {
       target={target}
       onClick={onClick}
       {...other}
-    >{content}{externalLinkIcon}
+    >{children}{externalLinkIcon}
     </a>
   );
 }
@@ -50,11 +53,16 @@ Hyperlink.defaultProps = {
 
 Hyperlink.propTypes = {
   destination: PropTypes.string.isRequired,
-  content: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  children: PropTypes.node.isRequired,
   target: PropTypes.string,
   onClick: PropTypes.func,
   externalLinkAlternativeText: isRequiredIf(PropTypes.string, props => props.target === '_blank'),
   externalLinkTitle: isRequiredIf(PropTypes.string, props => props.target === '_blank'),
 };
 
-export default Hyperlink;
+export default withDeprecatedProps(Hyperlink, {
+  content: {
+    deprType: DEPR_TYPES.MOVED,
+    newName: 'children',
+  },
+});

--- a/src/MailtoLink/MailtoLink.test.jsx
+++ b/src/MailtoLink/MailtoLink.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import MailtoLink from './index';
 
@@ -21,7 +21,7 @@ describe('correct rendering', () => {
         bcc={emailAddress}
       />
     );
-    const wrapper = shallow(singleRecipientLink);
+    const wrapper = mount(singleRecipientLink).find('a');
 
     expect(wrapper.prop('href')).toEqual('mailto:edx@example.com?bcc=edx%40example.com&body=body&cc=edx%40example.com&subject=subject');
   });
@@ -35,13 +35,13 @@ describe('correct rendering', () => {
         bcc={emailAddresses}
       />
     );
-    const wrapper = shallow(multiRecipientLink);
+    const wrapper = mount(multiRecipientLink).find('a');
 
     expect(wrapper.prop('href')).toEqual('mailto:foo@example.com,bar@example.com,baz@example.com?bcc=foo%40example.com%2Cbar%40example.com%2Cbaz%40example.com&body=body&cc=foo%40example.com%2Cbar%40example.com%2Cbaz%40example.com&subject=subject');
   });
 
   it('renders empty mailtoLink', () => {
-    const wrapper = shallow(<MailtoLink content={content} />);
+    const wrapper = mount(<MailtoLink content={content} />).find('a');
 
     expect(wrapper.prop('href')).toEqual('mailto:');
   });

--- a/src/MailtoLink/index.jsx
+++ b/src/MailtoLink/index.jsx
@@ -5,6 +5,8 @@ import isRequiredIf from 'react-proptype-conditional-require';
 import mailtoLink from 'mailto-link';
 
 import Hyperlink from '../Hyperlink';
+import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
+
 
 const MailtoLink = (props) => {
   const {
@@ -13,7 +15,7 @@ const MailtoLink = (props) => {
     bcc,
     subject,
     body,
-    content,
+    children,
     target,
     onClick,
     externalLink,
@@ -26,15 +28,16 @@ const MailtoLink = (props) => {
     to, cc, bcc, subject, body,
   });
 
-  return Hyperlink({
+  const hyperlinkProps = {
     destination,
-    content,
     target,
     onClick,
     externalLinkAlternativeText,
     externalLinkTitle,
     ...other,
-  });
+  };
+
+  return <Hyperlink {...hyperlinkProps}>{children}</Hyperlink>;
 };
 
 MailtoLink.defaultProps = {
@@ -52,7 +55,7 @@ MailtoLink.defaultProps = {
 };
 
 MailtoLink.propTypes = {
-  content: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  children: PropTypes.node.isRequired,
   to: PropTypes.oneOfType([PropTypes.arrayOf(emailPropType), emailPropType]),
   cc: PropTypes.oneOfType([PropTypes.arrayOf(emailPropType), emailPropType]),
   bcc: PropTypes.oneOfType([PropTypes.arrayOf(emailPropType), emailPropType]),
@@ -66,4 +69,10 @@ MailtoLink.propTypes = {
   }),
 };
 
-export default MailtoLink;
+
+export default withDeprecatedProps(MailtoLink, {
+  content: {
+    deprType: DEPR_TYPES.MOVED,
+    newName: 'children',
+  },
+});

--- a/src/Modal/index.jsx
+++ b/src/Modal/index.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-import Button, { buttonPropTypes } from '../Button';
+import Button from '../Button';
 import Icon from '../Icon';
 import newId from '../utils/newId';
 import Variant from '../utils/constants';
@@ -253,7 +253,7 @@ Modal.propTypes = {
   body: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   buttons: PropTypes.arrayOf(PropTypes.oneOfType([
     PropTypes.element,
-    PropTypes.shape(buttonPropTypes),
+    PropTypes.object, // TODO: Only accept nodes in the future
   ])),
   closeText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   onClose: PropTypes.func.isRequired,


### PR DESCRIPTION
Leverage the withDeprecatedProps high order component to move Button `label` and Hyperlink `content` to `props.children` in a backward compatible way. Usage of these components with deprecated props will show warnings in development.