### PR TITLE
Show warnings during development

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 coverage/*
 dist/
 node_modules/
+index.js

--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+// Set an environment variable on the window during
+// development mode of the consuming application.
+// This enables the production, built version of
+// Paragon to display warnings during development.
+if (process.env.NODE_ENV === 'development') {
+  window.PARAGON_ENV = 'development';
+}
+
+module.exports = require('./dist/paragon.js');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/paragon",
   "version": "0.0.0-development",
   "description": "Accessible, responsive UI component library based on Bootstrap.",
-  "main": "dist/paragon.js",
+  "main": "index.js",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -109,7 +109,7 @@ Button.defaultProps = {
   type: 'button',
 };
 
-export default withDeprecatedProps(Button, {
+export default withDeprecatedProps(Button, 'Button', {
   label: {
     deprType: DEPR_TYPES.MOVED,
     newName: 'children',

--- a/src/Hyperlink/index.jsx
+++ b/src/Hyperlink/index.jsx
@@ -63,7 +63,7 @@ Hyperlink.propTypes = {
   externalLinkTitle: isRequiredIf(PropTypes.string, props => props.target === '_blank'),
 };
 
-export default withDeprecatedProps(Hyperlink, {
+export default withDeprecatedProps(Hyperlink, 'Hyperlink', {
   content: {
     deprType: DEPR_TYPES.MOVED,
     newName: 'children',

--- a/src/Icon/index.jsx
+++ b/src/Icon/index.jsx
@@ -36,7 +36,7 @@ Icon.defaultProps = {
   screenReaderText: undefined,
 };
 
-export default withDeprecatedProps(Icon, {
+export default withDeprecatedProps(Icon, 'Icon', {
   className: {
     deprType: DEPR_TYPES.FORMAT,
     expect: value => typeof value === 'string',

--- a/src/InputSelect/index.jsx
+++ b/src/InputSelect/index.jsx
@@ -76,7 +76,7 @@ Select.propTypes = {
   ]).isRequired,
 };
 
-const InputSelect = asInput(withDeprecatedProps(Select, {
+const InputSelect = asInput(withDeprecatedProps(Select, 'InputSelect', {
   className: {
     deprType: DEPR_TYPES.FORMAT,
     expect: value => typeof value === 'string',

--- a/src/InputText/index.jsx
+++ b/src/InputText/index.jsx
@@ -52,7 +52,7 @@ const textDefaultProps = {
 Text.propTypes = { ...textPropTypes, ...inputProps };
 Text.defaultProps = { ...textDefaultProps, ...defaultProps };
 
-const InputText = asInput(withDeprecatedProps(Text, {
+const InputText = asInput(withDeprecatedProps(Text, 'InputText', {
   className: {
     deprType: DEPR_TYPES.FORMAT,
     expect: value => typeof value === 'string',

--- a/src/MailtoLink/index.jsx
+++ b/src/MailtoLink/index.jsx
@@ -70,7 +70,7 @@ MailtoLink.propTypes = {
 };
 
 
-export default withDeprecatedProps(MailtoLink, {
+export default withDeprecatedProps(MailtoLink, 'MailtoLink', {
   content: {
     deprType: DEPR_TYPES.MOVED,
     newName: 'children',

--- a/src/StatusAlert/index.jsx
+++ b/src/StatusAlert/index.jsx
@@ -124,7 +124,7 @@ StatusAlert.defaultProps = {
   open: false,
 };
 
-export default withDeprecatedProps(StatusAlert, {
+export default withDeprecatedProps(StatusAlert, 'StatusAlert', {
   className: {
     deprType: DEPR_TYPES.FORMAT,
     expect: value => typeof value === 'string',

--- a/src/Table/index.jsx
+++ b/src/Table/index.jsx
@@ -202,7 +202,7 @@ Table.defaultProps = {
 };
 
 
-export default withDeprecatedProps(Table, {
+export default withDeprecatedProps(Table, 'Table', {
   className: {
     deprType: DEPR_TYPES.FORMAT,
     expect: value => typeof value === 'string',

--- a/src/TextArea/index.jsx
+++ b/src/TextArea/index.jsx
@@ -26,7 +26,7 @@ function Text(props) {
 
 Text.propTypes = inputProps;
 
-const TextArea = asInput(withDeprecatedProps(Text, {
+const TextArea = asInput(withDeprecatedProps(Text, 'TextArea', {
   className: {
     deprType: DEPR_TYPES.FORMAT,
     expect: value => typeof value === 'string',

--- a/src/asInput/index.jsx
+++ b/src/asInput/index.jsx
@@ -275,7 +275,7 @@ const asInput = (WrappedComponent, inputType = undefined, labelFirst = true) => 
 
   NewComponent.defaultProps = defaultProps;
 
-  return withDeprecatedProps(NewComponent, {
+  return withDeprecatedProps(NewComponent, 'asInput', {
     className: {
       deprType: DEPR_TYPES.FORMAT,
       expect: value => typeof value === 'string',

--- a/src/withDeprecatedProps.jsx
+++ b/src/withDeprecatedProps.jsx
@@ -16,8 +16,8 @@ function withDeprecatedProps(WrappedComponent, componentName, deprecatedProps) {
     }
 
     warn(message) {
-      if (window && console && window.PARAGON_ENV === 'development') {
-        console.warn(`[Deprecated] ${message}`);
+      if (process.env.NODE_ENV === 'development' || (window && window.PARAGON_ENV === 'development')) {
+        if (console) console.warn(`[Deprecated] ${message}`);
       }
     }
 

--- a/src/withDeprecatedProps.jsx
+++ b/src/withDeprecatedProps.jsx
@@ -20,8 +20,9 @@ function withDeprecatedProps(WrappedComponent, deprecatedProps) {
     }
 
     warn(message) {
-      if (process.env.NODE_ENV !== 'development') return;
-      console.warn(`[Deprecated] ${message}`);
+      if (window && console && window.PARAGON_ENV === 'development') {
+        console.warn(`[Deprecated] ${message}`);
+      }
     }
 
     transformProps(acc, propName) {

--- a/src/withDeprecatedProps.jsx
+++ b/src/withDeprecatedProps.jsx
@@ -7,12 +7,8 @@ export const DEPR_TYPES = {
   FORMAT: 'FORMAT',
 };
 
-function getDisplayName(WrappedComponent) {
-  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
-}
 
-
-function withDeprecatedProps(WrappedComponent, deprecatedProps) {
+function withDeprecatedProps(WrappedComponent, componentName, deprecatedProps) {
   class WithDeprecatedProps extends React.Component {
     constructor(props) {
       super(props);
@@ -41,12 +37,12 @@ function withDeprecatedProps(WrappedComponent, deprecatedProps) {
 
       switch (deprType) {
         case DEPR_TYPES.MOVED:
-          this.warn(`${getDisplayName(WrappedComponent)}: The prop '${propName}' has been moved to '${newName}'.`);
+          this.warn(`${componentName}: The prop '${propName}' has been moved to '${newName}'.`);
           acc[newName] = this.props[propName];
           break;
         case DEPR_TYPES.FORMAT:
           if (!expect(this.props[propName])) {
-            this.warn(`${getDisplayName(WrappedComponent)}: The prop '${propName}' expects a new format. ${message}`);
+            this.warn(`${componentName}: The prop '${propName}' expects a new format. ${message}`);
             acc[propName] = transform(this.props[propName]);
           } else {
             acc[propName] = this.props[propName];
@@ -72,7 +68,7 @@ function withDeprecatedProps(WrappedComponent, deprecatedProps) {
     }
   }
 
-  WithDeprecatedProps.displayName = `WithDeprecatedProps(${getDisplayName(WrappedComponent)})`;
+  WithDeprecatedProps.displayName = `withDeprecatedProps(${componentName})`;
 
   return WithDeprecatedProps;
 }


### PR DESCRIPTION
Deprecation warnings were not showing in consuming applications because Paragon was using `process.env.NODE_ENV` to determine if a warning should be logged. Since this is always 'production' in the built, consumed version of Paragon, no warnings would be shown.

Now, the entry point for Paragon is `/index.js` which will set a variable `PARAGON_ENV` on the window during development. Since this file is not built by webpack it has access to the parent application's `process.env.NODE_ENV` value.

Lastly, a small change to `withDeprecatedProps` adds a parameter to specify the component name as a string. This way warnings will show the specified component name and not a minified one.

Result:
<img width="629" alt="Screen Shot 2019-04-08 at 12 09 07 PM" src="https://user-images.githubusercontent.com/1615421/55740354-e75e7700-59f8-11e9-9c89-c50e4cfa2e8e.png">
