### PR TITLE
fix: use webpack config to pass through NODE_ENV

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 coverage/*
 dist/
 node_modules/
-index.js

--- a/index.js
+++ b/index.js
@@ -1,9 +1,0 @@
-// Set an environment variable on the window during
-// development mode of the consuming application.
-// This enables the production, built version of
-// Paragon to display warnings during development.
-if (process.env.NODE_ENV === 'development') {
-  window.PARAGON_ENV = 'development';
-}
-
-module.exports = require('./dist/paragon.js');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/paragon",
   "version": "0.0.0-development",
   "description": "Accessible, responsive UI component library based on Bootstrap.",
-  "main": "index.js",
+  "main": "dist/paragon.js",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/src/withDeprecatedProps.jsx
+++ b/src/withDeprecatedProps.jsx
@@ -16,7 +16,7 @@ function withDeprecatedProps(WrappedComponent, componentName, deprecatedProps) {
     }
 
     warn(message) {
-      if (process.env.NODE_ENV === 'development' || (window && window.PARAGON_ENV === 'development')) {
+      if (process.env.NODE_ENV === 'development') {
         if (console) console.warn(`[Deprecated] ${message}`);
       }
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,12 @@ module.exports = {
     paragon: './src/index.js',
     style: './src/index.scss',
   },
+  optimization: {
+    nodeEnv: false,
+  },
+  node: {
+    process: false,
+  },
   output: {
     filename: '[name].js',
     library: 'paragon',


### PR DESCRIPTION
In order to gain access to `NODE_ENV` previously we had added a variable on the window. This approach is better and is hinted at here: https://github.com/webpack/webpack/issues/6673