### PR TITLE
fix: pass through unknown props for asInput components

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -1245,7 +1245,7 @@ exports[`Storyshots Navigation|Pagination basic usage 1`] = `
           <span
             aria-hidden={true}
             className="fa fa-chevron-left mr-2"
-            id="pagination-41"
+            id="pagination-42"
           />
           Previous
         </div>
@@ -1268,7 +1268,7 @@ exports[`Storyshots Navigation|Pagination basic usage 1`] = `
           <span
             aria-hidden={true}
             className="fa fa-chevron-right ml-2"
-            id="pagination-43"
+            id="pagination-44"
           />
         </div>
       </button>
@@ -1309,7 +1309,7 @@ exports[`Storyshots Navigation|Pagination with custom element labels 1`] = `
           <span
             aria-hidden={true}
             className="fa fa-chevron-left mr-2"
-            id="pagination-54"
+            id="pagination-55"
           />
           <span>
             Anterior
@@ -1336,7 +1336,7 @@ exports[`Storyshots Navigation|Pagination with custom element labels 1`] = `
           <span
             aria-hidden={true}
             className="fa fa-chevron-right ml-2"
-            id="pagination-56"
+            id="pagination-57"
           />
         </div>
       </button>
@@ -1377,7 +1377,7 @@ exports[`Storyshots Navigation|Pagination with custom string labels 1`] = `
           <span
             aria-hidden={true}
             className="fa fa-chevron-left mr-2"
-            id="pagination-51"
+            id="pagination-52"
           />
           Anterior
         </div>
@@ -1400,7 +1400,7 @@ exports[`Storyshots Navigation|Pagination with custom string labels 1`] = `
           <span
             aria-hidden={true}
             className="fa fa-chevron-right ml-2"
-            id="pagination-53"
+            id="pagination-54"
           />
         </div>
       </button>
@@ -1440,7 +1440,7 @@ exports[`Storyshots Navigation|Pagination with initial page selected 1`] = `
           <span
             aria-hidden={true}
             className="fa fa-chevron-left mr-2"
-            id="pagination-44"
+            id="pagination-45"
           />
           Previous
         </div>
@@ -1463,7 +1463,7 @@ exports[`Storyshots Navigation|Pagination with initial page selected 1`] = `
           <span
             aria-hidden={true}
             className="fa fa-chevron-right ml-2"
-            id="pagination-47"
+            id="pagination-48"
           />
         </div>
       </button>
@@ -1504,7 +1504,7 @@ exports[`Storyshots Navigation|Pagination with max pages displayed 1`] = `
           <span
             aria-hidden={true}
             className="fa fa-chevron-left mr-2"
-            id="pagination-48"
+            id="pagination-49"
           />
           Previous
         </div>
@@ -1527,7 +1527,7 @@ exports[`Storyshots Navigation|Pagination with max pages displayed 1`] = `
           <span
             aria-hidden={true}
             className="fa fa-chevron-right ml-2"
-            id="pagination-50"
+            id="pagination-51"
           />
         </div>
       </button>
@@ -1545,10 +1545,10 @@ exports[`Storyshots Navigation|Tabs basic usage 1`] = `
     role="tablist"
   >
     <button
-      aria-controls="tab-panel-tabInterface63-0"
+      aria-controls="tab-panel-tabInterface64-0"
       aria-selected={true}
       className="btn nav-link nav-item active"
-      id="tab-label-tabInterface63-0"
+      id="tab-label-tabInterface64-0"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -1558,10 +1558,10 @@ exports[`Storyshots Navigation|Tabs basic usage 1`] = `
       Panel 1
     </button>
     <button
-      aria-controls="tab-panel-tabInterface63-1"
+      aria-controls="tab-panel-tabInterface64-1"
       aria-selected={false}
       className="btn nav-link nav-item"
-      id="tab-label-tabInterface63-1"
+      id="tab-label-tabInterface64-1"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -1571,10 +1571,10 @@ exports[`Storyshots Navigation|Tabs basic usage 1`] = `
       Panel 2
     </button>
     <button
-      aria-controls="tab-panel-tabInterface63-2"
+      aria-controls="tab-panel-tabInterface64-2"
       aria-selected={false}
       className="btn nav-link nav-item"
-      id="tab-label-tabInterface63-2"
+      id="tab-label-tabInterface64-2"
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -1590,9 +1590,9 @@ exports[`Storyshots Navigation|Tabs basic usage 1`] = `
   >
     <div
       aria-hidden={false}
-      aria-labelledby="tab-label-tabInterface63-0"
+      aria-labelledby="tab-label-tabInterface64-0"
       className="tab-pane active"
-      id="tab-panel-tabInterface63-0"
+      id="tab-panel-tabInterface64-0"
       role="tabpanel"
     >
       <div>
@@ -1601,9 +1601,9 @@ exports[`Storyshots Navigation|Tabs basic usage 1`] = `
     </div>
     <div
       aria-hidden={true}
-      aria-labelledby="tab-label-tabInterface63-1"
+      aria-labelledby="tab-label-tabInterface64-1"
       className="tab-pane"
-      id="tab-panel-tabInterface63-1"
+      id="tab-panel-tabInterface64-1"
       role="tabpanel"
     >
       <div>
@@ -1612,9 +1612,9 @@ exports[`Storyshots Navigation|Tabs basic usage 1`] = `
     </div>
     <div
       aria-hidden={true}
-      aria-labelledby="tab-label-tabInterface63-2"
+      aria-labelledby="tab-label-tabInterface64-2"
       className="tab-pane"
-      id="tab-panel-tabInterface63-2"
+      id="tab-panel-tabInterface64-2"
       role="tabpanel"
     >
       <div>
@@ -3180,11 +3180,24 @@ exports[`Storyshots User Input|CheckBox basic usage 1`] = `
         "form-check-input is-invalid-nodanger",
       ]
     }
+    dangerIconDescription=""
+    describedBy="error-asInput3"
+    descriptionId="description-asInput3"
     disabled={false}
+    errorId="error-asInput3"
     id="asInput3"
+    inline={false}
+    isValid={true}
+    label="check me out!"
     name="checkbox"
+    onBlur={[Function]}
     onChange={[Function]}
+    onKeyPress={[Function]}
+    required={false}
+    themes={Array []}
     type="checkbox"
+    validationMessage=""
+    value=""
   />
   <label
     className="form-check-label"
@@ -3215,11 +3228,24 @@ exports[`Storyshots User Input|CheckBox call a function 1`] = `
         "form-check-input is-invalid-nodanger",
       ]
     }
+    dangerIconDescription=""
+    describedBy="error-asInput6"
+    descriptionId="description-asInput6"
     disabled={false}
+    errorId="error-asInput6"
     id="asInput6"
+    inline={false}
+    isValid={true}
+    label="check out the console"
     name="checkbox"
+    onBlur={[Function]}
     onChange={[Function]}
+    onKeyPress={[Function]}
+    required={false}
+    themes={Array []}
     type="checkbox"
+    validationMessage=""
+    value=""
   />
   <label
     className="form-check-label"
@@ -3260,11 +3286,24 @@ exports[`Storyshots User Input|CheckBox controlled 1`] = `
           "form-check-input is-invalid-nodanger",
         ]
       }
+      dangerIconDescription=""
+      describedBy="error-asInput7"
+      descriptionId="description-asInput7"
       disabled={false}
+      errorId="error-asInput7"
       id="asInput7"
+      inline={false}
+      isValid={true}
+      label="click the button"
       name="checkbox"
+      onBlur={[Function]}
       onChange={[Function]}
+      onKeyPress={[Function]}
+      required={false}
+      themes={Array []}
       type="checkbox"
+      validationMessage=""
+      value=""
     />
     <label
       className="form-check-label"
@@ -3296,11 +3335,24 @@ exports[`Storyshots User Input|CheckBox default checked 1`] = `
         "form-check-input is-invalid-nodanger",
       ]
     }
+    dangerIconDescription=""
+    describedBy="error-asInput5"
+    descriptionId="description-asInput5"
     disabled={false}
+    errorId="error-asInput5"
     id="asInput5"
+    inline={false}
+    isValid={true}
+    label="(un)check me out"
     name="checkbox"
+    onBlur={[Function]}
     onChange={[Function]}
+    onKeyPress={[Function]}
+    required={false}
+    themes={Array []}
     type="checkbox"
+    validationMessage=""
+    value=""
   />
   <label
     className="form-check-label"
@@ -3331,11 +3383,24 @@ exports[`Storyshots User Input|CheckBox disabled 1`] = `
         "form-check-input is-invalid-nodanger",
       ]
     }
+    dangerIconDescription=""
+    describedBy="error-asInput4"
+    descriptionId="description-asInput4"
     disabled={true}
+    errorId="error-asInput4"
     id="asInput4"
+    inline={false}
+    isValid={true}
+    label="you cannot check me out"
     name="checkbox"
+    onBlur={[Function]}
     onChange={[Function]}
+    onKeyPress={[Function]}
+    required={false}
+    themes={Array []}
     type="checkbox"
+    validationMessage=""
+    value=""
   />
   <label
     className="form-check-label"
@@ -3369,11 +3434,24 @@ exports[`Storyshots User Input|CheckBoxGroup basic usage 1`] = `
           "form-check-input is-invalid-nodanger",
         ]
       }
+      dangerIconDescription=""
+      describedBy="error-checkbox1"
+      descriptionId="description-checkbox1"
       disabled={false}
+      errorId="error-checkbox1"
       id="checkbox1"
+      inline={false}
+      isValid={true}
+      label="CheckBox 1"
       name="basicCheckBox1"
+      onBlur={[Function]}
       onChange={[Function]}
+      onKeyPress={[Function]}
+      required={false}
+      themes={Array []}
       type="checkbox"
+      validationMessage=""
+      value=""
     />
     <label
       className="form-check-label"
@@ -3401,11 +3479,24 @@ exports[`Storyshots User Input|CheckBoxGroup basic usage 1`] = `
           "form-check-input is-invalid-nodanger",
         ]
       }
+      dangerIconDescription=""
+      describedBy="error-checkbox2"
+      descriptionId="description-checkbox2"
       disabled={false}
+      errorId="error-checkbox2"
       id="checkbox2"
+      inline={false}
+      isValid={true}
+      label="CheckBox 2"
       name="basicCheckBox2"
+      onBlur={[Function]}
       onChange={[Function]}
+      onKeyPress={[Function]}
+      required={false}
+      themes={Array []}
       type="checkbox"
+      validationMessage=""
+      value=""
     />
     <label
       className="form-check-label"
@@ -3433,11 +3524,24 @@ exports[`Storyshots User Input|CheckBoxGroup basic usage 1`] = `
           "form-check-input is-invalid-nodanger",
         ]
       }
+      dangerIconDescription=""
+      describedBy="error-checkbox3"
+      descriptionId="description-checkbox3"
       disabled={false}
+      errorId="error-checkbox3"
       id="checkbox3"
+      inline={false}
+      isValid={true}
+      label="CheckBox 3"
       name="basicCheckBox3"
+      onBlur={[Function]}
       onChange={[Function]}
+      onKeyPress={[Function]}
+      required={false}
+      themes={Array []}
       type="checkbox"
+      validationMessage=""
+      value=""
     />
     <label
       className="form-check-label"
@@ -3486,8 +3590,13 @@ exports[`Storyshots User Input|Fieldset basic usage 1`] = `
           aria-invalid={false}
           autoComplete="on"
           className="form-control is-invalid-nodanger"
+          dangerIconDescription=""
+          descriptionId="description-asInput13"
           disabled={false}
+          errorId="error-asInput13"
           id="asInput13"
+          inline={false}
+          label="First Name"
           name="firstName"
           onBlur={[Function]}
           onChange={[Function]}
@@ -3496,6 +3605,7 @@ exports[`Storyshots User Input|Fieldset basic usage 1`] = `
           required={false}
           themes={Array []}
           type="text"
+          validationMessage=""
           value=""
         />
         <div
@@ -3521,8 +3631,13 @@ exports[`Storyshots User Input|Fieldset basic usage 1`] = `
           aria-invalid={false}
           autoComplete="on"
           className="form-control is-invalid-nodanger"
+          dangerIconDescription=""
+          descriptionId="description-asInput14"
           disabled={false}
+          errorId="error-asInput14"
           id="asInput14"
+          inline={false}
+          label="Last Name"
           name="lastName"
           onBlur={[Function]}
           onChange={[Function]}
@@ -3531,6 +3646,7 @@ exports[`Storyshots User Input|Fieldset basic usage 1`] = `
           required={false}
           themes={Array []}
           type="text"
+          validationMessage=""
           value=""
         />
         <div
@@ -3584,8 +3700,13 @@ exports[`Storyshots User Input|Fieldset client-side validation of fieldset 1`] =
           aria-invalid={false}
           autoComplete="on"
           className="form-control is-invalid-nodanger"
+          dangerIconDescription=""
+          descriptionId="description-asInput22"
           disabled={false}
+          errorId="error-asInput22"
           id="asInput22"
+          inline={false}
+          label="First Name"
           name="firstName"
           onBlur={[Function]}
           onChange={[Function]}
@@ -3594,6 +3715,7 @@ exports[`Storyshots User Input|Fieldset client-side validation of fieldset 1`] =
           required={false}
           themes={Array []}
           type="text"
+          validationMessage=""
           value=""
         />
         <div
@@ -3619,8 +3741,13 @@ exports[`Storyshots User Input|Fieldset client-side validation of fieldset 1`] =
           aria-invalid={false}
           autoComplete="on"
           className="form-control is-invalid-nodanger"
+          dangerIconDescription=""
+          descriptionId="description-asInput23"
           disabled={false}
+          errorId="error-asInput23"
           id="asInput23"
+          inline={false}
+          label="Last Name"
           name="lastName"
           onBlur={[Function]}
           onChange={[Function]}
@@ -3629,6 +3756,7 @@ exports[`Storyshots User Input|Fieldset client-side validation of fieldset 1`] =
           required={false}
           themes={Array []}
           type="text"
+          validationMessage=""
           value=""
         />
         <div
@@ -3685,8 +3813,13 @@ exports[`Storyshots User Input|Fieldset invalid 1`] = `
           aria-invalid={false}
           autoComplete="on"
           className="form-control is-invalid-nodanger"
+          dangerIconDescription=""
+          descriptionId="description-asInput16"
           disabled={false}
+          errorId="error-asInput16"
           id="asInput16"
+          inline={false}
+          label="First Name"
           name="firstName"
           onBlur={[Function]}
           onChange={[Function]}
@@ -3695,6 +3828,7 @@ exports[`Storyshots User Input|Fieldset invalid 1`] = `
           required={false}
           themes={Array []}
           type="text"
+          validationMessage=""
           value=""
         />
         <div
@@ -3720,8 +3854,13 @@ exports[`Storyshots User Input|Fieldset invalid 1`] = `
           aria-invalid={false}
           autoComplete="on"
           className="form-control is-invalid-nodanger"
+          dangerIconDescription=""
+          descriptionId="description-asInput17"
           disabled={false}
+          errorId="error-asInput17"
           id="asInput17"
+          inline={false}
+          label="Last Name"
           name="lastName"
           onBlur={[Function]}
           onChange={[Function]}
@@ -3730,6 +3869,7 @@ exports[`Storyshots User Input|Fieldset invalid 1`] = `
           required={false}
           themes={Array []}
           type="text"
+          validationMessage=""
           value=""
         />
         <div
@@ -3781,8 +3921,13 @@ exports[`Storyshots User Input|Fieldset invalid with danger theme 1`] = `
           aria-invalid={false}
           autoComplete="on"
           className="form-control is-invalid-nodanger"
+          dangerIconDescription=""
+          descriptionId="description-asInput19"
           disabled={false}
+          errorId="error-asInput19"
           id="asInput19"
+          inline={false}
+          label="First Name"
           name="firstName"
           onBlur={[Function]}
           onChange={[Function]}
@@ -3791,6 +3936,7 @@ exports[`Storyshots User Input|Fieldset invalid with danger theme 1`] = `
           required={false}
           themes={Array []}
           type="text"
+          validationMessage=""
           value=""
         />
         <div
@@ -3816,8 +3962,13 @@ exports[`Storyshots User Input|Fieldset invalid with danger theme 1`] = `
           aria-invalid={false}
           autoComplete="on"
           className="form-control is-invalid-nodanger"
+          dangerIconDescription=""
+          descriptionId="description-asInput20"
           disabled={false}
+          errorId="error-asInput20"
           id="asInput20"
+          inline={false}
+          label="Last Name"
           name="lastName"
           onBlur={[Function]}
           onChange={[Function]}
@@ -3826,6 +3977,7 @@ exports[`Storyshots User Input|Fieldset invalid with danger theme 1`] = `
           required={false}
           themes={Array []}
           type="text"
+          validationMessage=""
           value=""
         />
         <div
@@ -3871,13 +4023,30 @@ exports[`Storyshots User Input|InputSelect basic usage 1`] = `
   <select
     aria-describedby="error-asInput24"
     className="form-control is-invalid-nodanger"
+    dangerIconDescription=""
+    descriptionId="description-asInput24"
     disabled={false}
+    errorId="error-asInput24"
     id="asInput24"
+    inline={false}
+    isValid={true}
+    label="Fruits"
     name="fruits"
     onBlur={[Function]}
     onChange={[Function]}
+    onKeyPress={[Function]}
+    options={
+      Array [
+        "apple",
+        "orange",
+        "strawberry",
+        "banana",
+      ]
+    }
     required={false}
+    themes={Array []}
     type="select"
+    validationMessage=""
     value="strawberry"
   >
     <option
@@ -3926,13 +4095,30 @@ exports[`Storyshots User Input|InputSelect disabled usage 1`] = `
     aria-describedby="error-asInput28"
     aria-label="Fruits"
     className="form-control is-invalid-nodanger"
+    dangerIconDescription=""
+    descriptionId="description-asInput28"
     disabled={true}
+    errorId="error-asInput28"
     id="asInput28"
+    inline={false}
+    isValid={true}
+    label="Fruits"
     name="fruits"
     onBlur={[Function]}
     onChange={[Function]}
+    onKeyPress={[Function]}
+    options={
+      Array [
+        "apple",
+        "orange",
+        "strawberry",
+        "banana",
+      ]
+    }
     required={false}
+    themes={Array []}
     type="select"
+    validationMessage=""
     value="strawberry"
   >
     <option
@@ -3980,13 +4166,50 @@ exports[`Storyshots User Input|InputSelect separate labels and values 1`] = `
   <select
     aria-describedby="error-asInput25"
     className="form-control is-invalid-nodanger"
+    dangerIconDescription=""
+    descriptionId="description-asInput25"
     disabled={false}
+    errorId="error-asInput25"
     id="asInput25"
+    inline={false}
+    isValid={true}
+    label="New England States"
     name="new-england-states"
     onBlur={[Function]}
     onChange={[Function]}
+    onKeyPress={[Function]}
+    options={
+      Array [
+        Object {
+          "label": "Connecticut",
+          "value": "CN",
+        },
+        Object {
+          "label": "Maine",
+          "value": "ME",
+        },
+        Object {
+          "label": "Massachusetts",
+          "value": "MA",
+        },
+        Object {
+          "label": "New Hampshire",
+          "value": "NH",
+        },
+        Object {
+          "label": "Rhode Island",
+          "value": "RI",
+        },
+        Object {
+          "label": "Vermont",
+          "value": "VT",
+        },
+      ]
+    }
     required={false}
+    themes={Array []}
     type="select"
+    validationMessage=""
     value="RI"
   >
     <option
@@ -4044,13 +4267,92 @@ exports[`Storyshots User Input|InputSelect separate option groups 1`] = `
   <select
     aria-describedby="error-asInput26"
     className="form-control is-invalid-nodanger"
