### PR TITLE
For discussion: One Input component to rule them all

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -3857,6 +3857,105 @@ exports[`Storyshots User Input|Fieldset invalid with danger theme 1`] = `
 </form>
 `;
 
+exports[`Storyshots User Input|Input minimal usage 1`] = `
+<div>
+  <div
+    className="form-group"
+  >
+    <select
+      className="form-control"
+      defaultValue="Foo Bar"
+    >
+      <option
+        value="Foo Bar"
+      >
+        Foo Bar
+      </option>
+      <option
+        value="Foos Bar"
+      >
+        Bar foo
+      </option>
+      <option
+        value="Foo sBar"
+      >
+        FoBaro
+      </option>
+      <option
+        value="Foo ssBar"
+      >
+        Farboo
+      </option>
+      <optgroup
+        label="But there is more"
+      >
+        <option
+          value="vFoo Bar"
+        >
+          Foov Bar
+        </option>
+        <option
+          value="vFoos Bar"
+        >
+          Barv foo
+        </option>
+        <option
+          value="vFoo sBar"
+        >
+          FoBarov
+        </option>
+        <option
+          value="vFoo ssBar"
+        >
+          Farboov
+        </option>
+      </optgroup>
+    </select>
+  </div>
+  <div
+    className="form-group"
+  >
+    <textarea
+      className="form-control"
+      defaultValue="Hammock semiotics pok pok jianbing venmo, crucifix taiyaki stumptown irony ennui knausgaard bitters synth slow-carb iPhone."
+    />
+  </div>
+  <div
+    className="form-group"
+  >
+    <input
+      className="form-control"
+      defaultValue="Some text input"
+      type="text"
+    />
+  </div>
+  <div
+    className="form-group"
+  >
+    <input
+      className="form-control"
+      type="date"
+    />
+  </div>
+  <div
+    className="form-group"
+  >
+    <input
+      className="form-control-file"
+      type="file"
+    />
+  </div>
+  <div
+    className="form-group"
+  >
+    <input
+      className="form-control"
+      type="range"
+    />
+  </div>
+</div>
+`;
+
 exports[`Storyshots User Input|InputSelect basic usage 1`] = `
 <div
   className="form-group"

--- a/src/Input/Input.stories.jsx
+++ b/src/Input/Input.stories.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+
+import Input from './index';
+
+storiesOf('User Input|Input', module)
+  .add('minimal usage', () => (
+    <div>
+      <div className="form-group">
+        <Input
+          type="select"
+          defaultValue="Foo Bar"
+          options={[
+            { value: 'Foo Bar', label: 'Foo Bar' },
+            { value: 'Foos Bar', label: 'Bar foo' },
+            { value: 'Foo sBar', label: 'FoBaro' },
+            { value: 'Foo ssBar', label: 'Farboo' },
+            {
+              label: 'But there is more',
+              group: [
+                { value: 'vFoo Bar', label: 'Foov Bar' },
+                { value: 'vFoos Bar', label: 'Barv foo' },
+                { value: 'vFoo sBar', label: 'FoBarov' },
+                { value: 'vFoo ssBar', label: 'Farboov' },
+              ],
+            },
+          ]}
+        />
+      </div>
+      <div className="form-group">
+        <Input
+          type="textarea"
+          defaultValue="Hammock semiotics pok pok jianbing venmo, crucifix taiyaki stumptown irony ennui knausgaard bitters synth slow-carb iPhone."
+        />
+      </div>
+
+      <div className="form-group">
+        <Input type="text" defaultValue="Some text input" />
+      </div>
+      <div className="form-group">
+        <Input type="date" />
+      </div>
+      <div className="form-group">
+        <Input type="file" />
+      </div>
+      <div className="form-group">
+        <Input type="range" />
+      </div>
+    </div>
+  ));

--- a/src/Input/Input.stories.jsx
+++ b/src/Input/Input.stories.jsx
@@ -3,8 +3,10 @@ import { storiesOf } from '@storybook/react';
 
 
 import Input from './index';
+import README from './README.md';
 
 storiesOf('User Input|Input', module)
+  .addParameters({ info: { text: README } })
   .add('minimal usage', () => (
     <div>
       <div className="form-group">
@@ -34,7 +36,6 @@ storiesOf('User Input|Input', module)
           defaultValue="Hammock semiotics pok pok jianbing venmo, crucifix taiyaki stumptown irony ennui knausgaard bitters synth slow-carb iPhone."
         />
       </div>
-
       <div className="form-group">
         <Input type="text" defaultValue="Some text input" />
       </div>

--- a/src/Input/README.md
+++ b/src/Input/README.md
@@ -1,0 +1,27 @@
+# Input
+
+A component for all user input. It is responsible for rendering select, textarea, and inputs of any type with the appropriate bootstrap class name.
+
+## API
+
+### `type` (string; required)
+`type` specifies the type of component. One of select, textarea, or any valid type for an html input tag.
+
+### `className` (string; optional)
+`className` specifies the className in addition to a bootstrap class name.
+
+### `options` (element; optional)
+`options` should be used to specify the options of an Input of type select
+
+```
+[{...
+  label?: string,
+  value?: string,
+  group?: [{...
+    label?: string,
+    value?: string,
+  }],
+}]
+```
+
+All other props added to Input will be passed through to the html node.

--- a/src/Input/index.jsx
+++ b/src/Input/index.jsx
@@ -19,16 +19,16 @@ const renderOptions = options => options.map(({
   value,
   label,
   group,
-  ...others
+  ...attributes
 }) => {
   if (group) {
     return (
-      <optgroup key={`opt-group-${label}`} label={label} {...others}>
+      <optgroup key={`opt-group-${label}`} label={label} {...attributes}>
         {renderOptions(group)}
       </optgroup>
     );
   }
-  return <option key={value} value={value} {...others}>{label}</option>;
+  return <option key={value} value={value} {...attributes}>{label}</option>;
 });
 
 
@@ -40,13 +40,13 @@ const Input = React.forwardRef((props, ref) => {
     type,
     className,
     options,
-    ...attrs
+    ...attributes
   } = props;
   const htmlTag = getHTMLTagForType(type);
   const htmlProps = {
     className: classNames(getClassNameForType(type), className),
     type: htmlTag === 'input' ? type : undefined,
-    ...attrs,
+    ...attributes,
     ref,
   };
   const htmlChildren = type === 'select' ? renderOptions(options) : null;
@@ -61,9 +61,11 @@ Input.propTypes = {
   options: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string,
     value: PropTypes.string,
+    disabled: PropTypes.bool,
     group: PropTypes.arrayOf(PropTypes.shape({
       label: PropTypes.string,
       value: PropTypes.string,
+      disabled: PropTypes.bool,
     })),
   })),
 };

--- a/src/Input/index.jsx
+++ b/src/Input/index.jsx
@@ -15,42 +15,49 @@ const getClassNameForType = (inputType) => {
   return 'form-control';
 };
 
-const renderOptions = options => options.map(({ value, label, group }) => {
+const renderOptions = options => options.map(({
+  value,
+  label,
+  group,
+  ...others
+}) => {
   if (group) {
     return (
-      <optgroup key={`opt-group-${label}`} label={label}>
+      <optgroup key={`opt-group-${label}`} label={label} {...others}>
         {renderOptions(group)}
       </optgroup>
     );
   }
-  return <option key={value} value={value}>{label}</option>;
+  return <option key={value} value={value} {...others}>{label}</option>;
 });
 
 
-function Input({
-  type,
-  className,
-  children,
-  options,
-  ...attrs
-}) {
-  const htmlTag = getHTMLTagForType(type);
+// More on forwarding refs here:
+// https://reactjs.org/docs/forwarding-refs.html#displaying-a-custom-name-in-devtools
 
-  return React.createElement(
-    htmlTag,
-    {
-      className: classNames(getClassNameForType(type), className),
-      type: htmlTag === 'input' ? type : undefined,
-      ...attrs,
-    },
-    (type === 'select' && options) ? renderOptions(options) : children,
-  );
-}
+const Input = React.forwardRef((props, ref) => {
+  const {
+    type,
+    className,
+    options,
+    ...attrs
+  } = props;
+  const htmlTag = getHTMLTagForType(type);
+  const htmlProps = {
+    className: classNames(getClassNameForType(type), className),
+    type: htmlTag === 'input' ? type : undefined,
+    ...attrs,
+    ref,
+  };
+  const htmlChildren = type === 'select' ? renderOptions(options) : null;
+
+  return React.createElement(htmlTag, htmlProps, htmlChildren);
+});
+
 
 Input.propTypes = {
   type: PropTypes.string.isRequired,
   className: PropTypes.string,
-  children: PropTypes.node, // Should accept only <option> and <optgroup>
   options: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string,
     value: PropTypes.string,
@@ -63,8 +70,8 @@ Input.propTypes = {
 
 Input.defaultProps = {
   className: undefined,
-  children: undefined,
-  options: undefined,
+  options: [],
 };
+
 
 export default Input;

--- a/src/Input/index.jsx
+++ b/src/Input/index.jsx
@@ -16,14 +16,11 @@ const getClassNameForType = (inputType) => {
 };
 
 const renderOptions = options => options.map(({
-  value,
-  label,
-  group,
-  ...attributes
+  value, label, group, ...attributes
 }) => {
   if (group) {
     return (
-      <optgroup key={`opt-group-${label}`} label={label} {...attributes}>
+      <optgroup key={`optgroup-${label}`} label={label} {...attributes}>
         {renderOptions(group)}
       </optgroup>
     );
@@ -37,10 +34,7 @@ const renderOptions = options => options.map(({
 
 const Input = React.forwardRef((props, ref) => {
   const {
-    type,
-    className,
-    options,
-    ...attributes
+    type, className, options, ...attributes
   } = props;
   const htmlTag = getHTMLTagForType(type);
   const htmlProps = {

--- a/src/Input/index.jsx
+++ b/src/Input/index.jsx
@@ -29,24 +29,47 @@ const renderOptions = options => options.map(({
 });
 
 
-// More on forwarding refs here:
-// https://reactjs.org/docs/forwarding-refs.html#displaying-a-custom-name-in-devtools
+class Input extends React.Component {
+  constructor(props) {
+    super(props);
 
-const Input = React.forwardRef((props, ref) => {
-  const {
-    type, className, options, ...attributes
-  } = props;
-  const htmlTag = getHTMLTagForType(type);
-  const htmlProps = {
-    className: classNames(getClassNameForType(type), className),
-    type: htmlTag === 'input' ? type : undefined,
-    ...attributes,
-    ref,
-  };
-  const htmlChildren = type === 'select' ? renderOptions(options) : null;
+    this.innerRef = props.innerRef; // eslint-disable-line react/prop-types
+    if (process.env.NODE_ENV === 'development' && !this.innerRef) {
+      this.innerRef = React.createRef();
+    }
+  }
 
-  return React.createElement(htmlTag, htmlProps, htmlChildren);
-});
+  componentDidMount() {
+    this.checkHasLabel();
+  }
+
+  checkHasLabel() {
+    if (process.env.NODE_ENV !== 'development') return;
+
+    // eslint-disable-next-line react/prop-types
+    const hasLabel = (this.innerRef.current.labels.length > 0) || this.props['aria-label'];
+    if (hasLabel) return;
+
+    // eslint-disable-next-line no-console
+    if (console) console.warn('Input[a11y]: There is no associated label for this Input');
+  }
+
+  render() {
+    const {
+      type, className, options, innerRef, ...attributes // eslint-disable-line react/prop-types
+    } = this.props;
+    const htmlTag = getHTMLTagForType(type);
+    const htmlProps = {
+      className: classNames(getClassNameForType(type), className),
+      type: htmlTag === 'input' ? type : undefined,
+      ...attributes,
+      ref: this.innerRef,
+    };
+    const htmlChildren = type === 'select' ? renderOptions(options) : null;
+
+    return React.createElement(htmlTag, htmlProps, htmlChildren);
+  }
+}
 
 
 Input.propTypes = {
@@ -70,4 +93,8 @@ Input.defaultProps = {
 };
 
 
-export default Input;
+// Using React.forwardRef – more on forwarding refs here:
+// https://reactjs.org/docs/forwarding-refs.html
+
+// eslint-disable-next-line react/no-multi-comp
+export default React.forwardRef((props, ref) => <Input innerRef={ref} {...props} />);

--- a/src/Input/index.jsx
+++ b/src/Input/index.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+
+
+const getHTMLTagForType = (type) => {
+  if (type === 'select' || type === 'textarea') return type;
+  return 'input';
+};
+
+const getClassNameForType = (inputType) => {
+  if (inputType === 'file') return 'form-control-file';
+  if (inputType === 'checkbox') return 'form-check-input';
+  if (inputType === 'radio') return 'form-check-input';
+  return 'form-control';
+};
+
+const renderOptions = options => options.map(({ value, label, group }) => {
+  if (group) {
+    return (
+      <optgroup key={`opt-group-${label}`} label={label}>
+        {renderOptions(group)}
+      </optgroup>
+    );
+  }
+  return <option key={value} value={value}>{label}</option>;
+});
+
+
+function Input({
+  type,
+  className,
+  children,
+  options,
+  ...attrs
+}) {
+  const htmlTag = getHTMLTagForType(type);
+
+  return React.createElement(
+    htmlTag,
+    {
+      className: classNames(getClassNameForType(type), className),
+      type: htmlTag === 'input' ? type : undefined,
+      ...attrs,
+    },
+    (type === 'select' && options) ? renderOptions(options) : children,
+  );
+}
+
+Input.propTypes = {
+  type: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  children: PropTypes.node, // Should accept only <option> and <optgroup>
+  options: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string,
+    value: PropTypes.string,
+    group: PropTypes.arrayOf(PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.string,
+    })),
+  })),
+};
+
+Input.defaultProps = {
+  className: undefined,
+  children: undefined,
+  options: undefined,
+};
+
+export default Input;

--- a/src/Input/index.jsx
+++ b/src/Input/index.jsx
@@ -17,11 +17,15 @@ class Input extends React.Component {
   }
 
   getClassNameForType() {
-    const { type } = this.props;
-    if (type === 'file') return 'form-control-file';
-    if (type === 'checkbox') return 'form-check-input';
-    if (type === 'radio') return 'form-check-input';
-    return 'form-control';
+    switch (this.props.type) {
+      case 'file':
+        return 'form-control-file';
+      case 'checkbox':
+      case 'radio':
+        return 'form-check-input';
+      default:
+        return 'form-control';
+    }
   }
 
   getRef(forwardedRef) {
@@ -78,15 +82,40 @@ class Input extends React.Component {
 
 
 Input.propTypes = {
-  type: PropTypes.string.isRequired,
+  type: PropTypes.oneOf([
+    'textarea',
+    'select',
+    'checkbox',
+    'color',
+    'date',
+    'datetime',
+    'datetime-local',
+    'email',
+    'file',
+    'hidden',
+    'image',
+    'month',
+    'number',
+    'password',
+    'radio',
+    'range',
+    'reset',
+    'search',
+    'submit',
+    'tel',
+    'text',
+    'time',
+    'url',
+    'week',
+  ]).isRequired,
   className: PropTypes.string,
   options: PropTypes.arrayOf(PropTypes.shape({
-    label: PropTypes.string,
-    value: PropTypes.string,
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     disabled: PropTypes.bool,
     group: PropTypes.arrayOf(PropTypes.shape({
-      label: PropTypes.string,
-      value: PropTypes.string,
+      label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       disabled: PropTypes.bool,
     })),
   })),
@@ -97,9 +126,6 @@ Input.defaultProps = {
   options: [],
 };
 
-
-// Using React.forwardRef – more on forwarding refs here:
-// https://reactjs.org/docs/forwarding-refs.html
 
 // eslint-disable-next-line react/no-multi-comp
 export default React.forwardRef((props, ref) => <Input innerRef={ref} {...props} />);

--- a/src/ValidationFormGroup/ValidationFormGroup.stories.jsx
+++ b/src/ValidationFormGroup/ValidationFormGroup.stories.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import ValidationFormGroup from './index';
+import Input from '../Input';
 import README from './README.md';
 
 storiesOf('User Input|Validation Form Group', module)
@@ -12,8 +13,7 @@ storiesOf('User Input|Validation Form Group', module)
       helpText="This is your name."
     >
       <label htmlFor="firstName">First Name</label>
-      <input
-        className="form-control"
+      <Input
         type="text"
         id="firstName"
         name="first-name"
@@ -29,8 +29,7 @@ storiesOf('User Input|Validation Form Group', module)
       invalidMessage="Wrong!"
     >
       <label htmlFor="firstName">First Name</label>
-      <input
-        className="form-control"
+      <Input
         type="text"
         id="firstName"
         name="first-name"
@@ -46,8 +45,7 @@ storiesOf('User Input|Validation Form Group', module)
       validMessage="What a nice name!"
     >
       <label htmlFor="firstName">First Name</label>
-      <input
-        className="form-control"
+      <Input
         type="text"
         id="firstName"
         name="first-name"

--- a/src/ValidationFormGroup/index.jsx
+++ b/src/ValidationFormGroup/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-
+import Input from '../Input';
 
 const propTypes = {
   for: PropTypes.string.isRequired,
@@ -39,7 +39,7 @@ function ValidationFormGroup(props) {
 
   const renderChildren = () => React.Children.map(children, (child) => {
     // Any non-user input element should pass through unmodified
-    if (['input', 'textarea', 'select'].indexOf(child.type) === -1) return child;
+    if (['input', 'textarea', 'select', Input].indexOf(child.type) === -1) return child;
 
     // Add validation class names and describedby values to input element
     return React.cloneElement(child, {


### PR DESCRIPTION
This PR illustrates an option regarding what to do about html inputs. We've discussed simply using the html directly. This represents another option, creating a single component interface for all user input html tags (select, textarea, input(s)). My thoughts on pros/cons:

Pros:
- No need to remember bootstrap class names
- It enforces labelling in development mode by checking if the html element has an associated label tag or aria-label attribute on `componentDidMount`
- A single component for all kinds of input elements would make some templated code easier to write (imagine iterating through an array for field definitions and choosing whether to render a select, text, or other input type)
- We could require users of the component specify an id, encouraging them to add an associated label

Cons:
- Currently this component doesn't do very much
- Linters won't by default pick up on accessibility issues
- It could be argued that select, textarea, and input are different enough that they should not be wrapped up into a single component

# Input

A component for all user input. It is responsible for rendering select, textarea, and inputs of any type with the appropriate bootstrap class name.

## API

### `type` (string; required)
`type` specifies the type of component. One of select, textarea, or any valid type for an html input tag.

### `className` (string; optional)
`className` specifies the className in addition to a bootstrap class name.

### `options` (array; optional)
`options` should be used to specify the options of an Input of type select

```
[{...
    label: PropTypes.string,
    value: PropTypes.string,
    disabled: PropTypes.bool,
    group: PropTypes.arrayOf(PropTypes.shape({
      label: PropTypes.string,
      value: PropTypes.string,
      disabled: PropTypes.bool,
    })),
}]
```

### Other attributes
All other props added to Input will be passed through to the html node.