### PR TITLE
docs: remove interactive modal breaking gatsby build

### DIFF
--- a/www/src/pages/components/modal.mdx
+++ b/www/src/pages/components/modal.mdx
@@ -19,7 +19,7 @@ import PropsTable from '../../components/PropsTable';
 
 ##### Example Usage
 
-```jsx live=true
+```jsx
 class ModalWrapper extends React.Component {
   constructor(props) {
     super(props);


### PR DESCRIPTION
Modal is breaking in gatsby, therefore preventing the doc site from being built. This needs to be updated in the modal component in the future.