+    dangerIconDescription=""
+    descriptionId="description-asInput26"
     disabled={false}
+    errorId="error-asInput26"
     id="asInput26"
+    inline={false}
+    isValid={true}
+    label="Northeast States"
     name="northeast-states"
     onBlur={[Function]}
     onChange={[Function]}
+    onKeyPress={[Function]}
+    options={
+      Array [
+        Object {
+          "label": "New England States",
+          "options": Array [
+            Object {
+              "label": "Connecticut",
+              "value": "CN",
+            },
+            Object {
+              "label": "Maine",
+              "value": "ME",
+            },
+            Object {
+              "label": "Massachusetts",
+              "value": "MA",
+            },
+            Object {
+              "label": "New Hampshire",
+              "value": "NH",
+            },
+            Object {
+              "label": "Rhode Island",
+              "value": "RI",
+            },
+            Object {
+              "label": "Vermont",
+              "value": "VT",
+            },
+          ],
+        },
+        Object {
+          "label": "Mid Atlantic States",
+          "options": Array [
+            Object {
+              "label": "Delaware",
+              "value": "DE",
+            },
+            Object {
+              "label": "Maryland",
+              "value": "MD",
+            },
+            Object {
+              "label": "New Jersey",
+              "value": "NJ",
+            },
+            Object {
+              "label": "New York",
+              "value": "NY",
+            },
+            Object {
+              "label": "Pennsylvania",
+              "value": "PA",
+            },
+            Object {
+              "label": "Virginia",
+              "value": "VA",
+            },
+            Object {
+              "label": "Washington, DC",
+              "value": "DC",
+            },
+            Object {
+              "label": "West Virginia",
+              "value": "WV",
+            },
+          ],
+        },
+      ]
+    }
     required={false}
+    themes={Array []}
     type="select"
+    validationMessage=""
     value="MD"
   >
     <optgroup
@@ -4156,13 +4458,40 @@ exports[`Storyshots User Input|InputSelect with disabled option 1`] = `
   <select
     aria-describedby="error-asInput29"
     className="form-control is-invalid-nodanger"
+    dangerIconDescription=""
+    descriptionId="description-asInput29"
     disabled={false}
+    errorId="error-asInput29"
     id="asInput29"
+    inline={false}
+    isValid={true}
+    label="Fruits"
     name="fruits"
     onBlur={[Function]}
     onChange={[Function]}
+    onKeyPress={[Function]}
+    options={
+      Array [
+        Object {
+          "label": "apple",
+          "value": "apple",
+        },
+        Object {
+          "disabled": true,
+          "label": "orange",
+          "value": "orange",
+        },
+        Object {
+          "disabled": true,
+          "label": "banana",
+          "value": "banana",
+        },
+      ]
+    }
     required={false}
+    themes={Array []}
     type="select"
+    validationMessage=""
     value="strawberry"
   >
     <option
@@ -4207,13 +4536,34 @@ exports[`Storyshots User Input|InputSelect with validation 1`] = `
   <select
     aria-describedby="error-asInput27"
     className="form-control is-invalid-nodanger"
+    dangerIconDescription=""
+    descriptionId="description-asInput27"
     disabled={false}
+    errorId="error-asInput27"
     id="asInput27"
+    inline={false}
+    isValid={true}
+    label="Favorite Color"
     name="color"
     onBlur={[Function]}
     onChange={[Function]}
+    onKeyPress={[Function]}
+    options={
+      Array [
+        "",
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "blue",
+        "purple",
+      ]
+    }
     required={false}
+    themes={Array []}
     type="select"
+    validationMessage=""
+    validator={[Function]}
     value=""
   >
     <option
@@ -4279,8 +4629,13 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       aria-invalid={false}
       autoComplete="on"
       className="form-control is-invalid-nodanger"
+      dangerIconDescription=""
+      descriptionId="description-input-search"
       disabled={false}
+      errorId="error-input-search"
       id="input-search"
+      inline={false}
+      label="Search"
       name="search"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4289,6 +4644,7 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       required={false}
       themes={Array []}
       type="search"
+      validationMessage=""
       value="what is paragon"
     />
     <div
@@ -4314,8 +4670,13 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       aria-invalid={false}
       autoComplete="on"
       className="form-control is-invalid-nodanger"
+      dangerIconDescription=""
+      descriptionId="description-input-email"
       disabled={false}
+      errorId="error-input-email"
       id="input-email"
+      inline={false}
+      label="Email"
       name="email"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4324,6 +4685,7 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       required={false}
       themes={Array []}
       type="email"
+      validationMessage=""
       value="paragon@edx.org"
     />
     <div
@@ -4349,8 +4711,13 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       aria-invalid={false}
       autoComplete="on"
       className="form-control is-invalid-nodanger"
+      dangerIconDescription=""
+      descriptionId="description-input-url"
       disabled={false}
+      errorId="error-input-url"
       id="input-url"
+      inline={false}
+      label="Url"
       name="url"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4359,6 +4726,7 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       required={false}
       themes={Array []}
       type="url"
+      validationMessage=""
       value="https://edx.github.io/paragon"
     />
     <div
@@ -4384,8 +4752,13 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       aria-invalid={false}
       autoComplete="on"
       className="form-control is-invalid-nodanger"
+      dangerIconDescription=""
+      descriptionId="description-input-tel"
       disabled={false}
+      errorId="error-input-tel"
       id="input-tel"
+      inline={false}
+      label="Telephone"
       name="telephone"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4394,6 +4767,7 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       required={false}
       themes={Array []}
       type="tel"
+      validationMessage=""
       value="1-(555)-555-5555"
     />
     <div
@@ -4419,8 +4793,13 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       aria-invalid={false}
       autoComplete="on"
       className="form-control is-invalid-nodanger"
+      dangerIconDescription=""
+      descriptionId="description-input-password"
       disabled={false}
+      errorId="error-input-password"
       id="input-password"
+      inline={false}
+      label="Password"
       name="password"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4429,6 +4808,7 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       required={false}
       themes={Array []}
       type="password"
+      validationMessage=""
       value="hunter2"
     />
     <div
@@ -4454,8 +4834,13 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       aria-invalid={false}
       autoComplete="on"
       className="form-control is-invalid-nodanger"
+      dangerIconDescription=""
+      descriptionId="description-input-number"
       disabled={false}
+      errorId="error-input-number"
       id="input-number"
+      inline={false}
+      label="Number"
       name="number"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4464,6 +4849,7 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       required={false}
       themes={Array []}
       type="number"
+      validationMessage=""
       value={42}
     />
     <div
@@ -4489,8 +4875,13 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       aria-invalid={false}
       autoComplete="on"
       className="form-control is-invalid-nodanger"
+      dangerIconDescription=""
+      descriptionId="description-input-datetime-local"
       disabled={false}
+      errorId="error-input-datetime-local"
       id="input-datetime-local"
+      inline={false}
+      label="Date and time"
       name="datetime-local"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4499,6 +4890,7 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       required={false}
       themes={Array []}
       type="datetime-local"
+      validationMessage=""
       value="2017-04-27T13:45:00"
     />
     <div
@@ -4524,8 +4916,13 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       aria-invalid={false}
       autoComplete="on"
       className="form-control is-invalid-nodanger"
+      dangerIconDescription=""
+      descriptionId="description-input-date"
       disabled={false}
+      errorId="error-input-date"
       id="input-date"
+      inline={false}
+      label="Date"
       name="date"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4534,6 +4931,7 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       required={false}
       themes={Array []}
       type="date"
+      validationMessage=""
       value="2017-04-27"
     />
     <div
@@ -4559,8 +4957,13 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       aria-invalid={false}
       autoComplete="on"
       className="form-control is-invalid-nodanger"
+      dangerIconDescription=""
+      descriptionId="description-input-month"
       disabled={false}
+      errorId="error-input-month"
       id="input-month"
+      inline={false}
+      label="Month"
       name="month"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4569,6 +4972,7 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       required={false}
       themes={Array []}
       type="month"
+      validationMessage=""
       value="2017-04"
     />
     <div
@@ -4594,8 +4998,13 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       aria-invalid={false}
       autoComplete="on"
       className="form-control is-invalid-nodanger"
+      dangerIconDescription=""
+      descriptionId="description-input-week"
       disabled={false}
+      errorId="error-input-week"
       id="input-week"
+      inline={false}
+      label="Week"
       name="week"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4604,6 +5013,7 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       required={false}
       themes={Array []}
       type="week"
+      validationMessage=""
       value="2017-W33"
     />
     <div
@@ -4629,8 +5039,13 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       aria-invalid={false}
       autoComplete="on"
       className="form-control is-invalid-nodanger"
+      dangerIconDescription=""
+      descriptionId="description-input-time"
       disabled={false}
+      errorId="error-input-time"
       id="input-time"
+      inline={false}
+      label="Time"
       name="time"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4639,6 +5054,7 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       required={false}
       themes={Array []}
       type="time"
+      validationMessage=""
       value="13:45:00"
     />
     <div
@@ -4664,8 +5080,13 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       aria-invalid={false}
       autoComplete="on"
       className="form-control is-invalid-nodanger"
+      dangerIconDescription=""
+      descriptionId="description-input-color"
       disabled={false}
+      errorId="error-input-color"
       id="input-color"
+      inline={false}
+      label="Color"
       name="color"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4674,6 +5095,7 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
       required={false}
       themes={Array []}
       type="color"
+      validationMessage=""
       value="#BF472C"
     />
     <div
@@ -4693,18 +5115,23 @@ exports[`Storyshots User Input|InputText displayed inline 1`] = `
 >
   <label
     className=""
-    htmlFor="asInput34"
-    id="label-asInput34"
+    htmlFor="asInput35"
+    id="label-asInput35"
   >
     Username
   </label>
   <input
-    aria-describedby="error-asInput34"
+    aria-describedby="error-asInput35"
     aria-invalid={false}
     autoComplete="on"
     className="form-control is-invalid-nodanger"
+    dangerIconDescription=""
+    descriptionId="description-asInput35"
     disabled={false}
-    id="asInput34"
+    errorId="error-asInput35"
+    id="asInput35"
+    inline={true}
+    label="Username"
     name="username"
     onBlur={[Function]}
     onChange={[Function]}
@@ -4713,12 +5140,13 @@ exports[`Storyshots User Input|InputText displayed inline 1`] = `
     required={false}
     themes={Array []}
     type="text"
+    validationMessage=""
     value="foobar"
   />
   <div
     aria-live="polite"
     className="invalid-feedback invalid-feedback-nodanger"
-    id="error-asInput34"
+    id="error-asInput35"
   >
     <span />
   </div>
@@ -4767,8 +5195,13 @@ exports[`Storyshots User Input|InputText focus test 1`] = `
       aria-invalid={false}
       autoComplete="on"
       className="form-control is-invalid-nodanger"
+      dangerIconDescription=""
+      descriptionId="description-data"
       disabled={false}
+      errorId="error-data"
       id="data"
+      inline={false}
+      label="Data Input"
       name="data"
       onBlur={[Function]}
       onChange={[Function]}
@@ -4777,6 +5210,7 @@ exports[`Storyshots User Input|InputText focus test 1`] = `
       required={false}
       themes={Array []}
       type="text"
+      validationMessage=""
       value=""
     />
     <div
@@ -4810,8 +5244,19 @@ exports[`Storyshots User Input|InputText label as element 1`] = `
     aria-invalid={false}
     autoComplete="on"
     className="form-control is-invalid-nodanger"
+    dangerIconDescription=""
+    descriptionId="description-asInput33"
     disabled={false}
+    errorId="error-asInput33"
     id="asInput33"
+    inline={false}
+    label={
+      <span
+        lang="en"
+      >
+        Element
+      </span>
+    }
     name="username"
     onBlur={[Function]}
     onChange={[Function]}
@@ -4820,6 +5265,7 @@ exports[`Storyshots User Input|InputText label as element 1`] = `
     required={false}
     themes={Array []}
     type="text"
+    validationMessage=""
     value="Label is wrapped in language span"
   />
   <div
@@ -4848,8 +5294,13 @@ exports[`Storyshots User Input|InputText minimal usage 1`] = `
     aria-invalid={false}
     autoComplete="on"
     className="form-control is-invalid-nodanger"
+    dangerIconDescription=""
+    descriptionId="description-asInput30"
     disabled={false}
+    errorId="error-asInput30"
     id="asInput30"
+    inline={false}
+    label="First Name"
     name="name"
     onBlur={[Function]}
     onChange={[Function]}
@@ -4858,12 +5309,59 @@ exports[`Storyshots User Input|InputText minimal usage 1`] = `
     required={false}
     themes={Array []}
     type="text"
+    validationMessage=""
     value="Foo Bar"
   />
   <div
     aria-live="polite"
     className="invalid-feedback invalid-feedback-nodanger"
     id="error-asInput30"
+  >
+    <span />
+  </div>
+</div>
+`;
+
+exports[`Storyshots User Input|InputText price with step 1`] = `
+<div
+  className="form-group"
+>
+  <label
+    className=""
+    htmlFor="asInput34"
+    id="label-asInput34"
+  >
+    Price
+  </label>
+  <input
+    aria-describedby="error-asInput34"
+    aria-invalid={false}
+    autoComplete="on"
+    className="form-control is-invalid-nodanger"
+    dangerIconDescription=""
+    descriptionId="description-asInput34"
+    disabled={false}
+    errorId="error-asInput34"
+    id="asInput34"
+    inline={false}
+    label="Price"
+    min={0}
+    name="price"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onKeyPress={[Function]}
+    readOnly={false}
+    required={false}
+    step={0.01}
+    themes={Array []}
+    type="number"
+    validationMessage=""
+    value={3.5}
+  />
+  <div
+    aria-live="polite"
+    className="invalid-feedback invalid-feedback-nodanger"
+    id="error-asInput34"
   >
     <span />
   </div>
@@ -4886,8 +5384,13 @@ exports[`Storyshots User Input|InputText read only 1`] = `
     aria-invalid={false}
     autoComplete="on"
     className="form-control is-invalid-nodanger"
+    dangerIconDescription=""
+    descriptionId="description-asInput31"
     disabled={false}
+    errorId="error-asInput31"
     id="asInput31"
+    inline={false}
+    label="Input State"
     name="inputState"
     onBlur={[Function]}
     onChange={[Function]}
@@ -4896,6 +5399,7 @@ exports[`Storyshots User Input|InputText read only 1`] = `
     required={false}
     themes={Array []}
     type="text"
+    validationMessage=""
     value="Read Only"
   />
   <div
@@ -4924,8 +5428,14 @@ exports[`Storyshots User Input|InputText validation 1`] = `
     aria-invalid={false}
     autoComplete="on"
     className="form-control is-invalid-nodanger"
+    dangerIconDescription=""
+    description="The unique name that identifies you throughout the site."
+    descriptionId="description-username"
     disabled={false}
+    errorId="error-username"
     id="username"
+    inline={false}
+    label="Username"
     name="username"
     onBlur={[Function]}
     onChange={[Function]}
@@ -4934,6 +5444,8 @@ exports[`Storyshots User Input|InputText validation 1`] = `
     required={false}
     themes={Array []}
     type="text"
+    validationMessage=""
+    validator={[Function]}
     value=""
   />
   <div
@@ -4968,8 +5480,14 @@ exports[`Storyshots User Input|InputText validation with danger theme 1`] = `
     aria-invalid={false}
     autoComplete="on"
     className="form-control"
+    dangerIconDescription=""
+    description="The unique name that identifies you throughout the site."
+    descriptionId="description-asInput32"
     disabled={false}
+    errorId="error-asInput32"
     id="asInput32"
+    inline={false}
+    label="Username"
     name="username"
     onBlur={[Function]}
     onChange={[Function]}
@@ -4982,6 +5500,8 @@ exports[`Storyshots User Input|InputText validation with danger theme 1`] = `
       ]
     }
     type="text"
+    validationMessage=""
+    validator={[Function]}
     value=""
   />
   <div
@@ -5007,8 +5527,8 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
   >
     <label
       className=""
-      htmlFor="asInput35"
-      id="label-asInput35"
+      htmlFor="asInput36"
+      id="label-asInput36"
     >
       Username
     </label>
@@ -5025,57 +5545,24 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
         </div>
       </div>
       <input
-        aria-describedby="error-asInput35"
-        aria-invalid={false}
-        autoComplete="on"
-        className="form-control is-invalid-nodanger"
-        disabled={false}
-        id="asInput35"
-        name="username"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onKeyPress={[Function]}
-        readOnly={false}
-        required={false}
-        themes={Array []}
-        type="text"
-        value="foobar"
-      />
-      <div
-        className="input-group-append"
-      />
-    </div>
-    <div
-      aria-live="polite"
-      className="invalid-feedback invalid-feedback-nodanger"
-      id="error-asInput35"
-    >
-      <span />
-    </div>
-  </div>
-  <div
-    className="form-group"
-  >
-    <label
-      className=""
-      htmlFor="asInput36"
-      id="label-asInput36"
-    >
-      Username
-    </label>
-    <div
-      className="input-group"
-    >
-      <div
-        className="input-group-prepend"
-      />
-      <input
         aria-describedby="error-asInput36"
         aria-invalid={false}
         autoComplete="on"
         className="form-control is-invalid-nodanger"
+        dangerIconDescription=""
+        descriptionId="description-asInput36"
         disabled={false}
+        errorId="error-asInput36"
         id="asInput36"
+        inline={false}
+        inputGroupPrepend={
+          <div
+            className="input-group-text"
+          >
+            @
+          </div>
+        }
+        label="Username"
         name="username"
         onBlur={[Function]}
         onChange={[Function]}
@@ -5084,17 +5571,12 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
         required={false}
         themes={Array []}
         type="text"
+        validationMessage=""
         value="foobar"
       />
       <div
         className="input-group-append"
-      >
-        <div
-          className="input-group-text"
-        >
-          @example.com
-        </div>
-      </div>
+      />
     </div>
     <div
       aria-live="polite"
@@ -5112,36 +5594,43 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
       htmlFor="asInput37"
       id="label-asInput37"
     >
-      Money
+      Username
     </label>
     <div
       className="input-group"
     >
       <div
         className="input-group-prepend"
-      >
-        <div
-          className="input-group-text"
-        >
-          $
-        </div>
-      </div>
+      />
       <input
         aria-describedby="error-asInput37"
         aria-invalid={false}
         autoComplete="on"
         className="form-control is-invalid-nodanger"
+        dangerIconDescription=""
+        descriptionId="description-asInput37"
         disabled={false}
+        errorId="error-asInput37"
         id="asInput37"
-        name="money"
+        inline={false}
+        inputGroupAppend={
+          <div
+            className="input-group-text"
+          >
+            @example.com
+          </div>
+        }
+        label="Username"
+        name="username"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyPress={[Function]}
         readOnly={false}
         required={false}
         themes={Array []}
-        type="number"
-        value={1000}
+        type="text"
+        validationMessage=""
+        value="foobar"
       />
       <div
         className="input-group-append"
@@ -5149,7 +5638,7 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
         <div
           className="input-group-text"
         >
-          .00
+          @example.com
         </div>
       </div>
     </div>
