### PR TITLE
Ekii/tabs refactor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "eslint.autoFixOnSave": true
+}

--- a/src/Tabs/Tabs.stories.jsx
+++ b/src/Tabs/Tabs.stories.jsx
@@ -8,5 +8,5 @@ import README from './README.md';
 storiesOf('Navigation|Tabs', module)
   .addParameters({ info: { text: README } })
   .add('basic usage', () => (
-    <Tabs tabs={[{ label: 'One', content: 'Hello I am label one' }, { label: 'Two', content: 'Hello I am label two' }]} />
+    <Tabs tabs={[{ label: 'Panel 1', panel: 'Hello I am the first panel' }, { label: 'Panel 2', panel: 'Hello I am the second panel' }, { label: 'Panel 3', panel: 'Hello I am the third panel' }]} />
   ));

--- a/src/Tabs/Tabs.stories.jsx
+++ b/src/Tabs/Tabs.stories.jsx
@@ -4,12 +4,9 @@ import { storiesOf } from '@storybook/react';
 import Tabs from './index';
 import README from './README.md';
 
+
 storiesOf('Navigation|Tabs', module)
   .addParameters({ info: { text: README } })
   .add('basic usage', () => (
-    <Tabs>
-      <Tabs.Panel label="one">Hello I am the first panel</Tabs.Panel>
-      <Tabs.Panel label="two">Hello I am the second panel</Tabs.Panel>
-      <Tabs.Panel label="three">Hello I am the third panel</Tabs.Panel>
-    </Tabs>
+    <Tabs tabs={[{ label: 'One', content: 'Hello I am label one' }, { label: 'Two', content: 'Hello I am label two' }]} />
   ));

--- a/src/Tabs/Tabs.stories.jsx
+++ b/src/Tabs/Tabs.stories.jsx
@@ -7,15 +7,9 @@ import README from './README.md';
 storiesOf('Navigation|Tabs', module)
   .addParameters({ info: { text: README } })
   .add('basic usage', () => (
-    <Tabs
-      labels={[
-        'Panel 1',
-        'Panel 2',
-        'Panel 3',
-      ]}
-    >
-      <div>Hello I am the first panel</div>
-      <div>Hello I am the second panel</div>
-      <div>Hello I am the third panel</div>
+    <Tabs>
+      <Tabs.Panel label="one">Hello I am the first panel</Tabs.Panel>
+      <Tabs.Panel label="two">Hello I am the second panel</Tabs.Panel>
+      <Tabs.Panel label="three">Hello I am the third panel</Tabs.Panel>
     </Tabs>
   ));

--- a/src/Tabs/Tabs.test.jsx
+++ b/src/Tabs/Tabs.test.jsx
@@ -2,17 +2,13 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import Tabs from './index';
 
