### PR TITLE
fix: update invalid feedback to be strong

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -6331,12 +6331,12 @@ exports[`Storyshots User Input|Validation Form Group invalid message 1`] = `
     type="text"
     value="Casey"
   />
-  <div
+  <strong
     className="invalid-feedback"
     id="firstName-invalid-feedback"
   >
     Wrong!
-  </div>
+  </strong>
 </div>
 `;
 

--- a/src/ValidationFormGroup/__snapshots__/ValidationFormGroup.test.jsx.snap
+++ b/src/ValidationFormGroup/__snapshots__/ValidationFormGroup.test.jsx.snap
@@ -75,12 +75,12 @@ exports[`ValidationFormGroup renders an invalid message 1`] = `
   >
     This is your first name.
   </small>
-  <div
+  <strong
     className="invalid-feedback"
     id="firstName-invalid-feedback"
   >
     This is not your name.
-  </div>
+  </strong>
 </div>
 `;
 

--- a/src/ValidationFormGroup/index.jsx
+++ b/src/ValidationFormGroup/index.jsx
@@ -61,12 +61,29 @@ function ValidationFormGroup(props) {
     return <small id={`${id}-help-text`} className="form-text text-muted">{text}</small>;
   };
 
-  const renderFeedback = (message, state) => {
+  /**
+   * The red text conveys semantic emphasis using color and font weight. For WCAG 2.1, the
+   * semantics need to be exposed programmatically as well. To do this, we use <strong/>
+   * elements and attach the formatting classes to them.
+   */
+  const renderInvalidFeedback = (message) => {
+    if (!message) return null;
+    return (
+      <strong
+        id={`${id}-invalid-feedback`}
+        className="invalid-feedback"
+      >
+        {message}
+      </strong>
+    );
+  };
+
+  const renderValidFeedback = (message) => {
     if (!message) return null;
     return (
       <div
-        className={`${state}-feedback`}
-        id={`${id}-${state}-feedback`}
+        className="valid-feedback"
+        id={`${id}-valid-feedback`}
       >
         {message}
       </div>
@@ -77,8 +94,8 @@ function ValidationFormGroup(props) {
     <div className={classNames('form-group', className)}>
       {renderChildren()}
       {renderHelpText(helpText)}
-      {renderFeedback(invalidMessage, 'invalid')}
-      {renderFeedback(validMessage, 'valid')}
+      {renderInvalidFeedback(invalidMessage)}
+      {renderValidFeedback(validMessage)}
     </div>
   );
 }


### PR DESCRIPTION
The red text conveys semantic emphasis using color and font weight. For WCAG 2.1, the semantics need to be exposed programmatically as well. To do this, we use <strong/> elements and attach the formatting classes to them.

<img width="178" alt="Screen Shot 2019-05-24 at 11 01 55 AM" src="https://user-images.githubusercontent.com/410630/58337245-60802500-7e13-11e9-9218-5e5920e1f35f.png">