@@ -5169,43 +5658,65 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
       htmlFor="asInput38"
       id="label-asInput38"
     >
-      Search
+      Money
     </label>
     <div
       className="input-group"
     >
       <div
         className="input-group-prepend"
-      />
+      >
+        <div
+          className="input-group-text"
+        >
+          $
+        </div>
+      </div>
       <input
         aria-describedby="error-asInput38"
         aria-invalid={false}
         autoComplete="on"
         className="form-control is-invalid-nodanger"
+        dangerIconDescription=""
+        descriptionId="description-asInput38"
         disabled={false}
+        errorId="error-asInput38"
         id="asInput38"
-        name="search"
+        inline={false}
+        inputGroupAppend={
+          <div
+            className="input-group-text"
+          >
+            .00
+          </div>
+        }
+        inputGroupPrepend={
+          <div
+            className="input-group-text"
+          >
+            $
+          </div>
+        }
+        label="Money"
+        name="money"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyPress={[Function]}
         readOnly={false}
         required={false}
         themes={Array []}
-        type="text"
-        value="what is paragon"
+        type="number"
+        validationMessage=""
+        value={1000}
       />
       <div
         className="input-group-append"
       >
-        <button
-          className="btn btn-outline-secondary"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          type="button"
+        <div
+          className="input-group-text"
         >
-          Go
-        </button>
+          .00
+        </div>
       </div>
     </div>
     <div
@@ -5224,7 +5735,7 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
       htmlFor="asInput39"
       id="label-asInput39"
     >
-      Username
+      Search
     </label>
     <div
       className="input-group"
@@ -5237,9 +5748,20 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
         aria-invalid={false}
         autoComplete="on"
         className="form-control is-invalid-nodanger"
+        dangerIconDescription=""
+        descriptionId="description-asInput39"
         disabled={false}
+        errorId="error-asInput39"
         id="asInput39"
-        name="username"
+        inline={false}
+        inputGroupAppend={
+          <withDeprecatedProps(Button)
+            buttonType="outline-secondary"
+            label="Go"
+          />
+        }
+        label="Search"
+        name="search"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyPress={[Function]}
@@ -5247,25 +5769,12 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
         required={false}
         themes={Array []}
         type="text"
-        value="foobar"
+        validationMessage=""
+        value="what is paragon"
       />
       <div
         className="input-group-append"
       >
-        <div
-          className="input-group-text"
-        >
-          <span
-            aria-hidden={true}
-            className="fa fa-check"
-            id="checkmark"
-          />
-          <span
-            className="sr-only"
-          >
-            Checkmark
-          </span>
-        </div>
         <button
           className="btn btn-outline-secondary"
           onBlur={[Function]}
@@ -5293,7 +5802,7 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
       htmlFor="asInput40"
       id="label-asInput40"
     >
-      Password
+      Username
     </label>
     <div
       className="input-group"
@@ -5306,8 +5815,126 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
         aria-invalid={false}
         autoComplete="on"
         className="form-control is-invalid-nodanger"
+        dangerIconDescription=""
+        descriptionId="description-asInput40"
         disabled={false}
+        errorId="error-asInput40"
         id="asInput40"
+        inline={false}
+        inputGroupAppend={
+          Array [
+            <div
+              className="input-group-text"
+            >
+              <withDeprecatedProps(Icon)
+                className={
+                  Array [
+                    "fa",
+                    "fa-check",
+                  ]
+                }
+                id="checkmark"
+                screenReaderText="Checkmark"
+              />
+            </div>,
+            <withDeprecatedProps(Button)
+              buttonType="outline-secondary"
+              label="Go"
+            />,
+          ]
+        }
+        label="Username"
+        name="username"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onKeyPress={[Function]}
+        readOnly={false}
+        required={false}
+        themes={Array []}
+        type="text"
+        validationMessage=""
+        value="foobar"
+      />
+      <div
+        className="input-group-append"
+      >
+        <div
+          className="input-group-text"
+        >
+          <span
+            aria-hidden={true}
+            className="fa fa-check"
+            id="checkmark"
+          />
+          <span
+            className="sr-only"
+          >
+            Checkmark
+          </span>
+        </div>
+        <button
+          className="btn btn-outline-secondary"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          type="button"
+        >
+          Go
+        </button>
+      </div>
+    </div>
+    <div
+      aria-live="polite"
+      className="invalid-feedback invalid-feedback-nodanger"
+      id="error-asInput40"
+    >
+      <span />
+    </div>
+  </div>
+  <div
+    className="form-group"
+  >
+    <label
+      className=""
+      htmlFor="asInput41"
+      id="label-asInput41"
+    >
+      Password
+    </label>
+    <div
+      className="input-group"
+    >
+      <div
+        className="input-group-prepend"
+      />
+      <input
+        aria-describedby="error-asInput41"
+        aria-invalid={false}
+        autoComplete="on"
+        className="form-control is-invalid-nodanger"
+        dangerIconDescription=""
+        descriptionId="description-asInput41"
+        disabled={false}
+        errorId="error-asInput41"
+        id="asInput41"
+        inline={false}
+        inputGroupAppend={
+          <div
+            className="input-group-text"
+          >
+            <withDeprecatedProps(Icon)
+              className={
+                Array [
+                  "fa",
+                  "fa-check",
+                ]
+              }
+              id="checkmark"
+              screenReaderText="Checkmark"
+            />
+          </div>
+        }
+        label="Password"
         name="password"
         onBlur={[Function]}
         onChange={[Function]}
@@ -5316,6 +5943,7 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
         required={false}
         themes={Array []}
         type="text"
+        validationMessage=""
         value="secret"
       />
       <div
@@ -5340,7 +5968,7 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
     <div
       aria-live="polite"
       className="invalid-feedback invalid-feedback-nodanger"
-      id="error-asInput40"
+      id="error-asInput41"
     >
       <span />
     </div>
@@ -5475,231 +6103,6 @@ exports[`Storyshots User Input|SearchField basic usage 1`] = `
   >
     <label
       className=""
-      htmlFor="asInput57"
-      id="label-asInput57"
-    >
-      Search:
-    </label>
-    <div
-      className="input-group"
-    >
-      <div
-        className="input-group-prepend"
-      />
-      <input
-        aria-describedby="error-asInput57"
-        aria-invalid={false}
-        autoComplete="off"
-        className="form-control is-invalid-nodanger input no-clear-btn"
-        disabled={false}
-        id="asInput57"
-        name="search"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onKeyPress={[Function]}
-        placeholder=""
-        readOnly={false}
-        required={false}
-        themes={Array []}
-        type="search"
-        value=""
-      />
-      <div
-        className="input-group-append"
-      >
-        <button
-          className="btn search-btn"
-          disabled={true}
-          onBlur={[Function]}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          type="button"
-        >
-          <span
-            aria-hidden={true}
-            className="fa fa-search"
-            id="Icon1"
-          />
-          <span
-            className="sr-only"
-          >
-            Submit search
-          </span>
-        </button>
-      </div>
-    </div>
-    <div
-      aria-live="polite"
-      className="invalid-feedback invalid-feedback-nodanger"
-      id="error-asInput57"
-    >
-      <span />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots User Input|SearchField with callbacks 1`] = `
-<div
-  className="border search-field"
-  onBlur={[Function]}
-  onFocus={[Function]}
->
-  <div
-    className="form-group form-inline"
-  >
-    <label
-      className=""
-      htmlFor="asInput61"
-      id="label-asInput61"
-    >
-      Search:
-    </label>
-    <div
-      className="input-group"
-    >
-      <div
-        className="input-group-prepend"
-      />
-      <input
-        aria-describedby="error-asInput61"
-        aria-invalid={false}
-        autoComplete="off"
-        className="form-control is-invalid-nodanger input no-clear-btn"
-        disabled={false}
-        id="asInput61"
-        name="search"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onKeyPress={[Function]}
-        placeholder=""
-        readOnly={false}
-        required={false}
-        themes={Array []}
-        type="search"
-        value=""
-      />
-      <div
-        className="input-group-append"
-      >
-        <button
-          className="btn search-btn"
-          disabled={true}
-          onBlur={[Function]}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          type="button"
-        >
-          <span
-            aria-hidden={true}
-            className="fa fa-search"
-            id="Icon1"
-          />
-          <span
-            className="sr-only"
-          >
-            Submit search
-          </span>
-        </button>
-      </div>
-    </div>
-    <div
-      aria-live="polite"
-      className="invalid-feedback invalid-feedback-nodanger"
-      id="error-asInput61"
-    >
-      <span />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots User Input|SearchField with custom label and screenreader text 1`] = `
-<div
-  className="border search-field"
-  onBlur={[Function]}
-  onFocus={[Function]}
->
-  <div
-    className="form-group form-inline"
-  >
-    <label
-      className=""
-      htmlFor="asInput62"
-      id="label-asInput62"
-    >
-      Buscar:
-    </label>
-    <div
-      className="input-group"
-    >
-      <div
-        className="input-group-prepend"
-      />
-      <input
-        aria-describedby="error-asInput62"
-        aria-invalid={false}
-        autoComplete="off"
-        className="form-control is-invalid-nodanger input no-clear-btn"
-        disabled={false}
-        id="asInput62"
-        name="search"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onKeyPress={[Function]}
-        placeholder=""
-        readOnly={false}
-        required={false}
-        themes={Array []}
-        type="search"
-        value=""
-      />
-      <div
-        className="input-group-append"
-      >
-        <button
-          className="btn search-btn"
-          disabled={true}
-          onBlur={[Function]}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          type="button"
-        >
-          <span
-            aria-hidden={true}
-            className="fa fa-search"
-            id="Icon1"
-          />
-          <span
-            className="sr-only"
-          >
-            Enviar búsqueda
-          </span>
-        </button>
-      </div>
-    </div>
-    <div
-      aria-live="polite"
-      className="invalid-feedback invalid-feedback-nodanger"
-      id="error-asInput62"
-    >
-      <span />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots User Input|SearchField with placeholder 1`] = `
-<div
-  className="border search-field"
-  onBlur={[Function]}
-  onFocus={[Function]}
->
-  <div
-    className="form-group form-inline"
-  >
-    <label
-      className=""
       htmlFor="asInput58"
       id="label-asInput58"
     >
@@ -5716,17 +6119,49 @@ exports[`Storyshots User Input|SearchField with placeholder 1`] = `
         aria-invalid={false}
         autoComplete="off"
         className="form-control is-invalid-nodanger input no-clear-btn"
+        dangerIconDescription=""
+        descriptionId="description-asInput58"
         disabled={false}
+        errorId="error-asInput58"
         id="asInput58"
+        inline={true}
+        inputGroupAppend={
+          Array [
+            <withDeprecatedProps(Button)
+              className={
+                Array [
+                  "search-btn",
+                ]
+              }
+              disabled={true}
+              inputRef={[Function]}
+              label={
+                <withDeprecatedProps(Icon)
+                  className={
+                    Array [
+                      "fa",
+                      "fa-search",
+                    ]
+                  }
+                  screenReaderText="Submit search"
+                />
+              }
+              onClick={[Function]}
+            />,
+          ]
+        }
+        label="Search:"
         name="search"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyPress={[Function]}
-        placeholder="Search"
+        placeholder=""
         readOnly={false}
         required={false}
+        role="searchbox"
         themes={Array []}
         type="search"
+        validationMessage=""
         value=""
       />
       <div
@@ -5764,6 +6199,327 @@ exports[`Storyshots User Input|SearchField with placeholder 1`] = `
 </div>
 `;
 
+exports[`Storyshots User Input|SearchField with callbacks 1`] = `
+<div
+  className="border search-field"
+  onBlur={[Function]}
+  onFocus={[Function]}
+>
+  <div
+    className="form-group form-inline"
+  >
+    <label
+      className=""
+      htmlFor="asInput62"
+      id="label-asInput62"
+    >
+      Search:
+    </label>
+    <div
+      className="input-group"
+    >
+      <div
+        className="input-group-prepend"
+      />
+      <input
+        aria-describedby="error-asInput62"
+        aria-invalid={false}
+        autoComplete="off"
+        className="form-control is-invalid-nodanger input no-clear-btn"
+        dangerIconDescription=""
+        descriptionId="description-asInput62"
+        disabled={false}
+        errorId="error-asInput62"
+        id="asInput62"
+        inline={true}
+        inputGroupAppend={
+          Array [
+            <withDeprecatedProps(Button)
+              className={
+                Array [
+                  "search-btn",
+                ]
+              }
+              disabled={true}
+              inputRef={[Function]}
+              label={
+                <withDeprecatedProps(Icon)
+                  className={
+                    Array [
+                      "fa",
+                      "fa-search",
+                    ]
+                  }
+                  screenReaderText="Submit search"
+                />
+              }
+              onClick={[Function]}
+            />,
+          ]
+        }
+        label="Search:"
+        name="search"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onKeyPress={[Function]}
+        placeholder=""
+        readOnly={false}
+        required={false}
+        role="searchbox"
+        themes={Array []}
+        type="search"
+        validationMessage=""
+        value=""
+      />
+      <div
+        className="input-group-append"
+      >
+        <button
+          className="btn search-btn"
+          disabled={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          type="button"
+        >
+          <span
+            aria-hidden={true}
+            className="fa fa-search"
+            id="Icon1"
+          />
+          <span
+            className="sr-only"
+          >
+            Submit search
+          </span>
+        </button>
+      </div>
+    </div>
+    <div
+      aria-live="polite"
+      className="invalid-feedback invalid-feedback-nodanger"
+      id="error-asInput62"
+    >
+      <span />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots User Input|SearchField with custom label and screenreader text 1`] = `
+<div
+  className="border search-field"
+  onBlur={[Function]}
+  onFocus={[Function]}
+>
+  <div
+    className="form-group form-inline"
+  >
+    <label
+      className=""
+      htmlFor="asInput63"
+      id="label-asInput63"
+    >
+      Buscar:
+    </label>
+    <div
+      className="input-group"
+    >
+      <div
+        className="input-group-prepend"
+      />
+      <input
+        aria-describedby="error-asInput63"
+        aria-invalid={false}
+        autoComplete="off"
+        className="form-control is-invalid-nodanger input no-clear-btn"
+        dangerIconDescription=""
+        descriptionId="description-asInput63"
+        disabled={false}
+        errorId="error-asInput63"
+        id="asInput63"
+        inline={true}
+        inputGroupAppend={
+          Array [
+            <withDeprecatedProps(Button)
+              className={
+                Array [
+                  "search-btn",
+                ]
+              }
+              disabled={true}
+              inputRef={[Function]}
+              label={
+                <withDeprecatedProps(Icon)
+                  className={
+                    Array [
+                      "fa",
+                      "fa-search",
+                    ]
+                  }
+                  screenReaderText="Enviar búsqueda"
+                />
+              }
+              onClick={[Function]}
+            />,
+          ]
+        }
+        label="Buscar:"
+        name="search"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onKeyPress={[Function]}
+        placeholder=""
+        readOnly={false}
+        required={false}
+        role="searchbox"
+        themes={Array []}
+        type="search"
+        validationMessage=""
+        value=""
+      />
+      <div
+        className="input-group-append"
+      >
+        <button
+          className="btn search-btn"
+          disabled={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          type="button"
+        >
+          <span
+            aria-hidden={true}
+            className="fa fa-search"
+            id="Icon1"
+          />
+          <span
+            className="sr-only"
+          >
+            Enviar búsqueda
+          </span>
+        </button>
+      </div>
+    </div>
+    <div
+      aria-live="polite"
+      className="invalid-feedback invalid-feedback-nodanger"
+      id="error-asInput63"
+    >
+      <span />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots User Input|SearchField with placeholder 1`] = `
+<div
+  className="border search-field"
+  onBlur={[Function]}
+  onFocus={[Function]}
+>
+  <div
+    className="form-group form-inline"
+  >
+    <label
+      className=""
+      htmlFor="asInput59"
+      id="label-asInput59"
+    >
+      Search:
+    </label>
+    <div
+      className="input-group"
+    >
+      <div
+        className="input-group-prepend"
+      />
+      <input
+        aria-describedby="error-asInput59"
+        aria-invalid={false}
+        autoComplete="off"
+        className="form-control is-invalid-nodanger input no-clear-btn"
+        dangerIconDescription=""
+        descriptionId="description-asInput59"
+        disabled={false}
+        errorId="error-asInput59"
+        id="asInput59"
+        inline={true}
+        inputGroupAppend={
+          Array [
+            <withDeprecatedProps(Button)
+              className={
+                Array [
+                  "search-btn",
+                ]
+              }
+              disabled={true}
+              inputRef={[Function]}
+              label={
+                <withDeprecatedProps(Icon)
+                  className={
+                    Array [
+                      "fa",
+                      "fa-search",
+                    ]
+                  }
+                  screenReaderText="Submit search"
+                />
+              }
+              onClick={[Function]}
+            />,
+          ]
+        }
+        label="Search:"
+        name="search"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onKeyPress={[Function]}
+        placeholder="Search"
+        readOnly={false}
+        required={false}
+        role="searchbox"
+        themes={Array []}
+        type="search"
+        validationMessage=""
+        value=""
+      />
+      <div
+        className="input-group-append"
+      >
+        <button
+          className="btn search-btn"
+          disabled={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          type="button"
+        >
+          <span
+            aria-hidden={true}
+            className="fa fa-search"
+            id="Icon1"
+          />
+          <span
+            className="sr-only"
+          >
+            Submit search
+          </span>
+        </button>
+      </div>
+    </div>
+    <div
+      aria-live="polite"
+      className="invalid-feedback invalid-feedback-nodanger"
+      id="error-asInput59"
+    >
+      <span />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots User Input|SearchField with value 1`] = `
 <div
   className="border search-field"
@@ -5775,8 +6531,8 @@ exports[`Storyshots User Input|SearchField with value 1`] = `
   >
     <label
       className=""
-      htmlFor="asInput60"
-      id="label-asInput60"
+      htmlFor="asInput61"
+      id="label-asInput61"
     >
       Search:
     </label>
@@ -5787,12 +6543,63 @@ exports[`Storyshots User Input|SearchField with value 1`] = `
         className="input-group-prepend"
       />
       <input
-        aria-describedby="error-asInput60"
+        aria-describedby="error-asInput61"
         aria-invalid={false}
         autoComplete="off"
         className="form-control is-invalid-nodanger input"
+        dangerIconDescription=""
+        descriptionId="description-asInput61"
         disabled={false}
-        id="asInput60"
+        errorId="error-asInput61"
+        id="asInput61"
+        inline={true}
+        inputGroupAppend={
+          Array [
+            <withDeprecatedProps(Button)
+              className={
+                Array [
+                  "clear-btn ml-1",
+                ]
+              }
+              label={
+                <small>
+                  <withDeprecatedProps(Icon)
+                    className={
+                      Array [
+                        "fa fa-times",
+                      ]
+                    }
+                    id="icon-SearchField60"
+                    screenReaderText="Clear search"
+                  />
+                </small>
+              }
+              onClick={[Function]}
+            />,
+            <withDeprecatedProps(Button)
+              className={
+                Array [
+                  "search-btn border-left",
+                ]
+              }
+              disabled={false}
+              inputRef={[Function]}
+              label={
+                <withDeprecatedProps(Icon)
+                  className={
+                    Array [
+                      "fa",
+                      "fa-search",
+                    ]
+                  }
+                  screenReaderText="Submit search"
+                />
+              }
+              onClick={[Function]}
+            />,
+          ]
+        }
+        label="Search:"
         name="search"
         onBlur={[Function]}
         onChange={[Function]}
@@ -5800,8 +6607,10 @@ exports[`Storyshots User Input|SearchField with value 1`] = `
         placeholder="Search"
         readOnly={false}
         required={false}
