### PR TITLE
Add transition replace

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -3110,6 +3110,68 @@ exports[`Storyshots Table unstyled 1`] = `
 </table>
 `;
 
+exports[`Storyshots TransitionReplace basic usage 1`] = `
+Array [
+  <div>
+    <button
+      className="btn btn-primary mb-2"
+      onClick={[Function]}
+    >
+      Next Quote
+    </button>
+    <div
+      style={
+        Object {
+          "background": "#eee",
+          "maxWidth": "15rem",
+          "padding": "1rem",
+        }
+      }
+    >
+      <div
+        className="pgn-transition-replace-group"
+        style={
+          Object {
+            "height": null,
+            "overflow": null,
+            "position": "relative",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "padding": ".1px 0",
+            }
+          }
+        >
+          <blockquote
+            className="h2 m-0"
+          >
+            <p>
+              You know the golden rule, don’t you boy? Those who have the gold make the rules.
+            </p>
+            <footer>
+              — Crazy hunch-backed old guy in Aladdin
+            </footer>
+          </blockquote>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="pgn-transition-replace-group"
+    style={
+      Object {
+        "height": null,
+        "overflow": null,
+        "position": "relative",
+      }
+    }
+  />,
+]
+`;
+
 exports[`Storyshots User Input|CheckBox basic usage 1`] = `
 <div
   className="form-check"

--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -3129,12 +3129,10 @@ Array [
       }
     >
       <div
-        className="pgn-transition-replace-group"
+        className="pgn-transition-replace-group position-relative"
         style={
           Object {
             "height": null,
-            "overflow": null,
-            "position": "relative",
           }
         }
       >
@@ -3160,12 +3158,10 @@ Array [
     </div>
   </div>,
   <div
-    className="pgn-transition-replace-group"
+    className="pgn-transition-replace-group position-relative"
     style={
       Object {
         "height": null,
-        "overflow": null,
-        "position": "relative",
       }
     }
   />,

--- a/package-lock.json
+++ b/package-lock.json
@@ -993,7 +993,6 @@
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
       "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.12.0"
       }
@@ -8534,6 +8533,14 @@
       "dev": true,
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
       }
     },
     "dom-serializer": {
@@ -23276,8 +23283,7 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-modal": {
       "version": "3.8.1",
@@ -23404,6 +23410,17 @@
       "requires": {
         "@babel/runtime": "^7.1.2",
         "prop-types": "^15.6.0"
+      }
+    },
+    "react-transition-group": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.8.0.tgz",
+      "integrity": "sha512-So23a1MPn8CGoW5WNU4l0tLiVkOFmeXSS1K4Roe+dxxqqHvI/2XBmj76jx+u96LHnQddWG7LX8QovPAainSmWQ==",
+      "requires": {
+        "dom-helpers": "^3.3.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "reactjs-popup": {
@@ -23897,8 +23914,7 @@
     "regenerator-runtime": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-      "dev": true
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regenerator-transform": {
       "version": "0.13.4",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-proptype-conditional-require": "^1.0.4",
+    "react-transition-group": "^2.8.0",
     "react-responsive": "^6.1.1",
     "sanitize-html": "^1.20.0"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "/src"
   ],
   "scripts": {
-    "build": "webpack --mode production",
+    "build": "webpack --mode production --display-modules",
     "build-storybook": "build-storybook",
     "commit": "commit",
     "coveralls": "cat ./coverage/lcov.info | coveralls",

--- a/src/TransitionReplace/DemoTransitionReplace.jsx
+++ b/src/TransitionReplace/DemoTransitionReplace.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import TransitionReplace from './index';
+
+
+export default function DemoTransitionReplace() {
+  const contentOptions = [
+    (
+      <blockquote className="h2 m-0" key={0}>
+        <p>You know the golden rule, don’t you boy? Those who have the gold make the rules.</p>
+        <footer>— Crazy hunch-backed old guy in Aladdin</footer>
+      </blockquote>
+    ),
+    (
+      <blockquote className="m-0" key={1}>
+        <p>People say nothing is impossible, but I do nothing every day.</p>
+        <footer>— A. A. Milne</footer>
+      </blockquote>
+    ),
+    (
+      <blockquote className="h2 m-0" key={2}>
+        <p>
+          I won’t go into a big spiel about reincarnation, but the first time I was in the
+          Gucci store in Chicago was the closest I’ve ever felt to home.
+        </p>
+        <footer>— Kanye</footer>
+      </blockquote>
+    ),
+    (
+      <blockquote className="m-0" key={3}>
+        <p>The first time I see a jogger smiling, I’ll consider it.</p>
+        <footer>— Joan Rivers</footer>
+      </blockquote>
+    ),
+  ];
+
+  const [currentContentIndex, setCurrentContentIndex] = useState(0);
+  const changeContent = () => {
+    setCurrentContentIndex((currentContentIndex + 1) % contentOptions.length);
+  };
+
+  return (
+    <div>
+      <button className="btn btn-primary mb-2" onClick={changeContent}>Next Quote</button>
+      <div
+        style={{
+          background: '#eee',
+          padding: '1rem',
+          maxWidth: '15rem',
+        }}
+      >
+        <TransitionReplace>
+          {contentOptions[currentContentIndex]}
+        </TransitionReplace>
+      </div>
+    </div>
+  );
+}

--- a/src/TransitionReplace/README.md
+++ b/src/TransitionReplace/README.md
@@ -48,3 +48,9 @@ TransitionReplace uses [CSSTransition from the ReactTransitionGroup package](htt
 ```
 
 If you change the timing in CSS you should also match it using the `enterDuration` and `exitDuration` props.