+const tabOne = { label: 'first', panel: 'I am the first' };
+const tabTwo = { label: 'second', panel: 'I am the second' };
+const tabThree = { label: 'third', panel: 'I am the third' };
+
+
 const props = {
-  labels: [
-    'first',
-    'second',
-    'third',
-  ],
-  children: [
-    <div>first</div>,
-    <div>second</div>,
-    <div>third</div>,
-  ],
+  tabs: [tabOne, tabTwo, tabThree],
 };
 
 const tabSelectedAtIndex = (index, wrapper) => {

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -114,10 +114,14 @@ Tabs.Label = ({
 
 Tabs.Label.propTypes = {
   label: PropTypes.string.isRequired,
-  selected: PropTypes.string.isRequired,
+  selected: PropTypes.bool,
   toggle: PropTypes.func.isRequired,
-  labelId: PropTypes.number.isRequired,
+  labelId: PropTypes.string.isRequired,
   idx: PropTypes.number.isRequired,
+};
+
+Tabs.Label.defaultProps = {
+  selected: false,
 };
 
 Tabs.Panel = ({ selected, panelId, content }) => (
@@ -137,9 +141,15 @@ Tabs.Panel = ({ selected, panelId, content }) => (
 );
 
 Tabs.Panel.propTypes = {
-  selected: PropTypes.string.isRequired,
-  panelId: PropTypes.number.isRequired,
-  content: PropTypes.string.isRequired,
+  selected: PropTypes.bool,
+  panelId: PropTypes.string,
+  content: PropTypes.string,
+};
+
+Tabs.Panel.defaultProps = {
+  selected: false,
+  panelId: '',
+  content: undefined,
 };
 // TODO: custom validator that ensures labels and panels are the same length
 

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
+import Button from '../Button';
 import newId from '../utils/newId';
 
 class Tabs extends React.Component {
@@ -14,7 +15,6 @@ class Tabs extends React.Component {
     super(props);
 
     this.toggle = this.toggle.bind(this);
-
     this.state = {
       activeTab: 0,
       uuid: newId('tabInterface'),
@@ -37,120 +37,129 @@ class Tabs extends React.Component {
     return `tab-panel-${this.state.uuid}-${index}`;
   }
 
-  render() {
-    const { children } = this.props;
-    return (
-      <div className="tabs">
-        <div className={classNames('nav', 'nav-tabs')} role="tablist">
-          {
-          children.map((child, i) => {
-          const { label } = child.props;
-          const selected = this.state.activeTab === i;
-          const labelId = this.genLabelId(i);
+  buildLabels() {
+    const { labels } = this.props.tabs;
+    return labels.map((label, i) => {
+      const labelId = this.genLabelId(i);
+      const panelId = this.genPanelId(i);
 
-            return (
-              <Tabs.Label
-                label={label}
-                idx={i}
-                selected={selected}
-                labelId={labelId}
-                toggle={this.toggle}
-                key={labelId}
-              />
-            );
-          })
-        }
-        </div>
-        <div className="tabs-content">
-          {
-            children.map((child, i) => {
-              const content = child.props.children;
-              const selected = this.state.activeTab === i;
-              const panelId = this.genPanelId(i);
-              if (this.state.activeTab === i) {
-                return (
-                  <Tabs.Panel
-                    selected={selected}
-                    panelId={panelId}
-                    content={content}
-                  >
-                  </Tabs.Panel>
-                );
-              }
-                return undefined;
-            })
-          }
-        </div>
-      </div>
-    );
+      return (
+        <Tabs.Label
+          labelId={labelId}
+          panelId={panelId}
+          label={label}
+          index={i}
+          activeTab={this.state.activeTab}
+          toggle={this.toggle}
+        />
+      );
+    });
   }
+x
+buildPanels() {
+  const { contents } = this.props.tabs;
+  return contents.map((panel, i) => {
+    const panelId = this.genPanelId(i);
+    const labelId = this.genLabelId(i);
+
+    return (
+      <Tabs.Panel
+        labelId={labelId}
+        panelId={panelId}
+        panel={panel}
+        index={i}
+        activeTab={this.state.activeTab}
+      />
+    );
+  });
 }
 
+render() {
+  const labels = this.buildLabels();
+  const panels = this.buildPanels();
+
+  return (
+    <div className="tabs">
+      <div
+        role="tablist"
+        className={classNames([
+            'nav',
+            'nav-tabs',
+          ])}
+      >
+        {labels}
+      </div>
+      <div role="tabpanel" className="tab-content">
+        {panels}
+      </div>
+    </div>
+  );
+}
+}
 
 Tabs.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.element).isRequired,
+  tabs: PropTypes.element.isRequired,
 };
 
-Tabs.Label = ({
-  label, idx, selected, labelId, toggle,
-}) => (
-
-  <button
-    type="button"
-    role="tab"
-    aria-selected={selected}
-    aria-controls={labelId}
-    id={labelId}
-    onClick={() => { toggle(idx); }}
-    className={classNames('nav-link', 'nav-item', 'btn', {
-      active: selected,
-    })}
-    key={label}
-  >
-    {label}
-  </button>
-
-);
-
-Tabs.Label.propTypes = {
-  label: PropTypes.string.isRequired,
-  selected: PropTypes.bool,
-  toggle: PropTypes.func.isRequired,
-  labelId: PropTypes.string.isRequired,
-  idx: PropTypes.number.isRequired,
-};
-
-Tabs.Label.defaultProps = {
-  selected: false,
-};
-
-Tabs.Panel = ({ selected, panelId, content }) => (
-  <div
-    aria-hidden={!selected}
-    aria-labelledby={panelId}
-    className={classNames(
-    'tab-pane', 'fade', 'show active',
-    { active: selected },
-  )}
-    id={panelId}
-    key={panelId}
-    role="tabpanel"
-  >
-    {content}
-  </div>
-);
-
-Tabs.Panel.propTypes = {
-  selected: PropTypes.bool,
-  panelId: PropTypes.string,
-  content: PropTypes.string,
-};
-
-Tabs.Panel.defaultProps = {
-  selected: false,
-  panelId: '',
-  content: undefined,
-};
 // TODO: custom validator that ensures labels and panels are the same length
 
 export default Tabs;
+
+Tabs.Label = ({
+  labelId, panelId, label, index, activeTab, toggle,
+}) => {
+  const selected = index === activeTab;
+  return (
+    <Button
+      role="tab"
+      aria-selected={selected}
+      aria-controls={panelId}
+      id={labelId}
+      key={labelId}
+      onClick={() => { toggle(index); }}
+      className={classNames('nav-link nav-item', {
+        active: selected,
+      })}
+    >
+      {label}
+    </Button>
+  );
+};
+
+Tabs.Label.propTypes = {
+  labelId: PropTypes.string.isRequired,
+  panelId: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  index: PropTypes.string.isRequired,
+  activeTab: PropTypes.string.isRequired,
+  toggle: PropTypes.func.isRequired,
+};
+
+Tabs.Panel = ({
+  labelId, panelId, panel, index, activeTab,
+}) => {
+  const selected = index === activeTab;
+  return (
+    <div
+      aria-hidden={!selected}
+      aria-labelledby={labelId}
+      className={classNames(
+        'tab-pane',
+        { active: selected },
+      )}
+      id={panelId}
+      key={panelId}
+      role="tabpanel"
+    >
+      {panel}
+    </div>
+  );
+};
+
+Tabs.Panel.propTypes = {
+  labelId: PropTypes.string.isRequired,
+  panelId: PropTypes.string.isRequired,
+  panel: PropTypes.string.isRequired,
+  index: PropTypes.string.isRequired,
+  activeTab: PropTypes.string.isRequired,
+};

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-import Button from '../Button';
 import newId from '../utils/newId';
 
 class Tabs extends React.Component {
@@ -15,6 +14,7 @@ class Tabs extends React.Component {
     super(props);
 
     this.toggle = this.toggle.bind(this);
+
     this.state = {
       activeTab: 0,
       uuid: newId('tabInterface'),
@@ -37,82 +37,110 @@ class Tabs extends React.Component {
     return `tab-panel-${this.state.uuid}-${index}`;
   }
 
-  buildLabels() {
-    return this.props.labels.map((label, i) => {
-      const selected = this.state.activeTab === i;
-      const labelId = this.genLabelId(i);
-
-      return (
-        <Button
-          role="tab"
-          aria-selected={selected}
-          aria-controls={this.genPanelId(i)}
-          id={labelId}
-          key={labelId}
-          onClick={() => { this.toggle(i); }}
-          className={classNames('nav-link nav-item', {
-            active: selected,
-          })}
-        >
-          {label}
-        </Button>
-      );
-    });
-  }
-
-  buildPanels() {
-    return this.props.children.map((panel, i) => {
-      const selected = this.state.activeTab === i;
-      const panelId = this.genPanelId(i);
-
-      return (
-        <div
-          aria-hidden={!selected}
-          aria-labelledby={this.genLabelId(i)}
-          className={classNames(
-            'tab-pane',
-            { active: selected },
-          )}
-          id={panelId}
-          key={panelId}
-          role="tabpanel"
-        >
-          {panel}
-        </div>
-      );
-    });
-  }
-
   render() {
-    const labels = this.buildLabels();
-    const panels = this.buildPanels();
-
+    const { children } = this.props;
     return (
       <div className="tabs">
-        <div
-          role="tablist"
-          className={classNames([
-            'nav',
-            'nav-tabs',
-          ])}
-        >
-          {labels}
+        <div className={classNames('nav', 'nav-tabs')} role="tablist">
+          {
+          children.map((child, i) => {
+          const { label } = child.props;
+          const selected = this.state.activeTab === i;
+          const labelId = this.genLabelId(i);
+
+            return (
+              <Tabs.Label
+                label={label}
+                idx={i}
+                selected={selected}
+                labelId={labelId}
+                toggle={this.toggle}
+                key={labelId}
+              />
+            );
+          })
+        }
         </div>
-        <div role="tabpanel" className="tab-content">
-          {panels}
+        <div className="tabs-content">
+          {
+            children.map((child, i) => {
+              const content = child.props.children;
+              const selected = this.state.activeTab === i;
+              const panelId = this.genPanelId(i);
+              if (this.state.activeTab === i) {
+                return (
+                  <Tabs.Panel
+                    selected={selected}
+                    panelId={panelId}
+                    content={content}
+                  >
+                  </Tabs.Panel>
+                );
+              }
+                return undefined;
+            })
+          }
         </div>
       </div>
     );
   }
 }
 
-// TODO: custom validator that ensures labels and panels are the same length
+
 Tabs.propTypes = {
-  labels: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.string),
-    PropTypes.arrayOf(PropTypes.element),
-  ]).isRequired,
   children: PropTypes.arrayOf(PropTypes.element).isRequired,
 };
+
+Tabs.Label = ({
+  label, idx, selected, labelId, toggle,
+}) => (
+
+  <button
+    type="button"
+    role="tab"
+    aria-selected={selected}
+    aria-controls={labelId}
+    id={labelId}
+    onClick={() => { toggle(idx); }}
+    className={classNames('nav-link', 'nav-item', 'btn', {
+      active: selected,
+    })}
+    key={label}
+  >
+    {label}
+  </button>
+
+);
+
+Tabs.Label.propTypes = {
+  label: PropTypes.string.isRequired,
+  selected: PropTypes.string.isRequired,
+  toggle: PropTypes.func.isRequired,
+  labelId: PropTypes.number.isRequired,
+  idx: PropTypes.number.isRequired,
+};
+
+Tabs.Panel = ({ selected, panelId, content }) => (
+  <div
+    aria-hidden={!selected}
+    aria-labelledby={panelId}
+    className={classNames(
+    'tab-pane', 'fade', 'show active',
+    { active: selected },
+  )}
+    id={panelId}
+    key={panelId}
+    role="tabpanel"
+  >
+    {content}
+  </div>
+);
+
+Tabs.Panel.propTypes = {
+  selected: PropTypes.string.isRequired,
+  panelId: PropTypes.number.isRequired,
+  content: PropTypes.string.isRequired,
+};
+// TODO: custom validator that ensures labels and panels are the same length
 
 export default Tabs;

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -38,8 +38,8 @@ class Tabs extends React.Component {
   }
 
   buildLabels() {
-    const { labels } = this.props.tabs;
-    return labels.map((label, i) => {
+    return this.props.tabs.map((tab, i) => {
+      const { label } = tab;
       const labelId = this.genLabelId(i);
       const panelId = this.genPanelId(i);
 
@@ -55,50 +55,50 @@ class Tabs extends React.Component {
       );
     });
   }
-x
-buildPanels() {
-  const { contents } = this.props.tabs;
-  return contents.map((panel, i) => {
-    const panelId = this.genPanelId(i);
-    const labelId = this.genLabelId(i);
+
+  buildPanels() {
+    return this.props.tabs.map((tab, i) => {
+      const { panel } = tab;
+      const panelId = this.genPanelId(i);
+      const labelId = this.genLabelId(i);
+
+      return (
+        <Tabs.Panel
+          labelId={labelId}
+          panelId={panelId}
+          panel={panel}
+          index={i}
+          activeTab={this.state.activeTab}
+        />
+      );
+    });
+  }
+
+  render() {
+    const labels = this.buildLabels();
+    const panels = this.buildPanels();
 
     return (
-      <Tabs.Panel
-        labelId={labelId}
-        panelId={panelId}
-        panel={panel}
-        index={i}
-        activeTab={this.state.activeTab}
-      />
-    );
-  });
-}
-
-render() {
-  const labels = this.buildLabels();
-  const panels = this.buildPanels();
-
-  return (
-    <div className="tabs">
-      <div
-        role="tablist"
-        className={classNames([
+      <div className="tabs">
+        <div
+          role="tablist"
+          className={classNames([
             'nav',
             'nav-tabs',
           ])}
-      >
-        {labels}
+        >
+          {labels}
+        </div>
+        <div role="tabpanel" className="tab-content">
+          {panels}
+        </div>
       </div>
-      <div role="tabpanel" className="tab-content">
-        {panels}
-      </div>
-    </div>
-  );
-}
+    );
+  }
 }
 
 Tabs.propTypes = {
-  tabs: PropTypes.element.isRequired,
+  tabs: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.string)).isRequired,
 };
 
 // TODO: custom validator that ensures labels and panels are the same length
@@ -131,7 +131,7 @@ Tabs.Label.propTypes = {
   panelId: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   index: PropTypes.string.isRequired,
-  activeTab: PropTypes.string.isRequired,
+  activeTab: PropTypes.number.isRequired,
   toggle: PropTypes.func.isRequired,
 };
 
@@ -161,5 +161,5 @@ Tabs.Panel.propTypes = {
   panelId: PropTypes.string.isRequired,
   panel: PropTypes.string.isRequired,
   index: PropTypes.string.isRequired,
-  activeTab: PropTypes.string.isRequired,
+  activeTab: PropTypes.number.isRequired,
 };


### PR DESCRIPTION
Hi, 

So I looked into it a little further, and I can't structure tabs as below

<Tabs>
      <TabsPanel label> WOW! </TabsPanel> 
</Tabs> 

This is because I need the uuid generated label from the parent component from Tabs. I'm not sure if the uuid is required, it could be a lot simpler if I didn't need to pass down to the child component anything that isn't dependent on the parent's lexical scope. If I didn't need the uuid, I would generate the labelID and panelID required for the aria-labels on the child component itself.  

So I structured code so that the component is receiving information from tabs as an array of objects.

<Tabs tabs={[{label: whow, content: whow}, {label: ohno, content: ohno}]} />

Let me know what you think. I know its not what we talked about from yesterday, but I can talk through why the many ways I tried to get the other method to work (haha) 