### PR TITLE
docs: add CSS utility classes to doc pages

### DIFF
--- a/scss/core/utilities-only.scss
+++ b/scss/core/utilities-only.scss
@@ -1,0 +1,11 @@
+@import "~bootstrap/scss/functions";
+@import "~bootstrap/scss/variables";
+@import "~bootstrap/scss/mixins";
+
+@import "~bootstrap/scss/images";
+
+@import "~bootstrap/scss/grid";
+@import "~bootstrap/scss/transitions";
+@import "~bootstrap/scss/utilities";
+
+@import "extensions/utilities";

--- a/scss/edx/utilities-only.scss
+++ b/scss/edx/utilities-only.scss
@@ -1,0 +1,5 @@
+@import "~bootstrap/scss/functions";
+@import "functions";
+@import "variables";
+@import "../core/utilities-only";
+

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -22,7 +22,7 @@ function createCssUtilityClassNodes({ actions, createNodeId, createContentDigest
   const compiledCSS = sass
       .renderSync({
         file: path.resolve(__dirname, '../scss/edx/utilities-only.scss'),
-        // Resolve tildas the way webpack would in our base npm project 
+        // Resolve tildes the way webpack would in our base npm project 
         importer: function(url, prev, done) {
           if (url[0] === '~') {
             url = path.resolve(__dirname, '../node_modules', url.substr(1));

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -1,6 +1,8 @@
 // Reference: https://www.mrozilla.cz/blog/gatsby-eslint-vscode-import-alias/
 
 const path = require('path');
+const sass = require('node-sass');
+const css = require('css');
 
 exports.onCreateWebpackConfig = ({ actions }) => {
   actions.setWebpackConfig({
@@ -11,4 +13,58 @@ exports.onCreateWebpackConfig = ({ actions }) => {
       },
     },
   });
+};
+
+function createCssUtilityClassNodes({ actions, createNodeId, createContentDigest }) {
+  const { createNode } = actions;
+
+  // We convert to CSS first since we prefer the real values over tokens.
+  const compiledCSS = sass
+      .renderSync({
+        file: path.resolve(__dirname, '../scss/edx/utilities-only.scss'),
+        // Resolve tildas the way webpack would in our base npm project 
+        importer: function(url, prev, done) {
+          if (url[0] === '~') {
+            url = path.resolve(__dirname, '../node_modules', url.substr(1));
+          }
+          return { file: url };
+        },
+      }).css.toString();
+
+  const sheet = css.parse(compiledCSS).stylesheet;
+
+  sheet.rules.forEach(({
+    selectors, position, declarations,
+  }) => {
+    if (!selectors) return; 
+
+    selectors.forEach((selector) => {
+      if (selector[0] !== '.') return; // classes only
+
+      selector = selector.substr(1);
+      
+      const nodeData = {
+        selector,
+        declarations: declarations.map(({ property, value }) => `${property}: ${value};`),
+        isUtility: declarations.length === 1 && declarations[0].value.includes('!important'),
+      };
+
+      const nodeMeta = {
+        id: createNodeId(`rule-${selector}-${position.start.line}-${position.end.line}`),
+        parent: null,
+        children: [],
+        internal: {
+          type: `CssUtilityClasses`,
+          contentDigest: createContentDigest(nodeData),
+        }
+      };
+
+      const node = Object.assign({}, nodeData, nodeMeta)
+      createNode(node);
+    })
+  });
+}
+
+exports.sourceNodes = ({ actions, createNodeId, createContentDigest }) => {
+  createCssUtilityClassNodes({ actions, createNodeId, createContentDigest });
 };

--- a/www/package.json
+++ b/www/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",
+    "css": "^2.2.4",
     "eslint": "^5.16.0",
     "eslint-config-edx": "^4.0.4",
     "eslint-import-resolver-alias": "^1.1.2"

--- a/www/src/components/CSSUtilitiesTable.jsx
+++ b/www/src/components/CSSUtilitiesTable.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Table } from '~paragon-react';
+
+function CSSUtilitiesTable(props) {
+  return (
+    <Table
+      className="pgn-doc__status-table"
+      data={props.selectors.map(({ selector, declarations }) => ({
+        selector: <code>.{selector}</code>,
+        example: props.showExample ? (
+          <p
+            style={{
+              margin: '-.25em 0',
+              display: 'inline-block',
+              padding: '.25em .5em',
+              border: 'solid 1px transparent',
+            }}
+            className={selector}>
+            Aa Bb Cc
+          </p>
+        ) : null,
+        declarations: (
+          <div>
+            {declarations.map(declaration => (
+              <code key={declaration} className="mb-0 text-muted">{declaration}</code>
+            ))}
+          </div>
+        ),
+      }))}
+      columns={[
+        {
+          label: 'Utility Class Name',
+          key: 'selector',
+        },
+        {
+          label: 'Example',
+          hideHeader: true,
+          key: 'example',
+        },
+        {
+          label: 'Declarations',
+          key: 'declarations',
+          hideHeader: true,
+        },
+      ]}
+    /> 
+
+  );
+}
+
+export default CSSUtilitiesTable;

--- a/www/src/components/navigation.jsx
+++ b/www/src/components/navigation.jsx
@@ -13,44 +13,44 @@ const menu = [
   {
     section: 'FOUNDATIONS',
     items: [
-      { title: 'Colors', url: 'foundations/colors' },
-      { title: 'Typography', url: 'foundations/typography' },
-      { title: 'Layout & Grid', url: 'foundations/layout' },
-      { title: 'Spacing & Margins', url: 'foundations/spacing' },
-      { title: 'Icons', url: 'foundations/icons' },
-      { title: 'Illustrations', url: 'foundations/illustrations' },
-      { title: 'All Utilities', url: 'foundations/css-utilities' },
+      { title: 'Colors', url: '/foundations/colors' },
+      { title: 'Typography', url: '/foundations/typography' },
+      { title: 'Layout & Grid', url: '/foundations/layout' },
+      { title: 'Spacing & Margins', url: '/foundations/spacing' },
+      { title: 'Icons', url: '/foundations/icons' },
+      { title: 'Illustrations', url: '/foundations/illustrations' },
+      { title: 'All Utilities', url: '/foundations/css-utilities' },
     ],
   },
   {
     section: 'COMPONENTS',
     items: [
-      { title: 'Breadcrumbs', url: 'components/breadcrumbs' },
-      { title: 'Button', url: 'components/button' },
-      { title: 'Checkbox', url: 'components/checkbox' },
-      { title: 'CheckboxGroup', url: 'components/checkboxgroup' },
-      { title: 'Collapsible', url: 'components/collapsible' },
-      { title: 'Dropdown', url: 'components/dropdown' },
-      { title: 'Fieldset', url: 'components/fieldset' },
-      { title: 'Hyperlink', url: 'components/hyperlink' },
-      { title: 'Icon', url: 'components/icon' },
-      { title: 'Input', url: 'components/input' },
-      { title: 'InputSelect', url: 'components/inputselect' },
-      { title: 'InputText', url: 'components/inputtext' },
-      { title: 'ListBox', url: 'components/listbox' },
-      { title: 'Modal', url: 'components/modal' },
-      { title: 'MailtoLink', url: 'components/mailtolink' },
-      { title: 'Pagination', url: 'components/pagination' },
-      { title: 'RadioButtonGroup', url: 'components/radiobuttongroup' },
-      { title: 'Responsive', url: 'components/responsive' },
-      { title: 'SearchField', url: 'components/searchfield' },
-      { title: 'StatefulButton', url: 'components/statefulbutton' },
-      { title: 'StatusAlert', url: 'components/statusalert' },
-      { title: 'Table', url: 'components/table' },
-      { title: 'Tabs', url: 'components/tabs' },
-      { title: 'TextArea', url: 'components/textarea' },
-      { title: 'TransitionReplace', url: 'components/transitionreplace' },
-      { title: 'ValidationFormGroup', url: 'components/validationformgroup' },
+      { title: 'Breadcrumbs', url: '/components/breadcrumbs' },
+      { title: 'Button', url: '/components/button' },
+      { title: 'Checkbox', url: '/components/checkbox' },
+      { title: 'CheckboxGroup', url: '/components/checkboxgroup' },
+      { title: 'Collapsible', url: '/components/collapsible' },
+      { title: 'Dropdown', url: '/components/dropdown' },
+      { title: 'Fieldset', url: '/components/fieldset' },
+      { title: 'Hyperlink', url: '/components/hyperlink' },
+      { title: 'Icon', url: '/components/icon' },
+      { title: 'Input', url: '/components/input' },
+      { title: 'InputSelect', url: '/components/inputselect' },
+      { title: 'InputText', url: '/components/inputtext' },
+      { title: 'ListBox', url: '/components/listbox' },
+      { title: 'Modal', url: '/components/modal' },
+      { title: 'MailtoLink', url: '/components/mailtolink' },
+      { title: 'Pagination', url: '/components/pagination' },
+      { title: 'RadioButtonGroup', url: '/components/radiobuttongroup' },
+      { title: 'Responsive', url: '/components/responsive' },
+      { title: 'SearchField', url: '/components/searchfield' },
+      { title: 'StatefulButton', url: '/components/statefulbutton' },
+      { title: 'StatusAlert', url: '/components/statusalert' },
+      { title: 'Table', url: '/components/table' },
+      { title: 'Tabs', url: '/components/tabs' },
+      { title: 'TextArea', url: '/components/textarea' },
+      { title: 'TransitionReplace', url: '/components/transitionreplace' },
+      { title: 'ValidationFormGroup', url: '/components/validationformgroup' },
     ],
   },
 ];
@@ -60,12 +60,13 @@ const Navigation = ({ siteTitle }) => (
   <div className="pgn-doc__navigation">
     <div className="pgn-doc__navigation-slide">
       {menu.map(({ section, items }) => (
-        <nav className="nav flex-column">
+        <nav key={section} className="nav flex-column">
           <h3 className="pgn-doc__nav-section-header">
             {section}
           </h3>
           {items.map(({ title, url }) => (
             <Link
+              key={title}
               activeClassName="active"
               className="nav-link"
               to={url}

--- a/www/src/pages/foundations/colors.mdx
+++ b/www/src/pages/foundations/colors.mdx
@@ -1,6 +1,48 @@
 ---
-title: "A Trip To the Zoo"
-tags: ["animals", "Chicago", "zoos"]
+title: Colors
 ---
 
+import { graphql } from 'gatsby';
+import { Table } from '~paragon-react';
+import getCssSelectors from '../../utils/getCssSelectors.js';
+import CSSUtilitiesTable from '../../components/CSSUtilitiesTable';
+
 # Colors
+
+
+### Backgrounds
+
+<CSSUtilitiesTable
+  showExample
+  selectors={getCssSelectors(props.data.allCssUtilityClasses.nodes, /^bg/)}
+/>
+
+### Text
+
+<CSSUtilitiesTable
+  showExample
+  selectors={getCssSelectors(props.data.allCssUtilityClasses.nodes, /^text/)}
+/>
+
+### Borders
+
+<CSSUtilitiesTable
+  showExample
+  selectors={getCssSelectors(props.data.allCssUtilityClasses.nodes, /^border/)}
+/>
+
+
+export const pageQuery = graphql`
+{
+  allCssUtilityClasses(
+    filter: {declarations: {regex: "/color/"}, isUtility: {eq: true}},
+    sort: {fields: selector, order: ASC}
+  ) {
+    nodes {
+      selector
+      declarations
+    }
+    distinct(field: selector)
+  }
+}
+`;

--- a/www/src/pages/foundations/css-utilities.mdx
+++ b/www/src/pages/foundations/css-utilities.mdx
@@ -2,4 +2,31 @@
 title: CSS Utilities
 ---
 
+import { graphql } from 'gatsby';
+import { Table } from '~paragon-react';
+import getCssSelectors from '../../utils/getCssSelectors.js';
+import CSSUtilitiesTable from '../../components/CSSUtilitiesTable';
+
+
 # CSS Utilities
+
+
+### Utility Classes
+
+<CSSUtilitiesTable
+  selectors={getCssSelectors(props.data.utilities.nodes)}
+/>
+
+export const pageQuery = graphql`
+{
+  utilities: allCssUtilityClasses(
+    filter: {isUtility: {eq: true}},
+    sort: {fields: selector, order: ASC}
+  ) {
+    nodes {
+      selector
+      declarations
+    }
+  }
+}
+`;

--- a/www/src/pages/foundations/layout.mdx
+++ b/www/src/pages/foundations/layout.mdx
@@ -1,5 +1,62 @@
 ---
-title: Layout & Grid
+title: Layout
 ---
 
-# Layout & Grid
+import { graphql } from 'gatsby';
+import { Table } from '~paragon-react';
+import getCssSelectors from '../../utils/getCssSelectors.js';
+import CSSUtilitiesTable from '../../components/CSSUtilitiesTable';
+
+
+# Layout
+
+
+### Grid 
+
+
+### Display Utilities
+
+<CSSUtilitiesTable selectors={getCssSelectors(props.data.displayUtilities.nodes)} />
+
+### Position
+
+<CSSUtilitiesTable selectors={getCssSelectors(props.data.positionUtilities.nodes)} />
+
+### Flexbox
+
+<CSSUtilitiesTable selectors={getCssSelectors(props.data.flexUtilities.nodes)} />
+
+
+### Misc Layout
+
+<CSSUtilitiesTable selectors={getCssSelectors(props.data.miscUtilities.nodes)} />
+
+
+export const pageQuery = graphql`
+{
+  flexUtilities: allCssUtilityClasses(filter: {declarations: {regex: "/flex/"}, isUtility: {eq: true}}) {
+    nodes {
+      selector
+      declarations
+    }
+  }
+  displayUtilities: allCssUtilityClasses(filter: {declarations: {regex: "/display/"}, isUtility: {eq: true}}) {
+    nodes {
+      selector
+      declarations
+    }
+  }
+  positionUtilities: allCssUtilityClasses(filter: {selector: {regex: "/(^fixed-)|(position)/"}}) {
+    nodes {
+      selector
+      declarations
+    }
+  }
+  miscUtilities: allCssUtilityClasses(filter: {declarations: {regex: "/(float)|(overflow)/"}, isUtility: {eq: true}}) {
+    nodes {
+      selector
+      declarations
+    }
+  }
+}
+`;

--- a/www/src/pages/foundations/spacing.mdx
+++ b/www/src/pages/foundations/spacing.mdx
@@ -2,4 +2,32 @@
 title: Spacing
 ---
 
+import { graphql } from 'gatsby';
+import { Table } from '~paragon-react';
+import getCssSelectors from '../../utils/getCssSelectors.js';
+import CSSUtilitiesTable from '../../components/CSSUtilitiesTable';
+
+
 # Spacing
+
+
+### Spacing Utility Classes
+
+<CSSUtilitiesTable
+  
+  selectors={getCssSelectors(props.data.spacingUtilities.nodes)}
+/>
+
+export const pageQuery = graphql`
+{
+  spacingUtilities: allCssUtilityClasses(
+    filter: {isUtility: {eq: true}, selector: {regex: "/(^[m|p][t|r|l|b]?\\-?)/"}},
+    sort: {fields: selector, order: ASC}
+  ) {
+    nodes {
+      selector
+      declarations
+    }
+  }
+}
+`;

--- a/www/src/pages/foundations/typography.mdx
+++ b/www/src/pages/foundations/typography.mdx
@@ -2,4 +2,31 @@
 title: Typography
 ---
 
+import { graphql } from 'gatsby';
+import { Table } from '~paragon-react';
+import getCssSelectors from '../../utils/getCssSelectors.js';
+import CSSUtilitiesTable from '../../components/CSSUtilitiesTable';
+
 # Typography
+
+
+### Text Utilities
+
+<CSSUtilitiesTable
+  showExample
+  selectors={getCssSelectors(props.data.textUtilities.nodes)}
+/>
+
+export const pageQuery = graphql`
+{
+  textUtilities: allCssUtilityClasses(
+    filter: {isUtility: {eq: true}, declarations: {regex: "/^(?!color)/"}, selector: {regex: "/(^text)|(^font)/"}},
+    sort: {fields: selector, order: ASC}
+  ) {
+    nodes {
+      selector
+      declarations
+    }
+  }
+}
+`;

--- a/www/src/utils/getCssSelectors.js
+++ b/www/src/utils/getCssSelectors.js
@@ -1,0 +1,17 @@
+/**
+ * Given the `props` and a `fileName` like `aspect-ratio`, return the array of classes that
+ * correspond to that file. This function exists to simplify the Thumbprint Atomic MDX.
+ */
+const getCssSelectors = (nodes, regExpStr) => {
+  // return Object.keys(props.data, fileName);
+  if (!regExpStr) {
+    return nodes;
+  }
+
+  var regex = RegExp(regExpStr);
+  return nodes.filter(rule => regex.test(rule.selector));
+};
+    // props.data.all.edges.find(({ node }) => node.atomicFileName === fileName)
+    //     .node.atomicClasses;
+
+export default getCssSelectors;


### PR DESCRIPTION
Guides and examples still need to be written above these tables, but together these are a pretty good index of all the css utils available.

<img width="2032" alt="Screen Shot 2019-06-21 at 3 04 54 PM" src="https://user-images.githubusercontent.com/1615421/59953656-fd93a500-9435-11e9-81bd-50954725f014.png">