+        role="searchbox"
         themes={Array []}
         type="search"
+        validationMessage=""
         value="foobar"
       />
       <div
@@ -5818,7 +6627,7 @@ exports[`Storyshots User Input|SearchField with value 1`] = `
             <span
               aria-hidden={true}
               className="fa fa-times"
-              id="icon-SearchField59"
+              id="icon-SearchField60"
             />
             <span
               className="sr-only"
@@ -5851,7 +6660,7 @@ exports[`Storyshots User Input|SearchField with value 1`] = `
     <div
       aria-live="polite"
       className="invalid-feedback invalid-feedback-nodanger"
-      id="error-asInput60"
+      id="error-asInput61"
     >
       <span />
     </div>
@@ -5865,8 +6674,8 @@ exports[`Storyshots User Input|Textarea label as element 1`] = `
 >
   <label
     className=""
-    htmlFor="asInput67"
-    id="label-asInput67"
+    htmlFor="asInput68"
+    id="label-asInput68"
   >
     <span
       lang="en"
@@ -5875,26 +6684,39 @@ exports[`Storyshots User Input|Textarea label as element 1`] = `
     </span>
   </label>
   <textarea
-    aria-describedby="error-asInput67"
+    aria-describedby="error-asInput68"
     aria-invalid={false}
     className="form-control is-invalid-nodanger"
+    dangerIconDescription=""
+    descriptionId="description-asInput68"
     disabled={false}
-    id="asInput67"
+    errorId="error-asInput68"
+    id="asInput68"
+    inline={false}
+    label={
+      <span
+        lang="en"
+      >
+        Element
+      </span>
+    }
     name="username"
     onBlur={[Function]}
     onChange={[Function]}
+    onKeyPress={[Function]}
     required={false}
     themes={
       Array [
         "danger",
       ]
     }
+    validationMessage=""
     value="Label is wrapped in language span"
   />
   <div
     aria-live="polite"
     className="invalid-feedback invalid-feedback-nodanger"
-    id="error-asInput67"
+    id="error-asInput68"
   >
     <span />
   </div>
@@ -5907,32 +6729,39 @@ exports[`Storyshots User Input|Textarea minimal usage 1`] = `
 >
   <label
     className=""
-    htmlFor="asInput64"
-    id="label-asInput64"
+    htmlFor="asInput65"
+    id="label-asInput65"
   >
     First Name
   </label>
   <textarea
-    aria-describedby="error-asInput64"
+    aria-describedby="error-asInput65"
     aria-invalid={false}
     className="form-control is-invalid-nodanger"
+    dangerIconDescription=""
+    descriptionId="description-asInput65"
     disabled={false}
-    id="asInput64"
+    errorId="error-asInput65"
+    id="asInput65"
+    inline={false}
+    label="First Name"
     name="name"
     onBlur={[Function]}
     onChange={[Function]}
+    onKeyPress={[Function]}
     required={false}
     themes={
       Array [
         "danger",
       ]
     }
+    validationMessage=""
     value="Foo Bar"
   />
   <div
     aria-live="polite"
     className="invalid-feedback invalid-feedback-nodanger"
-    id="error-asInput64"
+    id="error-asInput65"
   >
     <span />
   </div>
@@ -5945,32 +6774,39 @@ exports[`Storyshots User Input|Textarea scrollable 1`] = `
 >
   <label
     className=""
-    htmlFor="asInput65"
-    id="label-asInput65"
+    htmlFor="asInput66"
+    id="label-asInput66"
   >
     Information
   </label>
   <textarea
-    aria-describedby="error-asInput65"
+    aria-describedby="error-asInput66"
     aria-invalid={false}
     className="form-control is-invalid-nodanger"
+    dangerIconDescription=""
+    descriptionId="description-asInput66"
     disabled={false}
-    id="asInput65"
+    errorId="error-asInput66"
+    id="asInput66"
+    inline={false}
+    label="Information"
     name="name"
     onBlur={[Function]}
     onChange={[Function]}
+    onKeyPress={[Function]}
     required={false}
     themes={
       Array [
         "danger",
       ]
     }
+    validationMessage=""
     value="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
   />
   <div
     aria-live="polite"
     className="invalid-feedback invalid-feedback-nodanger"
-    id="error-asInput65"
+    id="error-asInput66"
   >
     <span />
   </div>
@@ -5983,38 +6819,47 @@ exports[`Storyshots User Input|Textarea validation 1`] = `
 >
   <label
     className=""
-    htmlFor="asInput66"
-    id="label-asInput66"
+    htmlFor="asInput67"
+    id="label-asInput67"
   >
     Username
   </label>
   <textarea
-    aria-describedby="error-asInput66 description-asInput66"
+    aria-describedby="error-asInput67 description-asInput67"
     aria-invalid={false}
     className="form-control is-invalid-nodanger"
+    dangerIconDescription=""
+    description="The unique name that identifies you throughout the site."
+    descriptionId="description-asInput67"
     disabled={false}
-    id="asInput66"
+    errorId="error-asInput67"
+    id="asInput67"
+    inline={false}
+    label="Username"
     name="username"
     onBlur={[Function]}
     onChange={[Function]}
+    onKeyPress={[Function]}
     required={false}
     themes={
       Array [
         "danger",
       ]
     }
+    validationMessage=""
+    validator={[Function]}
     value=""
   />
   <div
     aria-live="polite"
     className="invalid-feedback invalid-feedback-nodanger"
-    id="error-asInput66"
+    id="error-asInput67"
   >
     <span />
   </div>
   <small
     className="form-text"
-    id="description-asInput66"
+    id="description-asInput67"
   >
     The unique name that identifies you throughout the site.
   </small>

--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -3174,29 +3174,18 @@ exports[`Storyshots User Input|CheckBox basic usage 1`] = `
 >
   <input
     aria-checked={false}
+    aria-describedby="error-asInput3"
+    aria-invalid={false}
     checked={false}
-    className={
-      Array [
-        "form-check-input is-invalid-nodanger",
-      ]
-    }
-    dangerIconDescription=""
-    describedBy="error-asInput3"
-    descriptionId="description-asInput3"
+    className="form-check-input is-invalid-nodanger"
     disabled={false}
-    errorId="error-asInput3"
     id="asInput3"
-    inline={false}
-    isValid={true}
-    label="check me out!"
     name="checkbox"
     onBlur={[Function]}
     onChange={[Function]}
     onKeyPress={[Function]}
     required={false}
-    themes={Array []}
     type="checkbox"
-    validationMessage=""
     value=""
   />
   <label
@@ -3222,29 +3211,18 @@ exports[`Storyshots User Input|CheckBox call a function 1`] = `
 >
   <input
     aria-checked={false}
+    aria-describedby="error-asInput6"
+    aria-invalid={false}
     checked={false}
-    className={
-      Array [
-        "form-check-input is-invalid-nodanger",
-      ]
-    }
-    dangerIconDescription=""
-    describedBy="error-asInput6"
-    descriptionId="description-asInput6"
+    className="form-check-input is-invalid-nodanger"
     disabled={false}
-    errorId="error-asInput6"
     id="asInput6"
-    inline={false}
-    isValid={true}
-    label="check out the console"
     name="checkbox"
     onBlur={[Function]}
     onChange={[Function]}
     onKeyPress={[Function]}
     required={false}
-    themes={Array []}
     type="checkbox"
-    validationMessage=""
     value=""
   />
   <label
@@ -3280,29 +3258,18 @@ exports[`Storyshots User Input|CheckBox controlled 1`] = `
   >
     <input
       aria-checked={false}
+      aria-describedby="error-asInput7"
+      aria-invalid={false}
       checked={false}
-      className={
-        Array [
-          "form-check-input is-invalid-nodanger",
-        ]
-      }
-      dangerIconDescription=""
-      describedBy="error-asInput7"
-      descriptionId="description-asInput7"
+      className="form-check-input is-invalid-nodanger"
       disabled={false}
-      errorId="error-asInput7"
       id="asInput7"
-      inline={false}
-      isValid={true}
-      label="click the button"
       name="checkbox"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
       required={false}
-      themes={Array []}
       type="checkbox"
-      validationMessage=""
       value=""
     />
     <label
@@ -3329,29 +3296,18 @@ exports[`Storyshots User Input|CheckBox default checked 1`] = `
 >
   <input
     aria-checked={true}
+    aria-describedby="error-asInput5"
+    aria-invalid={false}
     checked={true}
-    className={
-      Array [
-        "form-check-input is-invalid-nodanger",
-      ]
-    }
-    dangerIconDescription=""
-    describedBy="error-asInput5"
-    descriptionId="description-asInput5"
+    className="form-check-input is-invalid-nodanger"
     disabled={false}
-    errorId="error-asInput5"
     id="asInput5"
-    inline={false}
-    isValid={true}
-    label="(un)check me out"
     name="checkbox"
     onBlur={[Function]}
     onChange={[Function]}
     onKeyPress={[Function]}
     required={false}
-    themes={Array []}
     type="checkbox"
-    validationMessage=""
     value=""
   />
   <label
@@ -3377,29 +3333,18 @@ exports[`Storyshots User Input|CheckBox disabled 1`] = `
 >
   <input
     aria-checked={false}
+    aria-describedby="error-asInput4"
+    aria-invalid={false}
     checked={false}
-    className={
-      Array [
-        "form-check-input is-invalid-nodanger",
-      ]
-    }
-    dangerIconDescription=""
-    describedBy="error-asInput4"
-    descriptionId="description-asInput4"
+    className="form-check-input is-invalid-nodanger"
     disabled={true}
-    errorId="error-asInput4"
     id="asInput4"
-    inline={false}
-    isValid={true}
-    label="you cannot check me out"
     name="checkbox"
     onBlur={[Function]}
     onChange={[Function]}
     onKeyPress={[Function]}
     required={false}
-    themes={Array []}
     type="checkbox"
-    validationMessage=""
     value=""
   />
   <label
@@ -3428,29 +3373,18 @@ exports[`Storyshots User Input|CheckBoxGroup basic usage 1`] = `
   >
     <input
       aria-checked={false}
+      aria-describedby="error-checkbox1"
+      aria-invalid={false}
       checked={false}
-      className={
-        Array [
-          "form-check-input is-invalid-nodanger",
-        ]
-      }
-      dangerIconDescription=""
-      describedBy="error-checkbox1"
-      descriptionId="description-checkbox1"
+      className="form-check-input is-invalid-nodanger"
       disabled={false}
-      errorId="error-checkbox1"
       id="checkbox1"
-      inline={false}
-      isValid={true}
-      label="CheckBox 1"
       name="basicCheckBox1"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
       required={false}
-      themes={Array []}
       type="checkbox"
-      validationMessage=""
       value=""
     />
     <label
@@ -3473,29 +3407,18 @@ exports[`Storyshots User Input|CheckBoxGroup basic usage 1`] = `
   >
     <input
       aria-checked={false}
+      aria-describedby="error-checkbox2"
+      aria-invalid={false}
       checked={false}
-      className={
-        Array [
-          "form-check-input is-invalid-nodanger",
-        ]
-      }
-      dangerIconDescription=""
-      describedBy="error-checkbox2"
-      descriptionId="description-checkbox2"
+      className="form-check-input is-invalid-nodanger"
       disabled={false}
-      errorId="error-checkbox2"
       id="checkbox2"
-      inline={false}
-      isValid={true}
-      label="CheckBox 2"
       name="basicCheckBox2"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
       required={false}
-      themes={Array []}
       type="checkbox"
-      validationMessage=""
       value=""
     />
     <label
@@ -3518,29 +3441,18 @@ exports[`Storyshots User Input|CheckBoxGroup basic usage 1`] = `
   >
     <input
       aria-checked={false}
+      aria-describedby="error-checkbox3"
+      aria-invalid={false}
       checked={false}
-      className={
-        Array [
-          "form-check-input is-invalid-nodanger",
-        ]
-      }
-      dangerIconDescription=""
-      describedBy="error-checkbox3"
-      descriptionId="description-checkbox3"
+      className="form-check-input is-invalid-nodanger"
       disabled={false}
-      errorId="error-checkbox3"
       id="checkbox3"
-      inline={false}
-      isValid={true}
-      label="CheckBox 3"
       name="basicCheckBox3"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
       required={false}
-      themes={Array []}
       type="checkbox"
-      validationMessage=""
       value=""
     />
     <label
@@ -3588,24 +3500,15 @@ exports[`Storyshots User Input|Fieldset basic usage 1`] = `
         <input
           aria-describedby="error-asInput13"
           aria-invalid={false}
-          autoComplete="on"
           className="form-control is-invalid-nodanger"
-          dangerIconDescription=""
-          descriptionId="description-asInput13"
           disabled={false}
-          errorId="error-asInput13"
           id="asInput13"
-          inline={false}
-          label="First Name"
           name="firstName"
           onBlur={[Function]}
           onChange={[Function]}
           onKeyPress={[Function]}
-          readOnly={false}
           required={false}
-          themes={Array []}
           type="text"
-          validationMessage=""
           value=""
         />
         <div
@@ -3629,24 +3532,15 @@ exports[`Storyshots User Input|Fieldset basic usage 1`] = `
         <input
           aria-describedby="error-asInput14"
           aria-invalid={false}
-          autoComplete="on"
           className="form-control is-invalid-nodanger"
-          dangerIconDescription=""
-          descriptionId="description-asInput14"
           disabled={false}
-          errorId="error-asInput14"
           id="asInput14"
-          inline={false}
-          label="Last Name"
           name="lastName"
           onBlur={[Function]}
           onChange={[Function]}
           onKeyPress={[Function]}
-          readOnly={false}
           required={false}
-          themes={Array []}
           type="text"
-          validationMessage=""
           value=""
         />
         <div
@@ -3698,24 +3592,15 @@ exports[`Storyshots User Input|Fieldset client-side validation of fieldset 1`] =
         <input
           aria-describedby="error-asInput22"
           aria-invalid={false}
-          autoComplete="on"
           className="form-control is-invalid-nodanger"
-          dangerIconDescription=""
-          descriptionId="description-asInput22"
           disabled={false}
-          errorId="error-asInput22"
           id="asInput22"
-          inline={false}
-          label="First Name"
           name="firstName"
           onBlur={[Function]}
           onChange={[Function]}
           onKeyPress={[Function]}
-          readOnly={false}
           required={false}
-          themes={Array []}
           type="text"
-          validationMessage=""
           value=""
         />
         <div
@@ -3739,24 +3624,15 @@ exports[`Storyshots User Input|Fieldset client-side validation of fieldset 1`] =
         <input
           aria-describedby="error-asInput23"
           aria-invalid={false}
-          autoComplete="on"
           className="form-control is-invalid-nodanger"
-          dangerIconDescription=""
-          descriptionId="description-asInput23"
           disabled={false}
-          errorId="error-asInput23"
           id="asInput23"
-          inline={false}
-          label="Last Name"
           name="lastName"
           onBlur={[Function]}
           onChange={[Function]}
           onKeyPress={[Function]}
-          readOnly={false}
           required={false}
-          themes={Array []}
           type="text"
-          validationMessage=""
           value=""
         />
         <div
@@ -3811,24 +3687,15 @@ exports[`Storyshots User Input|Fieldset invalid 1`] = `
         <input
           aria-describedby="error-asInput16"
           aria-invalid={false}
-          autoComplete="on"
           className="form-control is-invalid-nodanger"
-          dangerIconDescription=""
-          descriptionId="description-asInput16"
           disabled={false}
-          errorId="error-asInput16"
           id="asInput16"
-          inline={false}
-          label="First Name"
           name="firstName"
           onBlur={[Function]}
           onChange={[Function]}
           onKeyPress={[Function]}
-          readOnly={false}
           required={false}
-          themes={Array []}
           type="text"
-          validationMessage=""
           value=""
         />
         <div
@@ -3852,24 +3719,15 @@ exports[`Storyshots User Input|Fieldset invalid 1`] = `
         <input
           aria-describedby="error-asInput17"
           aria-invalid={false}
-          autoComplete="on"
           className="form-control is-invalid-nodanger"
-          dangerIconDescription=""
-          descriptionId="description-asInput17"
           disabled={false}
-          errorId="error-asInput17"
           id="asInput17"
-          inline={false}
-          label="Last Name"
           name="lastName"
           onBlur={[Function]}
           onChange={[Function]}
           onKeyPress={[Function]}
-          readOnly={false}
           required={false}
-          themes={Array []}
           type="text"
-          validationMessage=""
           value=""
         />
         <div
@@ -3919,24 +3777,15 @@ exports[`Storyshots User Input|Fieldset invalid with danger theme 1`] = `
         <input
           aria-describedby="error-asInput19"
           aria-invalid={false}
-          autoComplete="on"
           className="form-control is-invalid-nodanger"
-          dangerIconDescription=""
-          descriptionId="description-asInput19"
           disabled={false}
-          errorId="error-asInput19"
           id="asInput19"
-          inline={false}
-          label="First Name"
           name="firstName"
           onBlur={[Function]}
           onChange={[Function]}
           onKeyPress={[Function]}
-          readOnly={false}
           required={false}
-          themes={Array []}
           type="text"
-          validationMessage=""
           value=""
         />
         <div
@@ -3960,24 +3809,15 @@ exports[`Storyshots User Input|Fieldset invalid with danger theme 1`] = `
         <input
           aria-describedby="error-asInput20"
           aria-invalid={false}
-          autoComplete="on"
           className="form-control is-invalid-nodanger"
-          dangerIconDescription=""
-          descriptionId="description-asInput20"
           disabled={false}
-          errorId="error-asInput20"
           id="asInput20"
-          inline={false}
-          label="Last Name"
           name="lastName"
           onBlur={[Function]}
           onChange={[Function]}
           onKeyPress={[Function]}
-          readOnly={false}
           required={false}
-          themes={Array []}
           type="text"
-          validationMessage=""
           value=""
         />
         <div
@@ -4022,15 +3862,10 @@ exports[`Storyshots User Input|InputSelect basic usage 1`] = `
   </label>
   <select
     aria-describedby="error-asInput24"
+    aria-invalid={false}
     className="form-control is-invalid-nodanger"
-    dangerIconDescription=""
-    descriptionId="description-asInput24"
     disabled={false}
-    errorId="error-asInput24"
     id="asInput24"
-    inline={false}
-    isValid={true}
-    label="Fruits"
     name="fruits"
     onBlur={[Function]}
     onChange={[Function]}
@@ -4044,9 +3879,7 @@ exports[`Storyshots User Input|InputSelect basic usage 1`] = `
       ]
     }
     required={false}
-    themes={Array []}
     type="select"
-    validationMessage=""
     value="strawberry"
   >
     <option
@@ -4093,16 +3926,11 @@ exports[`Storyshots User Input|InputSelect disabled usage 1`] = `
   </label>
   <select
     aria-describedby="error-asInput28"
+    aria-invalid={false}
     aria-label="Fruits"
     className="form-control is-invalid-nodanger"
-    dangerIconDescription=""
-    descriptionId="description-asInput28"
     disabled={true}
-    errorId="error-asInput28"
     id="asInput28"
-    inline={false}
-    isValid={true}
-    label="Fruits"
     name="fruits"
     onBlur={[Function]}
     onChange={[Function]}