+
+
+#### Note:
+
+Children are not required. When this component is empty, the a child inserted into it will not transition the height (from zero). No "replacement" transition will occur and new content will pop in like a normal insert. This behaviour makes it easier to work with asyncronously loaded content (for example: during the first load you don't have to do any special handling).
+

--- a/src/TransitionReplace/README.md
+++ b/src/TransitionReplace/README.md
@@ -15,7 +15,7 @@ TransitionReplace expects only one child at any time. Swap content inside the co
       <button type="submit">Save</button>
     </form>
   ): (
-    <div>
+    <div key="other">
       <h4>First Name</h4>
       <p>{name}</p>
     </div>

--- a/src/TransitionReplace/README.md
+++ b/src/TransitionReplace/README.md
@@ -46,3 +46,5 @@ TransitionReplace uses [CSSTransition from the ReactTransitionGroup package](htt
   transition: opacity 300ms ease;
 }
 ```
+
+If you change the timing in CSS you should also match it using the `enterDuration` and `exitDuration` props.

--- a/src/TransitionReplace/README.md
+++ b/src/TransitionReplace/README.md
@@ -1,1 +1,48 @@
 # Transition Replace
+
+Manages a transition when replacing content. By default this component will transition the height and do a cross-fade. The transition can be customized.
+
+TransitionReplace expects only one child at any time. Swap content inside the component (usually based on some state).
+
+### Usage
+
+```jsx
+<TransitionReplace>
+  {this.state.isEditing ? (
+    <form key="the-form">
+      <label htmlFor="name">First Name</label>
+      <input type="text" value={name} />
+      <button type="submit">Save</button>
+    </form>
+  ): (
+    <div>
+      <h4>First Name</h4>
+      <p>{name}</p>
+    </div>
+  )}
+</TransitionReplace>
+```
+
+**IMPORTANT NOTE: You must provide the `key` prop for all children**, even when only rendering a single item. This is how React will determine that a child is new rather than just updated.
+
+### Custom Transition
+
+TransitionReplace uses [CSSTransition from the ReactTransitionGroup package](http://reactcommunity.org/react-transition-group/css-transition). The `transitionClassNames` prop is a pass-through to CSSTransitions's `classNames` prop. You can use this to change the crossfade animation. By default this value is `pgn__transition-replace` and the cross-fade is defined as below:
+
+```css
+.pgn__transition-replace-enter {
+  opacity: 0;
+}
+.pgn__transition-replace-enter-active {
+  opacity: 1;
+  z-index: 1;
+  transition: opacity 300ms ease;
+}
+.pgn__transition-replace-exit {
+  opacity: 1;
+}
+.pgn__transition-replace-exit-active {
+  opacity: 0;
+  transition: opacity 300ms ease;
+}
+```

--- a/src/TransitionReplace/README.md
+++ b/src/TransitionReplace/README.md
@@ -1,0 +1,1 @@
+# Transition Replace

--- a/src/TransitionReplace/TransitionReplace.scss
+++ b/src/TransitionReplace/TransitionReplace.scss
@@ -1,0 +1,18 @@
+.pgn-transition-replace-group {
+  transition: height 300ms ease;
+}
+.pgn__transition-replace-enter {
+  opacity: 0;
+}
+.pgn__transition-replace-enter-active {
+  opacity: 1;
+  z-index: 1;
+  transition: opacity 300ms ease;
+}
+.pgn__transition-replace-exit {
+  opacity: 1;
+}
+.pgn__transition-replace-exit-active {
+  opacity: 0;
+  transition: opacity 300ms ease;
+}

--- a/src/TransitionReplace/TransitionReplace.stories.jsx
+++ b/src/TransitionReplace/TransitionReplace.stories.jsx
@@ -1,13 +1,68 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 
 import TransitionReplace from './index';
 import README from './README.md';
 
+function DemoTransitionReplace() {
+  const contentOptions = [
+    (
+      <blockquote className="h2 m-0" key={0}>
+        <p>You know the golden rule, don’t you boy? Those who have the gold make the rules.</p>
+        <footer>— Crazy hunch-backed old guy in Aladdin</footer>
+      </blockquote>
+    ),
+    (
+      <blockquote className="m-0" key={1}>
+        <p>People say nothing is impossible, but I do nothing every day.</p>
+        <footer>— A. A. Milne</footer>
+      </blockquote>
+    ),
+    (
+      <blockquote className="h2 m-0" key={2}>
+        <p>
+          I won’t go into a big spiel about reincarnation, but the first time I was in the
+          Gucci store in Chicago was the closest I’ve ever felt to home.
+        </p>
+        <footer>— Kanye</footer>
+      </blockquote>
+    ),
+    (
+      <blockquote className="m-0" key={3}>
+        <p>The first time I see a jogger smiling, I’ll consider it.</p>
+        <footer>— Joan Rivers</footer>
+      </blockquote>
+    ),
+  ];
+
+  const [currentContentIndex, setCurrentContentIndex] = useState(0);
+  const changeContent = () => {
+    setCurrentContentIndex((currentContentIndex + 1) % contentOptions.length);
+  };
+
+  return (
+    <div>
+      <button className="btn btn-primary mb-2" onClick={changeContent}>Next Quote</button>
+      <div
+        style={{
+          background: '#eee',
+          padding: '1rem',
+          maxWidth: '15rem',
+        }}
+      >
+        <TransitionReplace>
+          {contentOptions[currentContentIndex]}
+        </TransitionReplace>
+      </div>
+    </div>
+  );
+}
+
 storiesOf('TransitionReplace', module)
-  .addParameters({ info: { text: README } })
+  .addParameters({ info: { text: README, source: false } })
   .add('basic usage', () => (
-    <TransitionReplace>
-      Content
-    </TransitionReplace>
+    <React.Fragment>
+      <DemoTransitionReplace />
+      <TransitionReplace />
+    </React.Fragment>
   ));

--- a/src/TransitionReplace/TransitionReplace.stories.jsx
+++ b/src/TransitionReplace/TransitionReplace.stories.jsx
@@ -1,62 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import TransitionReplace from './index';
 import README from './README.md';
 
-function DemoTransitionReplace() {
-  const contentOptions = [
-    (
-      <blockquote className="h2 m-0" key={0}>
-        <p>You know the golden rule, don’t you boy? Those who have the gold make the rules.</p>
-        <footer>— Crazy hunch-backed old guy in Aladdin</footer>
-      </blockquote>
-    ),
-    (
-      <blockquote className="m-0" key={1}>
-        <p>People say nothing is impossible, but I do nothing every day.</p>
-        <footer>— A. A. Milne</footer>
-      </blockquote>
-    ),
-    (
-      <blockquote className="h2 m-0" key={2}>
-        <p>
-          I won’t go into a big spiel about reincarnation, but the first time I was in the
-          Gucci store in Chicago was the closest I’ve ever felt to home.
-        </p>
-        <footer>— Kanye</footer>
-      </blockquote>
-    ),
-    (
-      <blockquote className="m-0" key={3}>
-        <p>The first time I see a jogger smiling, I’ll consider it.</p>
-        <footer>— Joan Rivers</footer>
-      </blockquote>
-    ),
-  ];
-
-  const [currentContentIndex, setCurrentContentIndex] = useState(0);
-  const changeContent = () => {
-    setCurrentContentIndex((currentContentIndex + 1) % contentOptions.length);
-  };
-
-  return (
-    <div>
-      <button className="btn btn-primary mb-2" onClick={changeContent}>Next Quote</button>
-      <div
-        style={{
-          background: '#eee',
-          padding: '1rem',
-          maxWidth: '15rem',
-        }}
-      >
-        <TransitionReplace>
-          {contentOptions[currentContentIndex]}
-        </TransitionReplace>
-      </div>
-    </div>
-  );
-}
+import DemoTransitionReplace from './DemoTransitionReplace';
 
 storiesOf('TransitionReplace', module)
   .addParameters({ info: { text: README, source: false } })

--- a/src/TransitionReplace/TransitionReplace.stories.jsx
+++ b/src/TransitionReplace/TransitionReplace.stories.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import TransitionReplace from './index';
+import README from './README.md';
+
+storiesOf('TransitionReplace', module)
+  .addParameters({ info: { text: README } })
+  .add('basic usage', () => (
+    <TransitionReplace>
+      Content
+    </TransitionReplace>
+  ));

--- a/src/TransitionReplace/TransitionReplace.test.jsx
+++ b/src/TransitionReplace/TransitionReplace.test.jsx
@@ -1,0 +1,14 @@
+// import React from 'react';
+// import { mount, shallow } from 'enzyme';
+
+// import TransitionReplace from './index';
+
+// describe('<TransitionReplace />', () => {
+//   describe('renders', () => {
+//     const wrapper = mount((
+//       <TransitionReplace>
+//         Content
+//       </TransitionReplace>
+//     ));
+//   });
+// });

--- a/src/TransitionReplace/TransitionReplace.test.jsx
+++ b/src/TransitionReplace/TransitionReplace.test.jsx
@@ -1,14 +1,80 @@
-// import React from 'react';
-// import { mount, shallow } from 'enzyme';
+/* eslint-disable no-plusplus, react/prop-types */
+import React from 'react';
+import { mount } from 'enzyme';
 
-// import TransitionReplace from './index';
+import TransitionReplace from './index';
 
-// describe('<TransitionReplace />', () => {
-//   describe('renders', () => {
-//     const wrapper = mount((
-//       <TransitionReplace>
-//         Content
-//       </TransitionReplace>
-//     ));
-//   });
-// });
+
+function TestReplacement({ showContentA, ...props }) {
+  return (
+    <TransitionReplace {...props}>
+      {showContentA ? (
+        <div key="content-a">A</div>
+      ) : (
+        <div key="content-b">B</div>
+      )}
+    </TransitionReplace>
+  );
+}
+
+describe('TransitionReplace', () => {
+  const wrapper = mount((
+    <TestReplacement
+      showContentA
+      enterDuration={10}
+      exitDuration={10}
+      transitionClassNames="test"
+    />
+  ));
+
+  it('should add entering class names for each part of the transition', (done) => {
+    let count = 0;
+
+    wrapper.setProps({
+      showContentA: false,
+      onChildEnter: (node) => {
+        count++;
+        expect(count).toEqual(1);
+        expect(node.classList.contains('test-enter')).toEqual(true);
+      },
+      onChildEntering: (node) => {
+        count++;
+        expect(count).toEqual(2);
+        expect(node.classList.contains('test-enter-active')).toEqual(true);
+      },
+      onChildEntered: (node) => {
+        count++;
+        expect(count).toEqual(3);
+        expect(node.classList.contains('test-enter-done')).toEqual(true);
+        done();
+      },
+    });
+  });
+
+  it('should add exiting class names for each part of the transition', (done) => {
+    let count = 0;
+
+    wrapper.setProps({
+      showContentA: true, // swap from previous it()
+      onChildEnter: undefined,
+      onChildEntering: undefined,
+      onChildEntered: undefined,
+      onChildExit: (node) => {
+        count++;
+        expect(count).toEqual(1);
+        expect(node.classList.contains('test-exit')).toEqual(true);
+      },
+      onChildExiting: (node) => {
+        count++;
+        expect(count).toEqual(2);
+        expect(node.classList.contains('test-exit-active')).toEqual(true);
+      },
+      onChildExited: (node) => {
+        count++;
+        expect(count).toEqual(3);
+        expect(node.classList.contains('test-exit-done')).toEqual(true);
+        done();
+      },
+    });
+  });
+});

--- a/src/TransitionReplace/index.jsx
+++ b/src/TransitionReplace/index.jsx
@@ -10,8 +10,10 @@ const propTypes = {
   exitDuration: PropTypes.number,
   className: PropTypes.string,
   onChildEnter: PropTypes.func,
+  onChildEntering: PropTypes.func,
   onChildEntered: PropTypes.func,
   onChildExit: PropTypes.func,
+  onChildExiting: PropTypes.func,
   onChildExited: PropTypes.func,
   transitionStyles: PropTypes.shape({
     entering: PropTypes.object,
@@ -28,8 +30,10 @@ const defaultProps = {
   exitDuration: 300,
   className: undefined,
   onChildEnter: undefined,
+  onChildEntering: undefined,
   onChildEntered: undefined,
   onChildExit: undefined,
+  onChildExiting: undefined,
   onChildExited: undefined,
   transitionStyles: {},
   transitionClassNames: 'pgn__transition-replace',
@@ -46,6 +50,7 @@ class TransitionReplace extends React.Component {
     this.onChildEntering = this.onChildEntering.bind(this);
     this.onChildEntered = this.onChildEntered.bind(this);
     this.onChildExit = this.onChildExit.bind(this);
+    this.onChildExiting = this.onChildExiting.bind(this);
     this.onChildExited = this.onChildExited.bind(this);
   }
 
@@ -69,6 +74,7 @@ class TransitionReplace extends React.Component {
 
   onChildEntering(htmlNode) {
     this.setState({ height: htmlNode.offsetHeight });
+    if (this.props.onChildEntering) this.props.onChildEntering(htmlNode);
   }
 
   onChildEntered(htmlNode) {
@@ -79,6 +85,10 @@ class TransitionReplace extends React.Component {
   onChildExit(htmlNode) {
     this.setState({ height: htmlNode.offsetHeight });
     if (this.props.onChildExit) this.props.onChildExit(htmlNode);
+  }
+
+  onChildExiting(htmlNode) {
+    if (this.props.onChildExiting) this.props.onChildExiting(htmlNode);
   }
 
   onChildExited(htmlNode) {
@@ -123,6 +133,7 @@ class TransitionReplace extends React.Component {
         onEntering={this.onChildEntering}
         onEntered={this.onChildEntered}
         onExit={this.onChildExit}
+        onExiting={this.onChildExiting}
         onExited={this.onChildExited}
         classNames={this.props.transitionClassNames}
       >

--- a/src/TransitionReplace/index.jsx
+++ b/src/TransitionReplace/index.jsx
@@ -155,12 +155,13 @@ class TransitionReplace extends React.Component {
   render() {
     return (
       <TransitionGroup
-        className={classNames('pgn-transition-replace-group', this.props.className)}
-        style={{
-          position: 'relative',
-          overflow: this.state.height === null ? null : 'hidden',
-          height: this.state.height,
-        }}
+        className={classNames(
+          'pgn-transition-replace-group',
+          'position-relative',
+          { 'overflow-hidden': this.state.height !== null },
+          this.props.className,
+        )}
+        style={{ height: this.state.height }}
       >
         {React.Children.map(this.props.children, this.renderChildTransition, this)}
       </TransitionGroup>

--- a/src/TransitionReplace/index.jsx
+++ b/src/TransitionReplace/index.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 
 
 const propTypes = {
-  children: PropTypes.node,
+  children: PropTypes.element,
   enterDuration: PropTypes.number,
   exitDuration: PropTypes.number,
   className: PropTypes.string,
@@ -87,6 +87,10 @@ class TransitionReplace extends React.Component {
   }
 
   renderChildTransition(child) {
+    if (!child.key && process.env.NODE_ENV === 'development') {
+      // eslint-disable-next-line no-console
+      console.warn("TransitionReplace: A child is missing a 'key' prop. Key's are required for any child of this component.");
+    }
     // Makes the exiting and entering children occupy the same space
     // SCSS handles the crossfade so it can be easily overridden
     const commonChildStyles = {

--- a/src/TransitionReplace/index.jsx
+++ b/src/TransitionReplace/index.jsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import classNames from 'classnames';
+
+
+const propTypes = {
+  children: PropTypes.node,
+  enterDuration: PropTypes.number,
+  exitDuration: PropTypes.number,
+  className: PropTypes.string,
+  onChildEnter: PropTypes.func,
+  onChildEntered: PropTypes.func,
+  onChildExit: PropTypes.func,
+  onChildExited: PropTypes.func,
+  transitionStyles: PropTypes.shape({
+    entering: PropTypes.object,
+    entered: PropTypes.object,
+    exiting: PropTypes.object,
+    exited: PropTypes.object,
+  }),
+  transitionClassNames: PropTypes.string,
+};
+
+const defaultProps = {
+  children: undefined,
+  enterDuration: 300,
+  exitDuration: 300,
+  className: undefined,
+  onChildEnter: undefined,
+  onChildEntered: undefined,
+  onChildExit: undefined,
+  onChildExited: undefined,
+  transitionStyles: {},
+  transitionClassNames: 'pgn__transition-replace',
+};
+
+
+class TransitionReplace extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = { height: null };
+
+    this.onChildEnter = this.onChildEnter.bind(this);
+    this.onChildEntering = this.onChildEntering.bind(this);
+    this.onChildEntered = this.onChildEntered.bind(this);
+    this.onChildExit = this.onChildExit.bind(this);
+    this.onChildExited = this.onChildExited.bind(this);
+  }
+
+  // Transition events are fired in this order:
+  //
+  // onEnter > onEntering > onEntered
+  // onExit  > onExiting  > onExited
+  //
+  // Keep in mind that we always have two transitions happening
+  // both the entering and leaving children
+  //
+  // We set the container height (for animation) in this order:
+  //
+  // 1. onChildExit         (explicitly set the height to match the current current)
+  // 2. onChildEntering     (set the height to match the new content)
+  // 3. onChildExited       (reset the height to null)
+
+  onChildEnter(htmlNode) {
+    if (this.props.onChildEnter) this.props.onChildEnter(htmlNode);
+  }
+
+  onChildEntering(htmlNode) {
+    this.setState({ height: htmlNode.offsetHeight });
+  }
+
+  onChildEntered(htmlNode) {
+    this.setState({ height: null });
+    if (this.props.onChildEntered) this.props.onChildEntered(htmlNode);
+  }
+
+  onChildExit(htmlNode) {
+    this.setState({ height: htmlNode.offsetHeight });
+    if (this.props.onChildExit) this.props.onChildExit(htmlNode);
+  }
+
+  onChildExited(htmlNode) {
+    this.setState({ height: null });
+    if (this.props.onChildExited) this.props.onChildExited(htmlNode);
+  }
+
+  renderChildTransition(child) {
+    // Makes the exiting and entering children occupy the same space
+    // SCSS handles the crossfade so it can be easily overridden
+    const commonChildStyles = {
+      // Prevent margin-collapsing which throws off height calculations
+      padding: '.1px 0',
+    };
+
+    const transitionStyles = {
+      entering: {},
+      entered: {},
+      exiting: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        pointerEvents: 'none',
+      },
+      exited: {},
+    };
+
+    return (
+      <CSSTransition
+        timeout={{
+          enter: this.props.enterDuration,
+          exit: this.props.exitDuration,
+        }}
+        unmountOnExit
+        mountOnEnter
+        onEnter={this.onChildEnter}
+        onEntering={this.onChildEntering}
+        onEntered={this.onChildEntered}
+        onExit={this.onChildExit}
+        onExited={this.onChildExited}
+        classNames={this.props.transitionClassNames}
+      >
+        {state => (
+          <div
+            style={{
+              ...commonChildStyles,
+              ...transitionStyles[state],
+              ...this.props.transitionStyles[state],
+            }}
+          >
+            {child}
+          </div>
+        )}
+      </CSSTransition>
+    );
+  }
+
+  render() {
+    return (
+      <TransitionGroup
+        className={classNames('pgn-transition-replace-group', this.props.className)}
+        style={{
+          position: 'relative',
+          overflow: this.state.height === null ? null : 'hidden',
+          height: this.state.height,
+        }}
+      >
+        {React.Children.map(this.props.children, this.renderChildTransition, this)}
+      </TransitionGroup>
+    );
+  }
+}
+
+
+TransitionReplace.propTypes = propTypes;
+TransitionReplace.defaultProps = defaultProps;
+
+
+export default TransitionReplace;

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ import Table from './Table';
 import Tabs from './Tabs';
 import TextArea from './TextArea';
 import ValidationFormGroup from './ValidationFormGroup';
+import TransitionReplace from './TransitionReplace';
 import ValidationMessage from './ValidationMessage';
 import Variant from './utils/constants';
 
@@ -69,6 +70,7 @@ export {
   Tabs,
   TextArea,
   ValidationFormGroup,
+  TransitionReplace,
   ValidationMessage,
   Variant,
 };

--- a/src/index.scss
+++ b/src/index.scss
@@ -7,4 +7,5 @@
 @import './SearchField/SearchField.scss';
 @import './StatefulButton/StatefulButton.scss';
 @import './Table/Table.scss';
+@import './TransitionReplace/TransitionReplace.scss';
 @import './ValidationMessage/ValidationMessage.scss';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,12 @@ module.exports = {
       amd: 'ReactDOM',
       root: 'ReactDOM',
     },
+    'react-transition-group': {
+      commonjs: 'react-transition-group',
+      commonjs2: 'react-transition-group',
+      amd: 'ReactTransitionGroup',
+      root: 'ReactTransitionGroup',
+    },
   },
   plugins: [
     new UglifyJsPlugin(),


### PR DESCRIPTION
# Transition Replace

![transition-replace 2019-04-05 16_46_06](https://user-images.githubusercontent.com/1615421/55655474-59994680-57c2-11e9-92ec-0f3290a2a58c.gif)

Manages a transition when replacing content. By default this component will transition the height and do a cross-fade. The transition can be customized.

TransitionReplace expects only one child at any time. Swap content inside the component (usually based on some state).

### Usage

```jsx
<TransitionReplace>
  {this.state.isEditing ? (
    <form key="the-form">
      <label htmlFor="name">First Name</label>
      <input type="text" value={name} />
      <button type="submit">Save</button>
    </form>
  ): (
    <div key="other">
      <h4>First Name</h4>
      <p>{name}</p>
    </div>
  )}
</TransitionReplace>
```

**IMPORTANT NOTE: You must provide the `key` prop for all children**, even when only rendering a single item. This is how React will determine that a child is new rather than just updated.

### Custom Transition

TransitionReplace uses [CSSTransition from the ReactTransitionGroup package](http://reactcommunity.org/react-transition-group/css-transition). The `transitionClassNames` prop is a pass-through to CSSTransitions's `classNames` prop. You can use this to change the crossfade animation. By default this value is `pgn__transition-replace` and the cross-fade is defined as below:

```css
.pgn__transition-replace-enter {
  opacity: 0;
}
.pgn__transition-replace-enter-active {
  opacity: 1;
  z-index: 1;
  transition: opacity 300ms ease;
}
.pgn__transition-replace-exit {
  opacity: 1;
}
.pgn__transition-replace-exit-active {
  opacity: 0;
  transition: opacity 300ms ease;
}
```

If you change the timing in CSS you should also match it using the `enterDuration` and `exitDuration` props.
