### PR TITLE
fix: modal to not close when mouse drag from in modal to out

### DIFF
--- a/src/Modal/Modal.test.jsx
+++ b/src/Modal/Modal.test.jsx
@@ -199,7 +199,7 @@ describe('<Modal />', () => {
 
     it('closes when a user clicks outside of the modal', () => {
       modalOpen(true, wrapper);
-      wrapper.find('.modal').at(0).simulate('click');
+      wrapper.find('.modal').at(0).simulate('mouseDown');
       modalOpen(false, wrapper);
     });
 

--- a/src/Modal/index.jsx
+++ b/src/Modal/index.jsx
@@ -198,7 +198,7 @@ class Modal extends React.Component {
             },
           )}
           role="presentation"
-          onClick={this.close}
+          onMouseDown={this.close}
         >
           <div
             className={classNames({


### PR DESCRIPTION
@adamstankiewicz @abutterworth 

Changed the event handler from onClick to onMouseDown. Previous issue was that clicking on modal and dragging to outside modal closes the modal. Discussed that changing the even handler was an okay patch. 

This fix is related to sprint ticket in Enterprise: 

https://openedx.atlassian.net/browse/ENT-1966

edx-portal is currently using paragon version 3.8.1 (based on package.json)