@@ -4116,9 +3944,7 @@ exports[`Storyshots User Input|InputSelect disabled usage 1`] = `
       ]
     }
     required={false}
-    themes={Array []}
     type="select"
-    validationMessage=""
     value="strawberry"
   >
     <option
@@ -4165,15 +3991,10 @@ exports[`Storyshots User Input|InputSelect separate labels and values 1`] = `
   </label>
   <select
     aria-describedby="error-asInput25"
+    aria-invalid={false}
     className="form-control is-invalid-nodanger"
-    dangerIconDescription=""
-    descriptionId="description-asInput25"
     disabled={false}
-    errorId="error-asInput25"
     id="asInput25"
-    inline={false}
-    isValid={true}
-    label="New England States"
     name="new-england-states"
     onBlur={[Function]}
     onChange={[Function]}
@@ -4207,9 +4028,7 @@ exports[`Storyshots User Input|InputSelect separate labels and values 1`] = `
       ]
     }
     required={false}
-    themes={Array []}
     type="select"
-    validationMessage=""
     value="RI"
   >
     <option
@@ -4266,15 +4085,10 @@ exports[`Storyshots User Input|InputSelect separate option groups 1`] = `
   </label>
   <select
     aria-describedby="error-asInput26"
+    aria-invalid={false}
     className="form-control is-invalid-nodanger"
-    dangerIconDescription=""
-    descriptionId="description-asInput26"
     disabled={false}
-    errorId="error-asInput26"
     id="asInput26"
-    inline={false}
-    isValid={true}
-    label="Northeast States"
     name="northeast-states"
     onBlur={[Function]}
     onChange={[Function]}
@@ -4350,9 +4164,7 @@ exports[`Storyshots User Input|InputSelect separate option groups 1`] = `
       ]
     }
     required={false}
-    themes={Array []}
     type="select"
-    validationMessage=""
     value="MD"
   >
     <optgroup
@@ -4457,15 +4269,10 @@ exports[`Storyshots User Input|InputSelect with disabled option 1`] = `
   </label>
   <select
     aria-describedby="error-asInput29"
+    aria-invalid={false}
     className="form-control is-invalid-nodanger"
-    dangerIconDescription=""
-    descriptionId="description-asInput29"
     disabled={false}
-    errorId="error-asInput29"
     id="asInput29"
-    inline={false}
-    isValid={true}
-    label="Fruits"
     name="fruits"
     onBlur={[Function]}
     onChange={[Function]}
@@ -4489,9 +4296,7 @@ exports[`Storyshots User Input|InputSelect with disabled option 1`] = `
       ]
     }
     required={false}
-    themes={Array []}
     type="select"
-    validationMessage=""
     value="strawberry"
   >
     <option
@@ -4535,15 +4340,10 @@ exports[`Storyshots User Input|InputSelect with validation 1`] = `
   </label>
   <select
     aria-describedby="error-asInput27"
+    aria-invalid={false}
     className="form-control is-invalid-nodanger"
-    dangerIconDescription=""
-    descriptionId="description-asInput27"
     disabled={false}
-    errorId="error-asInput27"
     id="asInput27"
-    inline={false}
-    isValid={true}
-    label="Favorite Color"
     name="color"
     onBlur={[Function]}
     onChange={[Function]}
@@ -4560,10 +4360,7 @@ exports[`Storyshots User Input|InputSelect with validation 1`] = `
       ]
     }
     required={false}
-    themes={Array []}
     type="select"
-    validationMessage=""
-    validator={[Function]}
     value=""
   >
     <option
@@ -4627,24 +4424,15 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
     <input
       aria-describedby="error-input-search"
       aria-invalid={false}
-      autoComplete="on"
       className="form-control is-invalid-nodanger"
-      dangerIconDescription=""
-      descriptionId="description-input-search"
       disabled={false}
-      errorId="error-input-search"
       id="input-search"
-      inline={false}
-      label="Search"
       name="search"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
-      readOnly={false}
       required={false}
-      themes={Array []}
       type="search"
-      validationMessage=""
       value="what is paragon"
     />
     <div
@@ -4668,24 +4456,15 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
     <input
       aria-describedby="error-input-email"
       aria-invalid={false}
-      autoComplete="on"
       className="form-control is-invalid-nodanger"
-      dangerIconDescription=""
-      descriptionId="description-input-email"
       disabled={false}
-      errorId="error-input-email"
       id="input-email"
-      inline={false}
-      label="Email"
       name="email"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
-      readOnly={false}
       required={false}
-      themes={Array []}
       type="email"
-      validationMessage=""
       value="paragon@edx.org"
     />
     <div
@@ -4709,24 +4488,15 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
     <input
       aria-describedby="error-input-url"
       aria-invalid={false}
-      autoComplete="on"
       className="form-control is-invalid-nodanger"
-      dangerIconDescription=""
-      descriptionId="description-input-url"
       disabled={false}
-      errorId="error-input-url"
       id="input-url"
-      inline={false}
-      label="Url"
       name="url"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
-      readOnly={false}
       required={false}
-      themes={Array []}
       type="url"
-      validationMessage=""
       value="https://edx.github.io/paragon"
     />
     <div
@@ -4750,24 +4520,15 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
     <input
       aria-describedby="error-input-tel"
       aria-invalid={false}
-      autoComplete="on"
       className="form-control is-invalid-nodanger"
-      dangerIconDescription=""
-      descriptionId="description-input-tel"
       disabled={false}
-      errorId="error-input-tel"
       id="input-tel"
-      inline={false}
-      label="Telephone"
       name="telephone"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
-      readOnly={false}
       required={false}
-      themes={Array []}
       type="tel"
-      validationMessage=""
       value="1-(555)-555-5555"
     />
     <div
@@ -4791,24 +4552,15 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
     <input
       aria-describedby="error-input-password"
       aria-invalid={false}
-      autoComplete="on"
       className="form-control is-invalid-nodanger"
-      dangerIconDescription=""
-      descriptionId="description-input-password"
       disabled={false}
-      errorId="error-input-password"
       id="input-password"
-      inline={false}
-      label="Password"
       name="password"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
-      readOnly={false}
       required={false}
-      themes={Array []}
       type="password"
-      validationMessage=""
       value="hunter2"
     />
     <div
@@ -4832,24 +4584,15 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
     <input
       aria-describedby="error-input-number"
       aria-invalid={false}
-      autoComplete="on"
       className="form-control is-invalid-nodanger"
-      dangerIconDescription=""
-      descriptionId="description-input-number"
       disabled={false}
-      errorId="error-input-number"
       id="input-number"
-      inline={false}
-      label="Number"
       name="number"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
-      readOnly={false}
       required={false}
-      themes={Array []}
       type="number"
-      validationMessage=""
       value={42}
     />
     <div
@@ -4873,24 +4616,15 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
     <input
       aria-describedby="error-input-datetime-local"
       aria-invalid={false}
-      autoComplete="on"
       className="form-control is-invalid-nodanger"
-      dangerIconDescription=""
-      descriptionId="description-input-datetime-local"
       disabled={false}
-      errorId="error-input-datetime-local"
       id="input-datetime-local"
-      inline={false}
-      label="Date and time"
       name="datetime-local"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
-      readOnly={false}
       required={false}
-      themes={Array []}
       type="datetime-local"
-      validationMessage=""
       value="2017-04-27T13:45:00"
     />
     <div
@@ -4914,24 +4648,15 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
     <input
       aria-describedby="error-input-date"
       aria-invalid={false}
-      autoComplete="on"
       className="form-control is-invalid-nodanger"
-      dangerIconDescription=""
-      descriptionId="description-input-date"
       disabled={false}
-      errorId="error-input-date"
       id="input-date"
-      inline={false}
-      label="Date"
       name="date"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
-      readOnly={false}
       required={false}
-      themes={Array []}
       type="date"
-      validationMessage=""
       value="2017-04-27"
     />
     <div
@@ -4955,24 +4680,15 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
     <input
       aria-describedby="error-input-month"
       aria-invalid={false}
-      autoComplete="on"
       className="form-control is-invalid-nodanger"
-      dangerIconDescription=""
-      descriptionId="description-input-month"
       disabled={false}
-      errorId="error-input-month"
       id="input-month"
-      inline={false}
-      label="Month"
       name="month"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
-      readOnly={false}
       required={false}
-      themes={Array []}
       type="month"
-      validationMessage=""
       value="2017-04"
     />
     <div
@@ -4996,24 +4712,15 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
     <input
       aria-describedby="error-input-week"
       aria-invalid={false}
-      autoComplete="on"
       className="form-control is-invalid-nodanger"
-      dangerIconDescription=""
-      descriptionId="description-input-week"
       disabled={false}
-      errorId="error-input-week"
       id="input-week"
-      inline={false}
-      label="Week"
       name="week"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
-      readOnly={false}
       required={false}
-      themes={Array []}
       type="week"
-      validationMessage=""
       value="2017-W33"
     />
     <div
@@ -5037,24 +4744,15 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
     <input
       aria-describedby="error-input-time"
       aria-invalid={false}
-      autoComplete="on"
       className="form-control is-invalid-nodanger"
-      dangerIconDescription=""
-      descriptionId="description-input-time"
       disabled={false}
-      errorId="error-input-time"
       id="input-time"
-      inline={false}
-      label="Time"
       name="time"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
-      readOnly={false}
       required={false}
-      themes={Array []}
       type="time"
-      validationMessage=""
       value="13:45:00"
     />
     <div
@@ -5078,24 +4776,15 @@ exports[`Storyshots User Input|InputText different textual input types 1`] = `
     <input
       aria-describedby="error-input-color"
       aria-invalid={false}
-      autoComplete="on"
       className="form-control is-invalid-nodanger"
-      dangerIconDescription=""
-      descriptionId="description-input-color"
       disabled={false}
-      errorId="error-input-color"
       id="input-color"
-      inline={false}
-      label="Color"
       name="color"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
-      readOnly={false}
       required={false}
-      themes={Array []}
       type="color"
-      validationMessage=""
       value="#BF472C"
     />
     <div
@@ -5123,24 +4812,15 @@ exports[`Storyshots User Input|InputText displayed inline 1`] = `
   <input
     aria-describedby="error-asInput35"
     aria-invalid={false}
-    autoComplete="on"
     className="form-control is-invalid-nodanger"
-    dangerIconDescription=""
-    descriptionId="description-asInput35"
     disabled={false}
-    errorId="error-asInput35"
     id="asInput35"
-    inline={true}
-    label="Username"
     name="username"
     onBlur={[Function]}
     onChange={[Function]}
     onKeyPress={[Function]}
-    readOnly={false}
     required={false}
-    themes={Array []}
     type="text"
-    validationMessage=""
     value="foobar"
   />
   <div
@@ -5193,24 +4873,15 @@ exports[`Storyshots User Input|InputText focus test 1`] = `
     <input
       aria-describedby="error-data"
       aria-invalid={false}
-      autoComplete="on"
       className="form-control is-invalid-nodanger"
-      dangerIconDescription=""
-      descriptionId="description-data"
       disabled={false}
-      errorId="error-data"
       id="data"
-      inline={false}
-      label="Data Input"
       name="data"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyPress={[Function]}
-      readOnly={false}
       required={false}
-      themes={Array []}
       type="text"
-      validationMessage=""
       value=""
     />
     <div
@@ -5242,30 +4913,15 @@ exports[`Storyshots User Input|InputText label as element 1`] = `
   <input
     aria-describedby="error-asInput33"
     aria-invalid={false}
-    autoComplete="on"
     className="form-control is-invalid-nodanger"
-    dangerIconDescription=""
-    descriptionId="description-asInput33"
     disabled={false}
-    errorId="error-asInput33"
     id="asInput33"
-    inline={false}
-    label={
-      <span
-        lang="en"
-      >
-        Element
-      </span>
-    }
     name="username"
     onBlur={[Function]}
     onChange={[Function]}
     onKeyPress={[Function]}
-    readOnly={false}
     required={false}
-    themes={Array []}
     type="text"
-    validationMessage=""
     value="Label is wrapped in language span"
   />
   <div
@@ -5292,24 +4948,15 @@ exports[`Storyshots User Input|InputText minimal usage 1`] = `
   <input
     aria-describedby="error-asInput30"
     aria-invalid={false}
-    autoComplete="on"
     className="form-control is-invalid-nodanger"
-    dangerIconDescription=""
-    descriptionId="description-asInput30"
     disabled={false}
-    errorId="error-asInput30"
     id="asInput30"
-    inline={false}
-    label="First Name"
     name="name"
     onBlur={[Function]}
     onChange={[Function]}
     onKeyPress={[Function]}
-    readOnly={false}
     required={false}
-    themes={Array []}
     type="text"
-    validationMessage=""
     value="Foo Bar"
   />
   <div
@@ -5336,26 +4983,17 @@ exports[`Storyshots User Input|InputText price with step 1`] = `
   <input
     aria-describedby="error-asInput34"
     aria-invalid={false}
-    autoComplete="on"
     className="form-control is-invalid-nodanger"
-    dangerIconDescription=""
-    descriptionId="description-asInput34"
     disabled={false}
-    errorId="error-asInput34"
     id="asInput34"
-    inline={false}
-    label="Price"
     min={0}
     name="price"
     onBlur={[Function]}
     onChange={[Function]}
     onKeyPress={[Function]}
-    readOnly={false}
     required={false}
     step={0.01}
-    themes={Array []}
     type="number"
-    validationMessage=""
     value={3.5}
   />
   <div
@@ -5382,24 +5020,16 @@ exports[`Storyshots User Input|InputText read only 1`] = `
   <input
     aria-describedby="error-asInput31"
     aria-invalid={false}
-    autoComplete="on"
     className="form-control is-invalid-nodanger"
-    dangerIconDescription=""
-    descriptionId="description-asInput31"
     disabled={false}
-    errorId="error-asInput31"
     id="asInput31"
-    inline={false}
-    label="Input State"
     name="inputState"
     onBlur={[Function]}
     onChange={[Function]}
     onKeyPress={[Function]}
     readOnly={true}
     required={false}
-    themes={Array []}
     type="text"
-    validationMessage=""
     value="Read Only"
   />
   <div
@@ -5426,26 +5056,15 @@ exports[`Storyshots User Input|InputText validation 1`] = `
   <input
     aria-describedby="error-username description-username"
     aria-invalid={false}
-    autoComplete="on"
     className="form-control is-invalid-nodanger"
-    dangerIconDescription=""
-    description="The unique name that identifies you throughout the site."
-    descriptionId="description-username"
     disabled={false}
-    errorId="error-username"
     id="username"
-    inline={false}
-    label="Username"
     name="username"
     onBlur={[Function]}
     onChange={[Function]}
     onKeyPress={[Function]}
-    readOnly={false}
     required={false}
-    themes={Array []}
     type="text"
-    validationMessage=""
-    validator={[Function]}
     value=""
   />
   <div
@@ -5478,30 +5097,15 @@ exports[`Storyshots User Input|InputText validation with danger theme 1`] = `
   <input
     aria-describedby="error-asInput32 description-asInput32"
     aria-invalid={false}
-    autoComplete="on"
     className="form-control"
-    dangerIconDescription=""
-    description="The unique name that identifies you throughout the site."
-    descriptionId="description-asInput32"
     disabled={false}
-    errorId="error-asInput32"
     id="asInput32"
-    inline={false}
-    label="Username"
     name="username"
     onBlur={[Function]}
     onChange={[Function]}
     onKeyPress={[Function]}
-    readOnly={false}
     required={false}
-    themes={
-      Array [
-        "danger",
-      ]
-    }
     type="text"
-    validationMessage=""
-    validator={[Function]}
     value=""
   />
   <div
@@ -5547,31 +5151,15 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
       <input
         aria-describedby="error-asInput36"
         aria-invalid={false}
-        autoComplete="on"
         className="form-control is-invalid-nodanger"
-        dangerIconDescription=""
-        descriptionId="description-asInput36"
         disabled={false}
-        errorId="error-asInput36"
         id="asInput36"
-        inline={false}
-        inputGroupPrepend={
-          <div
-            className="input-group-text"
-          >
-            @
-          </div>
-        }
-        label="Username"
         name="username"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyPress={[Function]}
-        readOnly={false}
         required={false}
-        themes={Array []}
         type="text"
-        validationMessage=""
         value="foobar"
       />
       <div
@@ -5605,31 +5193,15 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
       <input
         aria-describedby="error-asInput37"
         aria-invalid={false}
-        autoComplete="on"
         className="form-control is-invalid-nodanger"
-        dangerIconDescription=""
-        descriptionId="description-asInput37"
         disabled={false}
-        errorId="error-asInput37"
         id="asInput37"
-        inline={false}
-        inputGroupAppend={
-          <div
-            className="input-group-text"
-          >
-            @example.com
-          </div>
-        }
-        label="Username"
         name="username"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyPress={[Function]}
-        readOnly={false}
         required={false}
-        themes={Array []}
         type="text"
-        validationMessage=""
         value="foobar"
       />
       <div
@@ -5675,38 +5247,15 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
       <input
         aria-describedby="error-asInput38"
         aria-invalid={false}
-        autoComplete="on"
         className="form-control is-invalid-nodanger"
-        dangerIconDescription=""
-        descriptionId="description-asInput38"
         disabled={false}
-        errorId="error-asInput38"
         id="asInput38"
-        inline={false}
-        inputGroupAppend={
-          <div
-            className="input-group-text"
-          >
-            .00
-          </div>
-        }
-        inputGroupPrepend={
-          <div
-            className="input-group-text"
-          >
-            $
-          </div>
-        }
-        label="Money"
         name="money"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyPress={[Function]}
-        readOnly={false}
         required={false}
-        themes={Array []}
         type="number"
-        validationMessage=""
         value={1000}
       />
       <div
@@ -5746,30 +5295,15 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
       <input
         aria-describedby="error-asInput39"
         aria-invalid={false}
-        autoComplete="on"
         className="form-control is-invalid-nodanger"
-        dangerIconDescription=""
-        descriptionId="description-asInput39"
         disabled={false}
-        errorId="error-asInput39"
         id="asInput39"
-        inline={false}
-        inputGroupAppend={
-          <withDeprecatedProps(Button)
-            buttonType="outline-secondary"
-            label="Go"
-          />
-        }
-        label="Search"
         name="search"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyPress={[Function]}
-        readOnly={false}
         required={false}
-        themes={Array []}
         type="text"
-        validationMessage=""
         value="what is paragon"
       />
       <div
@@ -5813,46 +5347,15 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
       <input
         aria-describedby="error-asInput40"
         aria-invalid={false}
-        autoComplete="on"
         className="form-control is-invalid-nodanger"
-        dangerIconDescription=""
-        descriptionId="description-asInput40"
         disabled={false}
-        errorId="error-asInput40"
         id="asInput40"
-        inline={false}
-        inputGroupAppend={
-          Array [
-            <div
-              className="input-group-text"
-            >
-              <withDeprecatedProps(Icon)
-                className={
-                  Array [
-                    "fa",
-                    "fa-check",
-                  ]
-                }
-                id="checkmark"
-                screenReaderText="Checkmark"
-              />
-            </div>,
-            <withDeprecatedProps(Button)
-              buttonType="outline-secondary"
-              label="Go"
-            />,
-          ]
-        }
-        label="Username"
         name="username"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyPress={[Function]}
-        readOnly={false}
         required={false}
-        themes={Array []}
         type="text"
-        validationMessage=""
         value="foobar"
       />
       <div
