### PR TITLE
fix: include scss files in dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "rm -rf ./dist && ./node_modules/.bin/babel src --out-dir dist --source-maps --ignore **/*.test.jsx,**/*.stories.jsx,**/__mocks__,**/setupTest.js && node build-scss.js",
+    "build": "rm -rf ./dist && ./node_modules/.bin/babel src --out-dir dist --source-maps --copy-files --ignore **/*.test.jsx,**/*.stories.jsx,**/__mocks__,**/setupTest.js && rm ./dist/**/*.stories.jsx && rm ./dist/**/*.test.jsx && node build-scss.js",
     "build-docs": "build-storybook && npm run build-gatsby && npm run move-gatsby",
     "build-storybook": "build-storybook",
     "build-gatsby": "cd ./www && \"$npm_execpath\" install && \"$npm_execpath\" run build",


### PR DESCRIPTION
The `--copy-files` CLI option will cause babel to include all files that it didn't process, which will copy over the test.js and stories.js files we don't want in addition to the .scss files we _do_ want.  So after babelizing, `rm` the test and stories files from the dist directory.  

If this gets any more complex we may want to consider adding a build process again.