### PR TITLE
fix: update proptypes change disabled behavior

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -187,9 +187,9 @@ exports[`Storyshots Basics|MailtoLink with subject and body 1`] = `
 exports[`Storyshots Basics|StatefulButton basic usage 1`] = `
 <div>
   <button
+    aria-disabled={false}
     aria-live="assertive"
     className="btn pgn__stateful-btn pgn__stateful-btn-state-default btn-primary mr-2"
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
@@ -202,9 +202,9 @@ exports[`Storyshots Basics|StatefulButton basic usage 1`] = `
     </span>
   </button>
   <button
+    aria-disabled={true}
     aria-live="assertive"
     className="btn pgn__stateful-btn pgn__stateful-btn-state-pending btn-primary mr-2 disabled"
-    disabled={true}
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
@@ -226,9 +226,9 @@ exports[`Storyshots Basics|StatefulButton basic usage 1`] = `
     </span>
   </button>
   <button
+    aria-disabled={true}
     aria-live="assertive"
     className="btn pgn__stateful-btn pgn__stateful-btn-state-complete btn-primary mr-2 disabled"
-    disabled={true}
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
@@ -255,9 +255,9 @@ exports[`Storyshots Basics|StatefulButton basic usage 1`] = `
 exports[`Storyshots Basics|StatefulButton custom icons and disable during state 1`] = `
 Array [
   <button
+    aria-disabled={false}
     aria-live="assertive"
     className="btn pgn__stateful-btn pgn__stateful-btn-state-default btn-primary mr-2"
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
@@ -279,9 +279,9 @@ Array [
     </span>
   </button>,
   <button
+    aria-disabled={true}
     aria-live="assertive"
     className="btn pgn__stateful-btn pgn__stateful-btn-state-pending btn-primary mr-2 disabled"
-    disabled={true}
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
@@ -303,9 +303,9 @@ Array [
     </span>
   </button>,
   <button
+    aria-disabled={false}
     aria-live="assertive"
     className="btn pgn__stateful-btn pgn__stateful-btn-state-complete btn-primary mr-2"
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
@@ -332,9 +332,9 @@ Array [
 exports[`Storyshots Basics|StatefulButton custom states 1`] = `
 Array [
   <button
+    aria-disabled={true}
     aria-live="assertive"
     className="btn pgn__stateful-btn pgn__stateful-btn-state-unedited btn-primary mr-2 disabled"
-    disabled={true}
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
@@ -356,9 +356,9 @@ Array [
     </span>
   </button>,
   <button
+    aria-disabled={false}
     aria-live="assertive"
     className="btn pgn__stateful-btn pgn__stateful-btn-state-edited btn-primary mr-2"
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}

--- a/src/StatefulButton/__snapshots__/StatefulButtontest.test.jsx.snap
+++ b/src/StatefulButton/__snapshots__/StatefulButtontest.test.jsx.snap
@@ -3,9 +3,9 @@
 exports[`StatefulButton renders basic usage 1`] = `
 <div>
   <button
+    aria-disabled={false}
     aria-live="assertive"
     className="btn pgn__stateful-btn pgn__stateful-btn-state-default btn-primary mr-2"
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
@@ -18,9 +18,9 @@ exports[`StatefulButton renders basic usage 1`] = `
     </span>
   </button>
   <button
+    aria-disabled={true}
     aria-live="assertive"
     className="btn pgn__stateful-btn pgn__stateful-btn-state-pending btn-primary mr-2 disabled"
-    disabled={true}
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
@@ -42,9 +42,9 @@ exports[`StatefulButton renders basic usage 1`] = `
     </span>
   </button>
   <button
+    aria-disabled={true}
     aria-live="assertive"
     className="btn pgn__stateful-btn pgn__stateful-btn-state-complete btn-primary mr-2 disabled"
-    disabled={true}
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
@@ -71,9 +71,9 @@ exports[`StatefulButton renders basic usage 1`] = `
 exports[`StatefulButton renders custom icons and disable during state 1`] = `
 Array [
   <button
+    aria-disabled={false}
     aria-live="assertive"
     className="btn pgn__stateful-btn pgn__stateful-btn-state-default btn-primary mr-2"
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
@@ -95,9 +95,9 @@ Array [
     </span>
   </button>,
   <button
+    aria-disabled={true}
     aria-live="assertive"
     className="btn pgn__stateful-btn pgn__stateful-btn-state-pending btn-primary mr-2 disabled"
-    disabled={true}
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
@@ -119,9 +119,9 @@ Array [
     </span>
   </button>,
   <button
+    aria-disabled={false}
     aria-live="assertive"
     className="btn pgn__stateful-btn pgn__stateful-btn-state-complete btn-primary mr-2"
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
@@ -148,9 +148,9 @@ Array [
 exports[`StatefulButton renders custom states 1`] = `
 Array [
   <button
+    aria-disabled={true}
     aria-live="assertive"
     className="btn pgn__stateful-btn pgn__stateful-btn-state-unedited btn-primary mr-2 disabled"
-    disabled={true}
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
@@ -172,9 +172,9 @@ Array [
     </span>
   </button>,
   <button
+    aria-disabled={false}
     aria-live="assertive"
     className="btn pgn__stateful-btn pgn__stateful-btn-state-edited btn-primary mr-2"
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}

--- a/src/StatefulButton/index.jsx
+++ b/src/StatefulButton/index.jsx
@@ -8,9 +8,10 @@ import Button from '../Button';
 const propTypes = {
   className: PropTypes.string,
   state: PropTypes.string,
-  labels: PropTypes.objectOf(PropTypes.string).isRequired,
+  labels: PropTypes.objectOf(PropTypes.node).isRequired,
   icons: PropTypes.objectOf(PropTypes.node),
   disabledStates: PropTypes.arrayOf(PropTypes.string),
+  onClick: PropTypes.func,
 };
 
 const defaultProps = {
@@ -22,7 +23,8 @@ const defaultProps = {
     complete: <Icon className="icon fa fa-check-circle" />,
     error: <Icon className="icon fa fa-times-circle" />,
   },
-  disabledStates: ['pending', 'complete', 'error'],
+  disabledStates: ['pending', 'complete'],
+  onClick: undefined,
 };
 
 
@@ -32,6 +34,7 @@ function StatefulButton({
   labels,
   icons,
   disabledStates,
+  onClick,
   ...attributes
 }) {
   const isDisabled = disabledStates.indexOf(state) !== -1;
@@ -40,13 +43,23 @@ function StatefulButton({
   return (
     <Button
       aria-live="assertive"
-      disabled={isDisabled}
       className={classNames(
         'pgn__stateful-btn',
         `pgn__stateful-btn-state-${state}`,
         className,
         { disabled: isDisabled },
       )}
+      onClick={(e) => {
+        // Swallow clicks if the button is disabled.
+        // We do this instead of disabling the button to prevent
+        // it from losing focus (disabled elements cannot have focus).
+        if (isDisabled) {
+          e.preventDefault();
+          return;
+        }
+
+        if (onClick) onClick(e);
+      }}
       {...attributes}
     >
       <span className="d-flex align-items-center justify-content-center">

--- a/src/StatefulButton/index.jsx
+++ b/src/StatefulButton/index.jsx
@@ -43,6 +43,7 @@ function StatefulButton({
   return (
     <Button
       aria-live="assertive"
+      aria-disabled={isDisabled}
       className={classNames(
         'pgn__stateful-btn',
         `pgn__stateful-btn-state-${state}`,


### PR DESCRIPTION
- Change labels proptype to accept nodes instead of just strings. (helpful when using ReactIntl
- Instead throw away click events instead of using the disabled attribute to disable the button