@@ -5910,40 +5413,15 @@ exports[`Storyshots User Input|InputText with input group addons 1`] = `
       <input
         aria-describedby="error-asInput41"
         aria-invalid={false}
-        autoComplete="on"
         className="form-control is-invalid-nodanger"
-        dangerIconDescription=""
-        descriptionId="description-asInput41"
         disabled={false}
-        errorId="error-asInput41"
         id="asInput41"
-        inline={false}
-        inputGroupAppend={
-          <div
-            className="input-group-text"
-          >
-            <withDeprecatedProps(Icon)
-              className={
-                Array [
-                  "fa",
-                  "fa-check",
-                ]
-              }
-              id="checkmark"
-              screenReaderText="Checkmark"
-            />
-          </div>
-        }
-        label="Password"
         name="password"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyPress={[Function]}
-        readOnly={false}
         required={false}
-        themes={Array []}
         type="text"
-        validationMessage=""
         value="secret"
       />
       <div
@@ -6119,49 +5597,16 @@ exports[`Storyshots User Input|SearchField basic usage 1`] = `
         aria-invalid={false}
         autoComplete="off"
         className="form-control is-invalid-nodanger input no-clear-btn"
-        dangerIconDescription=""
-        descriptionId="description-asInput58"
         disabled={false}
-        errorId="error-asInput58"
         id="asInput58"
-        inline={true}
-        inputGroupAppend={
-          Array [
-            <withDeprecatedProps(Button)
-              className={
-                Array [
-                  "search-btn",
-                ]
-              }
-              disabled={true}
-              inputRef={[Function]}
-              label={
-                <withDeprecatedProps(Icon)
-                  className={
-                    Array [
-                      "fa",
-                      "fa-search",
-                    ]
-                  }
-                  screenReaderText="Submit search"
-                />
-              }
-              onClick={[Function]}
-            />,
-          ]
-        }
-        label="Search:"
         name="search"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyPress={[Function]}
         placeholder=""
-        readOnly={false}
         required={false}
         role="searchbox"
-        themes={Array []}
         type="search"
-        validationMessage=""
         value=""
       />
       <div
@@ -6226,49 +5671,16 @@ exports[`Storyshots User Input|SearchField with callbacks 1`] = `
         aria-invalid={false}
         autoComplete="off"
         className="form-control is-invalid-nodanger input no-clear-btn"
-        dangerIconDescription=""
-        descriptionId="description-asInput62"
         disabled={false}
-        errorId="error-asInput62"
         id="asInput62"
-        inline={true}
-        inputGroupAppend={
-          Array [
-            <withDeprecatedProps(Button)
-              className={
-                Array [
-                  "search-btn",
-                ]
-              }
-              disabled={true}
-              inputRef={[Function]}
-              label={
-                <withDeprecatedProps(Icon)
-                  className={
-                    Array [
-                      "fa",
-                      "fa-search",
-                    ]
-                  }
-                  screenReaderText="Submit search"
-                />
-              }
-              onClick={[Function]}
-            />,
-          ]
-        }
-        label="Search:"
         name="search"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyPress={[Function]}
         placeholder=""
-        readOnly={false}
         required={false}
         role="searchbox"
-        themes={Array []}
         type="search"
-        validationMessage=""
         value=""
       />
       <div
@@ -6333,49 +5745,16 @@ exports[`Storyshots User Input|SearchField with custom label and screenreader te
         aria-invalid={false}
         autoComplete="off"
         className="form-control is-invalid-nodanger input no-clear-btn"
-        dangerIconDescription=""
-        descriptionId="description-asInput63"
         disabled={false}
-        errorId="error-asInput63"
         id="asInput63"
-        inline={true}
-        inputGroupAppend={
-          Array [
-            <withDeprecatedProps(Button)
-              className={
-                Array [
-                  "search-btn",
-                ]
-              }
-              disabled={true}
-              inputRef={[Function]}
-              label={
-                <withDeprecatedProps(Icon)
-                  className={
-                    Array [
-                      "fa",
-                      "fa-search",
-                    ]
-                  }
-                  screenReaderText="Enviar búsqueda"
-                />
-              }
-              onClick={[Function]}
-            />,
-          ]
-        }
-        label="Buscar:"
         name="search"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyPress={[Function]}
         placeholder=""
-        readOnly={false}
         required={false}
         role="searchbox"
-        themes={Array []}
         type="search"
-        validationMessage=""
         value=""
       />
       <div
@@ -6440,49 +5819,16 @@ exports[`Storyshots User Input|SearchField with placeholder 1`] = `
         aria-invalid={false}
         autoComplete="off"
         className="form-control is-invalid-nodanger input no-clear-btn"
-        dangerIconDescription=""
-        descriptionId="description-asInput59"
         disabled={false}
-        errorId="error-asInput59"
         id="asInput59"
-        inline={true}
-        inputGroupAppend={
-          Array [
-            <withDeprecatedProps(Button)
-              className={
-                Array [
-                  "search-btn",
-                ]
-              }
-              disabled={true}
-              inputRef={[Function]}
-              label={
-                <withDeprecatedProps(Icon)
-                  className={
-                    Array [
-                      "fa",
-                      "fa-search",
-                    ]
-                  }
-                  screenReaderText="Submit search"
-                />
-              }
-              onClick={[Function]}
-            />,
-          ]
-        }
-        label="Search:"
         name="search"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyPress={[Function]}
         placeholder="Search"
-        readOnly={false}
         required={false}
         role="searchbox"
-        themes={Array []}
         type="search"
-        validationMessage=""
         value=""
       />
       <div
@@ -6547,70 +5893,16 @@ exports[`Storyshots User Input|SearchField with value 1`] = `
         aria-invalid={false}
         autoComplete="off"
         className="form-control is-invalid-nodanger input"
-        dangerIconDescription=""
-        descriptionId="description-asInput61"
         disabled={false}
-        errorId="error-asInput61"
         id="asInput61"
-        inline={true}
-        inputGroupAppend={
-          Array [
-            <withDeprecatedProps(Button)
-              className={
-                Array [
-                  "clear-btn ml-1",
-                ]
-              }
-              label={
-                <small>
-                  <withDeprecatedProps(Icon)
-                    className={
-                      Array [
-                        "fa fa-times",
-                      ]
-                    }
-                    id="icon-SearchField60"
-                    screenReaderText="Clear search"
-                  />
-                </small>
-              }
-              onClick={[Function]}
-            />,
-            <withDeprecatedProps(Button)
-              className={
-                Array [
-                  "search-btn border-left",
-                ]
-              }
-              disabled={false}
-              inputRef={[Function]}
-              label={
-                <withDeprecatedProps(Icon)
-                  className={
-                    Array [
-                      "fa",
-                      "fa-search",
-                    ]
-                  }
-                  screenReaderText="Submit search"
-                />
-              }
-              onClick={[Function]}
-            />,
-          ]
-        }
-        label="Search:"
         name="search"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyPress={[Function]}
         placeholder="Search"
-        readOnly={false}
         required={false}
         role="searchbox"
-        themes={Array []}
         type="search"
-        validationMessage=""
         value="foobar"
       />
       <div
@@ -6687,30 +5979,13 @@ exports[`Storyshots User Input|Textarea label as element 1`] = `
     aria-describedby="error-asInput68"
     aria-invalid={false}
     className="form-control is-invalid-nodanger"
-    dangerIconDescription=""
-    descriptionId="description-asInput68"
     disabled={false}
-    errorId="error-asInput68"
     id="asInput68"
-    inline={false}
-    label={
-      <span
-        lang="en"
-      >
-        Element
-      </span>
-    }
     name="username"
     onBlur={[Function]}
     onChange={[Function]}
     onKeyPress={[Function]}
     required={false}
-    themes={
-      Array [
-        "danger",
-      ]
-    }
-    validationMessage=""
     value="Label is wrapped in language span"
   />
   <div
@@ -6738,24 +6013,13 @@ exports[`Storyshots User Input|Textarea minimal usage 1`] = `
     aria-describedby="error-asInput65"
     aria-invalid={false}
     className="form-control is-invalid-nodanger"
-    dangerIconDescription=""
-    descriptionId="description-asInput65"
     disabled={false}
-    errorId="error-asInput65"
     id="asInput65"
-    inline={false}
-    label="First Name"
     name="name"
     onBlur={[Function]}
     onChange={[Function]}
     onKeyPress={[Function]}
     required={false}
-    themes={
-      Array [
-        "danger",
-      ]
-    }
-    validationMessage=""
     value="Foo Bar"
   />
   <div
@@ -6783,24 +6047,13 @@ exports[`Storyshots User Input|Textarea scrollable 1`] = `
     aria-describedby="error-asInput66"
     aria-invalid={false}
     className="form-control is-invalid-nodanger"
-    dangerIconDescription=""
-    descriptionId="description-asInput66"
     disabled={false}
-    errorId="error-asInput66"
     id="asInput66"
-    inline={false}
-    label="Information"
     name="name"
     onBlur={[Function]}
     onChange={[Function]}
     onKeyPress={[Function]}
     required={false}
-    themes={
-      Array [
-        "danger",
-      ]
-    }
-    validationMessage=""
     value="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
   />
   <div
@@ -6828,26 +6081,13 @@ exports[`Storyshots User Input|Textarea validation 1`] = `
     aria-describedby="error-asInput67 description-asInput67"
     aria-invalid={false}
     className="form-control is-invalid-nodanger"
-    dangerIconDescription=""
-    description="The unique name that identifies you throughout the site."
-    descriptionId="description-asInput67"
     disabled={false}
-    errorId="error-asInput67"
     id="asInput67"
-    inline={false}
-    label="Username"
     name="username"
     onBlur={[Function]}
     onChange={[Function]}
     onKeyPress={[Function]}
     required={false}
-    themes={
-      Array [
-        "danger",
-      ]
-    }
-    validationMessage=""
-    validator={[Function]}
     value=""
   />
   <div

--- a/package-lock.json
+++ b/package-lock.json
@@ -2495,6 +2495,794 @@
         "@types/istanbul-lib-coverage": "^1.1.0"
       }
     },
