### PR TITLE
build: tighten up dist directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+build:
+	rm -rf ./dist
+	./node_modules/.bin/babel src --out-dir dist --source-maps --ignore **/*.test.jsx,**/*.stories.jsx,**/__mocks__,**/__snapshots__,**/setupTest.js --copy-files
+	# --copy-files will bring in everything else that wasn't processed by babel. Remove what we don't want.
+	rm -rf dist/**/*.test.jsx
+	rm -rf dist/**/*.stories.jsx
+	rm -rf dist/**/__snapshots__
+	rm -rf dist/__mocks__
+	rm -rf dist/setupTest.js
+	node build-scss.js

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "rm -rf ./dist && ./node_modules/.bin/babel src --out-dir dist --source-maps --copy-files --ignore **/*.test.jsx,**/*.stories.jsx,**/__mocks__,**/setupTest.js && rm ./dist/**/*.stories.jsx && rm ./dist/**/*.test.jsx && node build-scss.js",
+    "build": "make build",
     "build-docs": "build-storybook && npm run build-gatsby && npm run move-gatsby",
     "build-storybook": "build-storybook",
     "build-gatsby": "cd ./www && \"$npm_execpath\" install && \"$npm_execpath\" run build",


### PR DESCRIPTION
We were getting some test gunk in the `dist` directory.  This should tighten that up to include only the files we really want in `dist`.