+    "@jest/test-sequencer": {
+      "version": "24.7.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.7.1.tgz",
+      "integrity": "sha512-84HQkCpVZI/G1zq53gHJvSmhUer4aMYp9tTaffW28Ih5OxfCg8hGr3nTSbL1OhVDRrFZwvF+/R9gY6JRkDUpUA==",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^24.7.1",
+        "jest-haste-map": "^24.7.1",
+        "jest-runner": "^24.7.1",
+        "jest-runtime": "^24.7.1"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
+          "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
+          "dev": true,
+          "requires": {
+            "@jest/source-map": "^24.3.0",
+            "chalk": "^2.0.1",
+            "slash": "^2.0.0"
+          }
+        },
+        "@jest/environment": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.7.1.tgz",
+          "integrity": "sha512-wmcTTYc4/KqA+U5h1zQd5FXXynfa7VGP2NfF+c6QeGJ7c+2nStgh65RQWNX62SC716dTtqheTRrZl0j+54oGHw==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^24.7.1",
+            "@jest/transform": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "jest-mock": "^24.7.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.7.1.tgz",
+          "integrity": "sha512-4vSQJDKfR2jScOe12L9282uiwuwQv9Lk7mgrCSZHA9evB9efB/qx8i0KJxsAKtp8fgJYBJdYY7ZU6u3F4/pyjA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0",
+            "jest-message-util": "^24.7.1",
+            "jest-mock": "^24.7.0"
+          }
+        },
+        "@jest/test-result": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.7.1.tgz",
+          "integrity": "sha512-3U7wITxstdEc2HMfBX7Yx3JZgiNBubwDqQMh+BXmZXHa3G13YWF3p6cK+5g0hGkN3iufg/vGPl3hLxQXD74Npg==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "@types/istanbul-lib-coverage": "^2.0.0"
+          }
+        },
+        "@jest/transform": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.7.1.tgz",
+          "integrity": "sha512-EsOUqP9ULuJ66IkZQhI5LufCHlTbi7hrcllRMUEV/tOgqBVQi93+9qEvkX0n8mYpVXQ8VjwmICeRgg58mrtIEw==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/types": "^24.7.0",
+            "babel-plugin-istanbul": "^5.1.0",
+            "chalk": "^2.0.1",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graceful-fs": "^4.1.15",
+            "jest-haste-map": "^24.7.1",
+            "jest-regex-util": "^24.3.0",
+            "jest-util": "^24.7.1",
+            "micromatch": "^3.1.10",
+            "realpath-native": "^1.1.0",
+            "slash": "^2.0.0",
+            "source-map": "^0.6.1",
+            "write-file-atomic": "2.4.1"
+          }
+        },
+        "@jest/types": {
+          "version": "24.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
+          "integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/yargs": "^12.0.9"
+          }
+        },
+        "@types/istanbul-lib-coverage": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
+          "integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "babel-jest": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.7.1.tgz",
+          "integrity": "sha512-GPnLqfk8Mtt0i4OemjWkChi73A3ALs4w2/QbG64uAj8b5mmwzxc7jbJVRZt8NJkxi6FopVHog9S3xX6UJKb2qg==",
+          "dev": true,
+          "requires": {
+            "@jest/transform": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "@types/babel__core": "^7.1.0",
+            "babel-plugin-istanbul": "^5.1.0",
+            "babel-preset-jest": "^24.6.0",
+            "chalk": "^2.4.2",
+            "slash": "^2.0.0"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "24.6.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
+          "integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
+          "dev": true,
+          "requires": {
+            "@types/babel__traverse": "^7.0.6"
+          }
+        },
+        "babel-preset-jest": {
+          "version": "24.6.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
+          "integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
+          "dev": true,
+          "requires": {
+            "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+            "babel-plugin-jest-hoist": "^24.6.0"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "expect": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-24.7.1.tgz",
+          "integrity": "sha512-mGfvMTPduksV3xoI0xur56pQsg2vJjNf5+a+bXOjqCkiCBbmCayrBbHS/75y9K430cfqyocPr2ZjiNiRx4SRKw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0",
+            "ansi-styles": "^3.2.0",
+            "jest-get-type": "^24.3.0",
+            "jest-matcher-utils": "^24.7.0",
+            "jest-message-util": "^24.7.1",
+            "jest-regex-util": "^24.3.0"
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "jest-config": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.7.1.tgz",
+          "integrity": "sha512-8FlJNLI+X+MU37j7j8RE4DnJkvAghXmBWdArVzypW6WxfGuxiL/CCkzBg0gHtXhD2rxla3IMOSUAHylSKYJ83g==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/test-sequencer": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "babel-jest": "^24.7.1",
+            "chalk": "^2.0.1",
+            "glob": "^7.1.1",
+            "jest-environment-jsdom": "^24.7.1",
+            "jest-environment-node": "^24.7.1",
+            "jest-get-type": "^24.3.0",
+            "jest-jasmine2": "^24.7.1",
+            "jest-regex-util": "^24.3.0",
+            "jest-resolve": "^24.7.1",
+            "jest-util": "^24.7.1",
+            "jest-validate": "^24.7.0",
+            "micromatch": "^3.1.10",
+            "pretty-format": "^24.7.0",
+            "realpath-native": "^1.1.0"
+          }
+        },
+        "jest-diff": {
+          "version": "24.7.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.7.0.tgz",
+          "integrity": "sha512-ULQZ5B1lWpH70O4xsANC4tf4Ko6RrpwhE3PtG6ERjMg1TiYTC2Wp4IntJVGro6a8HG9luYHhhmF4grF0Pltckg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "diff-sequences": "^24.3.0",
+            "jest-get-type": "^24.3.0",
+            "pretty-format": "^24.7.0"
+          }
+        },
+        "jest-each": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.7.1.tgz",
+          "integrity": "sha512-4fsS8fEfLa3lfnI1Jw6NxjhyRTgfpuOVTeUZZFyVYqeTa4hPhr2YkToUhouuLTrL2eMGOfpbdMyRx0GQ/VooKA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0",
+            "chalk": "^2.0.1",
+            "jest-get-type": "^24.3.0",
+            "jest-util": "^24.7.1",
+            "pretty-format": "^24.7.0"
+          }
+        },
+        "jest-environment-jsdom": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.7.1.tgz",
+          "integrity": "sha512-Gnhb+RqE2JuQGb3kJsLF8vfqjt3PHKSstq4Xc8ic+ax7QKo4Z0RWGucU3YV+DwKR3T9SYc+3YCUQEJs8r7+Jxg==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^24.7.1",
+            "@jest/fake-timers": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "jest-mock": "^24.7.0",
+            "jest-util": "^24.7.1",
+            "jsdom": "^11.5.1"
+          }
+        },
+        "jest-environment-node": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.7.1.tgz",
+          "integrity": "sha512-GJJQt1p9/C6aj6yNZMvovZuxTUd+BEJprETdvTKSb4kHcw4mFj8777USQV0FJoJ4V3djpOwA5eWyPwfq//PFBA==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^24.7.1",
+            "@jest/fake-timers": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "jest-mock": "^24.7.0",
+            "jest-util": "^24.7.1"
+          }
+        },
+        "jest-get-type": {
+          "version": "24.3.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.3.0.tgz",
+          "integrity": "sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==",
+          "dev": true
+        },
+        "jest-haste-map": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.7.1.tgz",
+          "integrity": "sha512-g0tWkzjpHD2qa03mTKhlydbmmYiA2KdcJe762SbfFo/7NIMgBWAA0XqQlApPwkWOF7Cxoi/gUqL0i6DIoLpMBw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0",
+            "anymatch": "^2.0.0",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^1.2.7",
+            "graceful-fs": "^4.1.15",
+            "invariant": "^2.2.4",
+            "jest-serializer": "^24.4.0",
+            "jest-util": "^24.7.1",
+            "jest-worker": "^24.6.0",
+            "micromatch": "^3.1.10",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-jasmine2": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.7.1.tgz",
+          "integrity": "sha512-Y/9AOJDV1XS44wNwCaThq4Pw3gBPiOv/s6NcbOAkVRRUEPu+36L2xoPsqQXsDrxoBerqeyslpn2TpCI8Zr6J2w==",
+          "dev": true,
+          "requires": {
+            "@babel/traverse": "^7.1.0",
+            "@jest/environment": "^24.7.1",
+            "@jest/test-result": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "chalk": "^2.0.1",
+            "co": "^4.6.0",
+            "expect": "^24.7.1",
+            "is-generator-fn": "^2.0.0",
+            "jest-each": "^24.7.1",
+            "jest-matcher-utils": "^24.7.0",
+            "jest-message-util": "^24.7.1",
+            "jest-runtime": "^24.7.1",
+            "jest-snapshot": "^24.7.1",
+            "jest-util": "^24.7.1",
+            "pretty-format": "^24.7.0",
+            "throat": "^4.0.0"
+          }
+        },
+        "jest-leak-detector": {
+          "version": "24.7.0",
+          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.7.0.tgz",
+          "integrity": "sha512-zV0qHKZGXtmPVVzT99CVEcHE9XDf+8LwiE0Ob7jjezERiGVljmqKFWpV2IkG+rkFIEUHFEkMiICu7wnoPM/RoQ==",
+          "dev": true,
+          "requires": {
+            "pretty-format": "^24.7.0"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "24.7.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.7.0.tgz",
+          "integrity": "sha512-158ieSgk3LNXeUhbVJYRXyTPSCqNgVXOp/GT7O94mYd3pk/8+odKTyR1JLtNOQSPzNi8NFYVONtvSWA/e1RDXg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-diff": "^24.7.0",
+            "jest-get-type": "^24.3.0",
+            "pretty-format": "^24.7.0"
+          }
+        },
+        "jest-message-util": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.7.1.tgz",
+          "integrity": "sha512-dk0gqVtyqezCHbcbk60CdIf+8UHgD+lmRHifeH3JRcnAqh4nEyPytSc9/L1+cQyxC+ceaeP696N4ATe7L+omcg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/test-result": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "@types/stack-utils": "^1.0.1",
+            "chalk": "^2.0.1",
+            "micromatch": "^3.1.10",
+            "slash": "^2.0.0",
+            "stack-utils": "^1.0.1"
+          }
+        },
+        "jest-mock": {
+          "version": "24.7.0",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.7.0.tgz",
+          "integrity": "sha512-6taW4B4WUcEiT2V9BbOmwyGuwuAFT2G8yghF7nyNW1/2gq5+6aTqSPcS9lS6ArvEkX55vbPAS/Jarx5LSm4Fng==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0"
+          }
+        },
+        "jest-resolve": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.7.1.tgz",
+          "integrity": "sha512-Bgrc+/UUZpGJ4323sQyj85hV9d+ANyPNu6XfRDUcyFNX1QrZpSoM0kE4Mb2vZMAYTJZsBFzYe8X1UaOkOELSbw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0",
+            "browser-resolve": "^1.11.3",
+            "chalk": "^2.0.1",
+            "jest-pnp-resolver": "^1.2.1",
+            "realpath-native": "^1.1.0"
+          }
+        },
+        "jest-runner": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.7.1.tgz",
+          "integrity": "sha512-aNFc9liWU/xt+G9pobdKZ4qTeG/wnJrJna3VqunziDNsWT3EBpmxXZRBMKCsNMyfy+A/XHiV+tsMLufdsNdgCw==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^24.7.1",
+            "@jest/environment": "^24.7.1",
+            "@jest/test-result": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "chalk": "^2.4.2",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.1.15",
+            "jest-config": "^24.7.1",
+            "jest-docblock": "^24.3.0",
+            "jest-haste-map": "^24.7.1",
+            "jest-jasmine2": "^24.7.1",
+            "jest-leak-detector": "^24.7.0",
+            "jest-message-util": "^24.7.1",
+            "jest-resolve": "^24.7.1",
+            "jest-runtime": "^24.7.1",
+            "jest-util": "^24.7.1",
+            "jest-worker": "^24.6.0",
+            "source-map-support": "^0.5.6",
+            "throat": "^4.0.0"
+          }
+        },
+        "jest-runtime": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.7.1.tgz",
+          "integrity": "sha512-0VAbyBy7tll3R+82IPJpf6QZkokzXPIS71aDeqh+WzPRXRCNz6StQ45otFariPdJ4FmXpDiArdhZrzNAC3sj6A==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^24.7.1",
+            "@jest/environment": "^24.7.1",
+            "@jest/source-map": "^24.3.0",
+            "@jest/transform": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "@types/yargs": "^12.0.2",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.1.15",
+            "jest-config": "^24.7.1",
+            "jest-haste-map": "^24.7.1",
+            "jest-message-util": "^24.7.1",
+            "jest-mock": "^24.7.0",
+            "jest-regex-util": "^24.3.0",
+            "jest-resolve": "^24.7.1",
+            "jest-snapshot": "^24.7.1",
+            "jest-util": "^24.7.1",
+            "jest-validate": "^24.7.0",
+            "realpath-native": "^1.1.0",
+            "slash": "^2.0.0",
+            "strip-bom": "^3.0.0",
+            "yargs": "^12.0.2"
+          }
+        },
+        "jest-snapshot": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.7.1.tgz",
+          "integrity": "sha512-8Xk5O4p+JsZZn4RCNUS3pxA+ORKpEKepE+a5ejIKrId9CwrVN0NY+vkqEkXqlstA5NMBkNahXkR/4qEBy0t5yA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0",
+            "@jest/types": "^24.7.0",
+            "chalk": "^2.0.1",
+            "expect": "^24.7.1",
+            "jest-diff": "^24.7.0",
+            "jest-matcher-utils": "^24.7.0",
+            "jest-message-util": "^24.7.1",
+            "jest-resolve": "^24.7.1",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^24.7.0",
+            "semver": "^5.5.0"
+          }
+        },
+        "jest-util": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.7.1.tgz",
+          "integrity": "sha512-/KilOue2n2rZ5AnEBYoxOXkeTu6vi7cjgQ8MXEkih0oeAXT6JkS3fr7/j8+engCjciOU1Nq5loMSKe0A1oeX0A==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^24.7.1",
+            "@jest/fake-timers": "^24.7.1",
+            "@jest/source-map": "^24.3.0",
+            "@jest/test-result": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "callsites": "^3.0.0",
+            "chalk": "^2.0.1",
+            "graceful-fs": "^4.1.15",
+            "is-ci": "^2.0.0",
+            "mkdirp": "^0.5.1",
+            "slash": "^2.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "jest-validate": {
+          "version": "24.7.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.7.0.tgz",
+          "integrity": "sha512-cgai/gts9B2chz1rqVdmLhzYxQbgQurh1PEQSvSgPZ8KGa1AqXsqC45W5wKEwzxKrWqypuQrQxnF4+G9VejJJA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0",
+            "camelcase": "^5.0.0",
+            "chalk": "^2.0.1",
+            "jest-get-type": "^24.3.0",
+            "leven": "^2.1.0",
+            "pretty-format": "^24.7.0"
+          }
+        },
+        "jest-worker": {
+          "version": "24.6.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
+          "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
+          "dev": true,
+          "requires": {
+            "merge-stream": "^1.0.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "24.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",
+          "integrity": "sha512-apen5cjf/U4dj7tHetpC7UEFCvtAgnNZnBDkfPv3fokzIqyOJckAG9OlAPC1BlFALnqT/lGB2tl9EJjlK6eCsA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0",
+            "ansi-regex": "^4.0.0",
+            "ansi-styles": "^3.2.0",
+            "react-is": "^16.8.4"
+          }
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "@jest/transform": {
       "version": "24.5.0",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.5.0.tgz",
@@ -13855,6 +14643,949 @@
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-cli": {
+      "version": "24.7.1",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.7.1.tgz",
+      "integrity": "sha512-32OBoSCVPzcTslGFl6yVCMzB2SqX3IrWwZCY5mZYkb0D2WsogmU3eV2o8z7+gRQa4o4sZPX/k7GU+II7CxM6WQ==",
+      "dev": true,
+      "requires": {
+        "@jest/core": "^24.7.1",
+        "@jest/test-result": "^24.7.1",
+        "@jest/types": "^24.7.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "import-local": "^2.0.0",
+        "is-ci": "^2.0.0",
+        "jest-config": "^24.7.1",
+        "jest-util": "^24.7.1",
+        "jest-validate": "^24.7.0",
+        "prompts": "^2.0.1",
+        "realpath-native": "^1.1.0",
+        "yargs": "^12.0.2"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
+          "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
+          "dev": true,
+          "requires": {
+            "@jest/source-map": "^24.3.0",
+            "chalk": "^2.0.1",
+            "slash": "^2.0.0"
+          }
+        },
+        "@jest/core": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.7.1.tgz",
+          "integrity": "sha512-ivlZ8HX/FOASfHcb5DJpSPFps8ydfUYzLZfgFFqjkLijYysnIEOieg72YRhO4ZUB32xu40hsSMmaw+IGYeKONA==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^24.7.1",
+            "@jest/reporters": "^24.7.1",
+            "@jest/test-result": "^24.7.1",
+            "@jest/transform": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.1.15",
+            "jest-changed-files": "^24.7.0",
+            "jest-config": "^24.7.1",
+            "jest-haste-map": "^24.7.1",
+            "jest-message-util": "^24.7.1",
+            "jest-regex-util": "^24.3.0",
+            "jest-resolve-dependencies": "^24.7.1",
+            "jest-runner": "^24.7.1",
+            "jest-runtime": "^24.7.1",
+            "jest-snapshot": "^24.7.1",
+            "jest-util": "^24.7.1",
+            "jest-validate": "^24.7.0",
+            "jest-watcher": "^24.7.1",
+            "micromatch": "^3.1.10",
+            "p-each-series": "^1.0.0",
+            "pirates": "^4.0.1",
+            "realpath-native": "^1.1.0",
+            "rimraf": "^2.5.4",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "@jest/environment": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.7.1.tgz",
+          "integrity": "sha512-wmcTTYc4/KqA+U5h1zQd5FXXynfa7VGP2NfF+c6QeGJ7c+2nStgh65RQWNX62SC716dTtqheTRrZl0j+54oGHw==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^24.7.1",
+            "@jest/transform": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "jest-mock": "^24.7.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.7.1.tgz",
+          "integrity": "sha512-4vSQJDKfR2jScOe12L9282uiwuwQv9Lk7mgrCSZHA9evB9efB/qx8i0KJxsAKtp8fgJYBJdYY7ZU6u3F4/pyjA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0",
+            "jest-message-util": "^24.7.1",
+            "jest-mock": "^24.7.0"
+          }
+        },
+        "@jest/reporters": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.7.1.tgz",
+          "integrity": "sha512-bO+WYNwHLNhrjB9EbPL4kX/mCCG4ZhhfWmO3m4FSpbgr7N83MFejayz30kKjgqr7smLyeaRFCBQMbXpUgnhAJw==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^24.7.1",
+            "@jest/test-result": "^24.7.1",
+            "@jest/transform": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "glob": "^7.1.2",
+            "istanbul-api": "^2.1.1",
+            "istanbul-lib-coverage": "^2.0.2",
+            "istanbul-lib-instrument": "^3.0.1",
+            "istanbul-lib-source-maps": "^3.0.1",
+            "jest-haste-map": "^24.7.1",
+            "jest-resolve": "^24.7.1",
+            "jest-runtime": "^24.7.1",
+            "jest-util": "^24.7.1",
+            "jest-worker": "^24.6.0",
+            "node-notifier": "^5.2.1",
+            "slash": "^2.0.0",
+            "source-map": "^0.6.0",
+            "string-length": "^2.0.0"
+          }
+        },
+        "@jest/test-result": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.7.1.tgz",
+          "integrity": "sha512-3U7wITxstdEc2HMfBX7Yx3JZgiNBubwDqQMh+BXmZXHa3G13YWF3p6cK+5g0hGkN3iufg/vGPl3hLxQXD74Npg==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "@types/istanbul-lib-coverage": "^2.0.0"
+          }
+        },
+        "@jest/transform": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.7.1.tgz",
+          "integrity": "sha512-EsOUqP9ULuJ66IkZQhI5LufCHlTbi7hrcllRMUEV/tOgqBVQi93+9qEvkX0n8mYpVXQ8VjwmICeRgg58mrtIEw==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/types": "^24.7.0",
+            "babel-plugin-istanbul": "^5.1.0",
+            "chalk": "^2.0.1",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graceful-fs": "^4.1.15",
+            "jest-haste-map": "^24.7.1",
+            "jest-regex-util": "^24.3.0",
+            "jest-util": "^24.7.1",
+            "micromatch": "^3.1.10",
+            "realpath-native": "^1.1.0",
+            "slash": "^2.0.0",
+            "source-map": "^0.6.1",
+            "write-file-atomic": "2.4.1"
+          }
+        },
+        "@jest/types": {
+          "version": "24.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
+          "integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/yargs": "^12.0.9"
+          }
+        },
+        "@types/istanbul-lib-coverage": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
+          "integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "babel-jest": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.7.1.tgz",
+          "integrity": "sha512-GPnLqfk8Mtt0i4OemjWkChi73A3ALs4w2/QbG64uAj8b5mmwzxc7jbJVRZt8NJkxi6FopVHog9S3xX6UJKb2qg==",
+          "dev": true,
+          "requires": {
+            "@jest/transform": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "@types/babel__core": "^7.1.0",
+            "babel-plugin-istanbul": "^5.1.0",
+            "babel-preset-jest": "^24.6.0",
+            "chalk": "^2.4.2",
+            "slash": "^2.0.0"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "24.6.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
+          "integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
+          "dev": true,
+          "requires": {
+            "@types/babel__traverse": "^7.0.6"
+          }
+        },
+        "babel-preset-jest": {
+          "version": "24.6.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
+          "integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
+          "dev": true,
+          "requires": {
+            "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+            "babel-plugin-jest-hoist": "^24.6.0"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "expect": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-24.7.1.tgz",
+          "integrity": "sha512-mGfvMTPduksV3xoI0xur56pQsg2vJjNf5+a+bXOjqCkiCBbmCayrBbHS/75y9K430cfqyocPr2ZjiNiRx4SRKw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0",
+            "ansi-styles": "^3.2.0",
+            "jest-get-type": "^24.3.0",
+            "jest-matcher-utils": "^24.7.0",
+            "jest-message-util": "^24.7.1",
+            "jest-regex-util": "^24.3.0"
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "jest-changed-files": {
+          "version": "24.7.0",
+          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.7.0.tgz",
+          "integrity": "sha512-33BgewurnwSfJrW7T5/ZAXGE44o7swLslwh8aUckzq2e17/2Os1V0QU506ZNik3hjs8MgnEMKNkcud442NCDTw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0",
+            "execa": "^1.0.0",
+            "throat": "^4.0.0"
+          }
+        },
+        "jest-config": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.7.1.tgz",
+          "integrity": "sha512-8FlJNLI+X+MU37j7j8RE4DnJkvAghXmBWdArVzypW6WxfGuxiL/CCkzBg0gHtXhD2rxla3IMOSUAHylSKYJ83g==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/test-sequencer": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "babel-jest": "^24.7.1",
+            "chalk": "^2.0.1",
+            "glob": "^7.1.1",
+            "jest-environment-jsdom": "^24.7.1",
+            "jest-environment-node": "^24.7.1",
+            "jest-get-type": "^24.3.0",
+            "jest-jasmine2": "^24.7.1",
+            "jest-regex-util": "^24.3.0",
+            "jest-resolve": "^24.7.1",
+            "jest-util": "^24.7.1",
+            "jest-validate": "^24.7.0",
+            "micromatch": "^3.1.10",
+            "pretty-format": "^24.7.0",
+            "realpath-native": "^1.1.0"
+          }
+        },
+        "jest-diff": {
+          "version": "24.7.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.7.0.tgz",
+          "integrity": "sha512-ULQZ5B1lWpH70O4xsANC4tf4Ko6RrpwhE3PtG6ERjMg1TiYTC2Wp4IntJVGro6a8HG9luYHhhmF4grF0Pltckg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "diff-sequences": "^24.3.0",
+            "jest-get-type": "^24.3.0",
+            "pretty-format": "^24.7.0"
+          }
+        },
+        "jest-each": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.7.1.tgz",
+          "integrity": "sha512-4fsS8fEfLa3lfnI1Jw6NxjhyRTgfpuOVTeUZZFyVYqeTa4hPhr2YkToUhouuLTrL2eMGOfpbdMyRx0GQ/VooKA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0",
+            "chalk": "^2.0.1",
+            "jest-get-type": "^24.3.0",
+            "jest-util": "^24.7.1",
+            "pretty-format": "^24.7.0"
+          }
+        },
+        "jest-environment-jsdom": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.7.1.tgz",
+          "integrity": "sha512-Gnhb+RqE2JuQGb3kJsLF8vfqjt3PHKSstq4Xc8ic+ax7QKo4Z0RWGucU3YV+DwKR3T9SYc+3YCUQEJs8r7+Jxg==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^24.7.1",
+            "@jest/fake-timers": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "jest-mock": "^24.7.0",
+            "jest-util": "^24.7.1",
+            "jsdom": "^11.5.1"
+          }
+        },
+        "jest-environment-node": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.7.1.tgz",
+          "integrity": "sha512-GJJQt1p9/C6aj6yNZMvovZuxTUd+BEJprETdvTKSb4kHcw4mFj8777USQV0FJoJ4V3djpOwA5eWyPwfq//PFBA==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^24.7.1",
+            "@jest/fake-timers": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "jest-mock": "^24.7.0",
+            "jest-util": "^24.7.1"
+          }
+        },
+        "jest-get-type": {
+          "version": "24.3.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.3.0.tgz",
+          "integrity": "sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==",
+          "dev": true
+        },
+        "jest-haste-map": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.7.1.tgz",
+          "integrity": "sha512-g0tWkzjpHD2qa03mTKhlydbmmYiA2KdcJe762SbfFo/7NIMgBWAA0XqQlApPwkWOF7Cxoi/gUqL0i6DIoLpMBw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0",
+            "anymatch": "^2.0.0",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^1.2.7",
+            "graceful-fs": "^4.1.15",
+            "invariant": "^2.2.4",
+            "jest-serializer": "^24.4.0",
+            "jest-util": "^24.7.1",
+            "jest-worker": "^24.6.0",
+            "micromatch": "^3.1.10",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-jasmine2": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.7.1.tgz",
+          "integrity": "sha512-Y/9AOJDV1XS44wNwCaThq4Pw3gBPiOv/s6NcbOAkVRRUEPu+36L2xoPsqQXsDrxoBerqeyslpn2TpCI8Zr6J2w==",
+          "dev": true,
+          "requires": {
+            "@babel/traverse": "^7.1.0",
+            "@jest/environment": "^24.7.1",
+            "@jest/test-result": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "chalk": "^2.0.1",
+            "co": "^4.6.0",
+            "expect": "^24.7.1",
+            "is-generator-fn": "^2.0.0",
+            "jest-each": "^24.7.1",
+            "jest-matcher-utils": "^24.7.0",
+            "jest-message-util": "^24.7.1",
+            "jest-runtime": "^24.7.1",
+            "jest-snapshot": "^24.7.1",
+            "jest-util": "^24.7.1",
+            "pretty-format": "^24.7.0",
+            "throat": "^4.0.0"
+          }
+        },
+        "jest-leak-detector": {
+          "version": "24.7.0",
+          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.7.0.tgz",
+          "integrity": "sha512-zV0qHKZGXtmPVVzT99CVEcHE9XDf+8LwiE0Ob7jjezERiGVljmqKFWpV2IkG+rkFIEUHFEkMiICu7wnoPM/RoQ==",
+          "dev": true,
+          "requires": {
+            "pretty-format": "^24.7.0"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "24.7.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.7.0.tgz",
+          "integrity": "sha512-158ieSgk3LNXeUhbVJYRXyTPSCqNgVXOp/GT7O94mYd3pk/8+odKTyR1JLtNOQSPzNi8NFYVONtvSWA/e1RDXg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-diff": "^24.7.0",
+            "jest-get-type": "^24.3.0",
+            "pretty-format": "^24.7.0"
+          }
+        },
+        "jest-message-util": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.7.1.tgz",
+          "integrity": "sha512-dk0gqVtyqezCHbcbk60CdIf+8UHgD+lmRHifeH3JRcnAqh4nEyPytSc9/L1+cQyxC+ceaeP696N4ATe7L+omcg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/test-result": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "@types/stack-utils": "^1.0.1",
+            "chalk": "^2.0.1",
+            "micromatch": "^3.1.10",
+            "slash": "^2.0.0",
+            "stack-utils": "^1.0.1"
+          }
+        },
+        "jest-mock": {
+          "version": "24.7.0",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.7.0.tgz",
+          "integrity": "sha512-6taW4B4WUcEiT2V9BbOmwyGuwuAFT2G8yghF7nyNW1/2gq5+6aTqSPcS9lS6ArvEkX55vbPAS/Jarx5LSm4Fng==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0"
+          }
+        },
+        "jest-resolve": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.7.1.tgz",
+          "integrity": "sha512-Bgrc+/UUZpGJ4323sQyj85hV9d+ANyPNu6XfRDUcyFNX1QrZpSoM0kE4Mb2vZMAYTJZsBFzYe8X1UaOkOELSbw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0",
+            "browser-resolve": "^1.11.3",
+            "chalk": "^2.0.1",
+            "jest-pnp-resolver": "^1.2.1",
+            "realpath-native": "^1.1.0"
+          }
+        },
+        "jest-resolve-dependencies": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.7.1.tgz",
+          "integrity": "sha512-2Eyh5LJB2liNzfk4eo7bD1ZyBbqEJIyyrFtZG555cSWW9xVHxII2NuOkSl1yUYTAYCAmM2f2aIT5A7HzNmubyg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0",
+            "jest-regex-util": "^24.3.0",
+            "jest-snapshot": "^24.7.1"
+          }
+        },
+        "jest-runner": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.7.1.tgz",
+          "integrity": "sha512-aNFc9liWU/xt+G9pobdKZ4qTeG/wnJrJna3VqunziDNsWT3EBpmxXZRBMKCsNMyfy+A/XHiV+tsMLufdsNdgCw==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^24.7.1",
+            "@jest/environment": "^24.7.1",
+            "@jest/test-result": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "chalk": "^2.4.2",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.1.15",
+            "jest-config": "^24.7.1",
+            "jest-docblock": "^24.3.0",
+            "jest-haste-map": "^24.7.1",
+            "jest-jasmine2": "^24.7.1",
+            "jest-leak-detector": "^24.7.0",
+            "jest-message-util": "^24.7.1",
+            "jest-resolve": "^24.7.1",
+            "jest-runtime": "^24.7.1",
+            "jest-util": "^24.7.1",
+            "jest-worker": "^24.6.0",
+            "source-map-support": "^0.5.6",
+            "throat": "^4.0.0"
+          }
+        },
+        "jest-runtime": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.7.1.tgz",
+          "integrity": "sha512-0VAbyBy7tll3R+82IPJpf6QZkokzXPIS71aDeqh+WzPRXRCNz6StQ45otFariPdJ4FmXpDiArdhZrzNAC3sj6A==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^24.7.1",
+            "@jest/environment": "^24.7.1",
+            "@jest/source-map": "^24.3.0",
+            "@jest/transform": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "@types/yargs": "^12.0.2",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.1.15",
+            "jest-config": "^24.7.1",
+            "jest-haste-map": "^24.7.1",
+            "jest-message-util": "^24.7.1",
+            "jest-mock": "^24.7.0",
+            "jest-regex-util": "^24.3.0",
+            "jest-resolve": "^24.7.1",
+            "jest-snapshot": "^24.7.1",
+            "jest-util": "^24.7.1",
+            "jest-validate": "^24.7.0",
+            "realpath-native": "^1.1.0",
+            "slash": "^2.0.0",
+            "strip-bom": "^3.0.0",
+            "yargs": "^12.0.2"
+          }
+        },
+        "jest-snapshot": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.7.1.tgz",
+          "integrity": "sha512-8Xk5O4p+JsZZn4RCNUS3pxA+ORKpEKepE+a5ejIKrId9CwrVN0NY+vkqEkXqlstA5NMBkNahXkR/4qEBy0t5yA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0",
+            "@jest/types": "^24.7.0",
+            "chalk": "^2.0.1",
+            "expect": "^24.7.1",
+            "jest-diff": "^24.7.0",
+            "jest-matcher-utils": "^24.7.0",
+            "jest-message-util": "^24.7.1",
+            "jest-resolve": "^24.7.1",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^24.7.0",
+            "semver": "^5.5.0"
+          }
+        },
+        "jest-util": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.7.1.tgz",
+          "integrity": "sha512-/KilOue2n2rZ5AnEBYoxOXkeTu6vi7cjgQ8MXEkih0oeAXT6JkS3fr7/j8+engCjciOU1Nq5loMSKe0A1oeX0A==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^24.7.1",
+            "@jest/fake-timers": "^24.7.1",
+            "@jest/source-map": "^24.3.0",
+            "@jest/test-result": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "callsites": "^3.0.0",
+            "chalk": "^2.0.1",
+            "graceful-fs": "^4.1.15",
+            "is-ci": "^2.0.0",
+            "mkdirp": "^0.5.1",
+            "slash": "^2.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "jest-validate": {
+          "version": "24.7.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.7.0.tgz",
+          "integrity": "sha512-cgai/gts9B2chz1rqVdmLhzYxQbgQurh1PEQSvSgPZ8KGa1AqXsqC45W5wKEwzxKrWqypuQrQxnF4+G9VejJJA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0",
+            "camelcase": "^5.0.0",
+            "chalk": "^2.0.1",
+            "jest-get-type": "^24.3.0",
+            "leven": "^2.1.0",
+            "pretty-format": "^24.7.0"
+          }
+        },
+        "jest-watcher": {
+          "version": "24.7.1",
+          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.7.1.tgz",
+          "integrity": "sha512-Wd6TepHLRHVKLNPacEsBwlp9raeBIO+01xrN24Dek4ggTS8HHnOzYSFnvp+6MtkkJ3KfMzy220KTi95e2rRkrw==",
+          "dev": true,
+          "requires": {
+            "@jest/test-result": "^24.7.1",
+            "@jest/types": "^24.7.0",
+            "@types/yargs": "^12.0.9",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.1",
+            "jest-util": "^24.7.1",
+            "string-length": "^2.0.0"
+          }
+        },
+        "jest-worker": {
+          "version": "24.6.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
+          "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
+          "dev": true,
+          "requires": {
+            "merge-stream": "^1.0.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "24.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",
+          "integrity": "sha512-apen5cjf/U4dj7tHetpC7UEFCvtAgnNZnBDkfPv3fokzIqyOJckAG9OlAPC1BlFALnqT/lGB2tl9EJjlK6eCsA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.7.0",
+            "ansi-regex": "^4.0.0",
+            "ansi-styles": "^3.2.0",
+            "react-is": "^16.8.4"
+          }
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "husky": "^1.3.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.5.0",
+    "jest-cli": "^24.7.1",
     "markdown-loader-jest": "^0.1.1",
     "mini-css-extract-plugin": "^0.5.0",
     "node-sass": "^4.11.0",

--- a/src/CheckBox/CheckBox.test.jsx
+++ b/src/CheckBox/CheckBox.test.jsx
@@ -28,7 +28,7 @@ describe('<CheckBox />', () => {
 
   it('check that callback function is triggered when clicked', () => {
     const spy = jest.fn();
-    const wrapper = mount(<CheckBox name="checkbox" label="check me out!"onChange={spy} />);
+    const wrapper = mount(<CheckBox name="checkbox" label="check me out!" onChange={spy} />);
 
     expect(spy).toHaveBeenCalledTimes(0);
     // check

--- a/src/CheckBox/index.jsx
+++ b/src/CheckBox/index.jsx
@@ -30,18 +30,13 @@ class Check extends React.Component {
   }
 
   render() {
-    const props = { ...this.props };
-
     return (
       <input
-        id={props.id}
-        className={props.className}
+        {...this.props}
         type="checkbox"
-        name={props.name}
         checked={this.state.checked}
         aria-checked={this.state.checked}
         onChange={this.onChange}
-        disabled={props.disabled}
       />
     );
   }

--- a/src/CheckBox/index.jsx
+++ b/src/CheckBox/index.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import asInput from '../asInput';
+import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
+
 
 class Check extends React.Component {
   constructor(props) {
@@ -30,10 +32,15 @@ class Check extends React.Component {
   }
 
   render() {
+    const {
+      inputRef,
+      ...others
+    } = this.props;
     return (
       <input
-        {...this.props}
+        {...others}
         type="checkbox"
+        ref={inputRef}
         checked={this.state.checked}
         aria-checked={this.state.checked}
         onChange={this.onChange}
@@ -42,16 +49,27 @@ class Check extends React.Component {
   }
 }
 
+
 Check.propTypes = {
   checked: PropTypes.bool,
   onChange: PropTypes.func,
+  inputRef: PropTypes.func,
 };
 
 Check.defaultProps = {
   checked: false,
   onChange: () => {},
+  inputRef: undefined,
 };
 
-const CheckBox = asInput(Check, 'checkbox', false);
+
+const CheckBox = asInput(withDeprecatedProps(Check, 'Checkbox', {
+  className: {
+    deprType: DEPR_TYPES.FORMAT,
+    expect: value => typeof value === 'string',
+    transform: value => (Array.isArray(value) ? value.join(' ') : value),
+    message: 'It should be a string.',
+  },
+}), 'checkbox', false);
 
 export default CheckBox;

--- a/src/InputSelect/index.jsx
+++ b/src/InputSelect/index.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-import asInput, { inputProps } from '../asInput';
+import asInput from '../asInput';
 import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
+
 
 class Select extends React.Component {
   static getOption(option, i) {
@@ -45,9 +45,7 @@ class Select extends React.Component {
 
   render() {
     const {
-      ariaLabel,
       className,
-      describedBy,
       inputRef,
       ...others
     } = this.props;
@@ -56,10 +54,8 @@ class Select extends React.Component {
     return (
       <select
         {...others}
-        className={classNames(className)}
+        className={className}
         type="select"
-        aria-label={ariaLabel}
-        aria-describedby={describedBy}
         ref={inputRef}
       >
         {options}
@@ -68,13 +64,21 @@ class Select extends React.Component {
   }
 }
 
+
 Select.propTypes = {
-  ...inputProps,
+  className: PropTypes.string,
+  inputRef: PropTypes.func,
   options: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.arrayOf(PropTypes.object),
   ]).isRequired,
 };
+
+Select.defaultProps = {
+  className: undefined,
+  inputRef: undefined,
+};
+
 
 const InputSelect = asInput(withDeprecatedProps(Select, 'InputSelect', {
   className: {
@@ -84,11 +88,5 @@ const InputSelect = asInput(withDeprecatedProps(Select, 'InputSelect', {
     message: 'It should be a string.',
   },
 }));
-
-InputSelect.propTypes = {
-  ...InputSelect.propTypes,
-  ...Select.propTypes,
-};
-
 
 export default InputSelect;

--- a/src/InputSelect/index.jsx
+++ b/src/InputSelect/index.jsx
@@ -44,23 +44,23 @@ class Select extends React.Component {
   }
 
   render() {
-    const props = { ...this.props };
+    const {
+      ariaLabel,
+      className,
+      describedBy,
+      inputRef,
+      ...others
+    } = this.props;
     const options = this.getOptions();
 
     return (
       <select
-        id={props.id}
-        className={classNames(props.className)}
+        {...others}
+        className={classNames(className)}
         type="select"
-        name={props.name}
-        value={props.value}
-        aria-label={props.ariaLabel}
-        aria-describedby={props.describedBy}
-        onChange={props.onChange}
-        onBlur={props.onBlur}
-        ref={props.inputRef}
-        disabled={props.disabled}
-        required={props.required}
+        aria-label={ariaLabel}
+        aria-describedby={describedBy}
+        ref={inputRef}
       >
         {options}
       </select>

--- a/src/InputText/InputText.stories.jsx
+++ b/src/InputText/InputText.stories.jsx
@@ -194,6 +194,16 @@ storiesOf('User Input|InputText', module)
       />
     </form>
   ))
+  .add('price with step', () => (
+    <InputText
+      name="price"
+      label="Price"
+      type="number"
+      value={3.50}
+      min={0}
+      step={0.01}
+    />
+  ))
   .add('displayed inline', () => (
     <InputText
       name="username"

--- a/src/InputText/index.jsx
+++ b/src/InputText/index.jsx
@@ -8,25 +8,23 @@ import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
 
 
 function Text(props) {
+  const {
+    className,
+    describedBy,
+    inputRef,
+    isValid,
+    type,
+    ...others
+  } = props;
+
   return (
     <input
-      id={props.id}
-      className={classNames(props.className)}
-      type={props.type || 'text'}
-      name={props.name}
-      value={props.value}
-      placeholder={props.placeholder}
-      aria-describedby={props.describedBy}
-      onChange={props.onChange}
-      onKeyPress={props.onKeyPress}
-      onBlur={props.onBlur}
-      aria-invalid={!props.isValid}
-      autoComplete={props.autoComplete}
-      disabled={props.disabled}
-      readOnly={props.readOnly}
-      required={props.required}
-      ref={props.inputRef}
-      themes={props.themes}
+      {...others}
+      className={classNames(className)}
+      type={type || 'text'}
+      aria-describedby={describedBy}
+      aria-invalid={!isValid}
+      ref={inputRef}
     />
   );
 }

--- a/src/InputText/index.jsx
+++ b/src/InputText/index.jsx
@@ -1,18 +1,14 @@
 import React from 'react';
-import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-
-import asInput, { inputProps, defaultProps } from '../asInput';
+import asInput from '../asInput';
 import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
 
 
 function Text(props) {
   const {
     className,
-    describedBy,
     inputRef,
-    isValid,
     type,
     ...others
   } = props;
@@ -20,35 +16,26 @@ function Text(props) {
   return (
     <input
       {...others}
-      className={classNames(className)}
+      className={className}
       type={type || 'text'}
-      aria-describedby={describedBy}
-      aria-invalid={!isValid}
       ref={inputRef}
     />
   );
 }
 
-const textPropTypes = {
-  type: PropTypes.string,
-  describedBy: PropTypes.string,
-  isValid: PropTypes.bool,
-  autoComplete: PropTypes.string,
+
+Text.propTypes = {
+  className: PropTypes.string,
   inputRef: PropTypes.func,
-  readOnly: PropTypes.bool,
+  type: PropTypes.string,
 };
 
-const textDefaultProps = {
+Text.defaultProps = {
+  className: undefined,
+  inputRef: undefined,
   type: 'text',
-  describedBy: '',
-  isValid: true,
-  autoComplete: 'on',
-  inputRef: () => {},
-  readOnly: false,
 };
 
-Text.propTypes = { ...textPropTypes, ...inputProps };
-Text.defaultProps = { ...textDefaultProps, ...defaultProps };
 
 const InputText = asInput(withDeprecatedProps(Text, 'InputText', {
   className: {

--- a/src/TextArea/index.jsx
+++ b/src/TextArea/index.jsx
@@ -5,20 +5,21 @@ import asInput, { inputProps } from '../asInput';
 import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
 
 function Text(props) {
+  const {
+    className,
+    describedBy,
+    inputRef,
+    isValid,
+    ...others
+  } = props;
+
   return (
     <textarea
-      id={props.id}
-      className={classNames(props.className)}
-      name={props.name}
-      value={props.value}
-      placeholder={props.placeholder}
-      aria-describedby={props.describedBy}
-      onChange={props.onChange}
-      onBlur={props.onBlur}
-      aria-invalid={!props.isValid}
-      disabled={props.disabled}
-      required={props.required}
-      ref={props.inputRef}
+      {...others}
+      className={classNames(className)}
+      aria-describedby={describedBy}
+      aria-invalid={!isValid}
+      ref={inputRef}
       themes={['danger']}
     />
   );

--- a/src/TextArea/index.jsx
+++ b/src/TextArea/index.jsx
@@ -1,31 +1,37 @@
 import React from 'react';
-import classNames from 'classnames';
+import PropTypes from 'prop-types';
 
-import asInput, { inputProps } from '../asInput';
+import asInput from '../asInput';
 import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
+
 
 function Text(props) {
   const {
     className,
-    describedBy,
     inputRef,
-    isValid,
     ...others
   } = props;
 
   return (
     <textarea
       {...others}
-      className={classNames(className)}
-      aria-describedby={describedBy}
-      aria-invalid={!isValid}
+      className={className}
       ref={inputRef}
-      themes={['danger']}
     />
   );
 }
 
-Text.propTypes = inputProps;
+
+Text.propTypes = {
+  className: PropTypes.string,
+  inputRef: PropTypes.func,
+};
+
+Text.defaultProps = {
+  className: undefined,
+  inputRef: undefined,
+};
+
 
 const TextArea = asInput(withDeprecatedProps(Text, 'TextArea', {
   className: {

--- a/src/asInput/index.jsx
+++ b/src/asInput/index.jsx
@@ -35,6 +35,8 @@ export const inputProps = {
   inline: PropTypes.bool,
   inputGroupPrepend: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.element), PropTypes.element]),
   inputGroupAppend: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.element), PropTypes.element]),
+  type: PropTypes.string,
+  inputRef: PropTypes.func,
 };
 
 export const defaultProps = {
@@ -55,6 +57,8 @@ export const defaultProps = {
   inline: false,
   inputGroupPrepend: undefined,
   inputGroupAppend: undefined,
+  type: undefined,
+  inputRef: undefined,
 };
 
 const asInput = (WrappedComponent, inputType = undefined, labelFirst = true) => {
@@ -76,9 +80,6 @@ const asInput = (WrappedComponent, inputType = undefined, labelFirst = true) => 
         isValid,
         validationMessage,
         dangerIconDescription,
-        describedBy: [],
-        errorId: `error-${id}`,
-        descriptionId: `description-${id}`,
       };
     }
 
@@ -190,6 +191,7 @@ const asInput = (WrappedComponent, inputType = undefined, labelFirst = true) => 
 
     handleChange(event) {
       this.setState({ value: event.target.value });
+
       this.props.onChange(
         event.target.type === 'checkbox' ? event.target.checked : event.target.value,
         this.props.name,
@@ -205,12 +207,29 @@ const asInput = (WrappedComponent, inputType = undefined, labelFirst = true) => 
     }
 
     renderInput(describedBy) {
-      const { className } = this.props;
+      const {
+        className,
+        inputRef,
+        type,
+        isValid,
+        // unused
+        validator,
+        themes,
+        inline,
+        inputGroupPrepend,
+        inputGroupAppend,
+        label,
+        dangerIconDescription,
+        description,
+        validationMessage,
+        ...others
+      } = this.props;
 
       return (
         <WrappedComponent
-          {...this.props}
-          {...this.state}
+          {...others}
+          id={this.state.id}
+          value={this.state.value}
           className={[classNames(
             {
               'form-control': !this.isGroupedInput(),
@@ -220,10 +239,13 @@ const asInput = (WrappedComponent, inputType = undefined, labelFirst = true) => 
             },
             className,
           ).trim()]}
-          describedBy={describedBy}
+          aria-describedby={describedBy}
+          aria-invalid={!isValid}
           onChange={this.handleChange}
           onBlur={this.handleBlur}
           onKeyPress={this.handleKeyPress}
+          type={type}
+          inputRef={inputRef}
         />
       );
     }
@@ -281,6 +303,10 @@ const asInput = (WrappedComponent, inputType = undefined, labelFirst = true) => 
       expect: value => typeof value === 'string',
       transform: value => (Array.isArray(value) ? value.join(' ') : value),
       message: 'It should be a string.',
+    },
+    ariaLabel: {
+      deprType: DEPR_TYPES.MOVED,
+      newName: 'aria-label',
     },
   });
 };


### PR DESCRIPTION
This way properties that we don't explicitly care about can still get through to the underlying input element. There are a lot of input props, seems unnecessary to gatekeep them.

In my immediate case, I was interested in using min and step - hence the new storybook that uses them.

I also set a version for jest-cli, which had an implicit version before at 20.x or something. I hit an error when updating the snapshot that was fixed in 22.x, so I set it's version to match the version we demand for just "jest".