### PR TITLE
fix(asinput): proptype validation to include both func and obj

### DIFF
--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -88,7 +88,10 @@ export const buttonPropTypes = {
   buttonType: PropTypes.string,
   className: PropTypes.string,
   children: PropTypes.node.isRequired,
-  inputRef: PropTypes.func,
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
   isClose: PropTypes.bool,
   onBlur: PropTypes.func,
   onClick: PropTypes.func,

--- a/src/CheckBox/index.jsx
+++ b/src/CheckBox/index.jsx
@@ -53,7 +53,10 @@ class Check extends React.Component {
 Check.propTypes = {
   checked: PropTypes.bool,
   onChange: PropTypes.func,
-  inputRef: PropTypes.func,
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
 };
 
 Check.defaultProps = {

--- a/src/InputSelect/index.jsx
+++ b/src/InputSelect/index.jsx
@@ -26,6 +26,10 @@ class Select extends React.Component {
     );
   }
 
+  componentDidMount() {
+    console.log('this is the ref', this.props.inputRef);
+  }
+
   getOptions() {
     return this.props.options.map((option, i) => {
       let section;
@@ -67,7 +71,10 @@ class Select extends React.Component {
 
 Select.propTypes = {
   className: PropTypes.string,
-  inputRef: PropTypes.func,
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
   options: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.arrayOf(PropTypes.object),

--- a/src/InputSelect/index.jsx
+++ b/src/InputSelect/index.jsx
@@ -26,10 +26,6 @@ class Select extends React.Component {
     );
   }
 
-  componentDidMount() {
-    console.log('this is the ref', this.props.inputRef);
-  }
-
   getOptions() {
     return this.props.options.map((option, i) => {
       let section;

--- a/src/InputText/index.jsx
+++ b/src/InputText/index.jsx
@@ -26,7 +26,10 @@ function Text(props) {
 
 Text.propTypes = {
   className: PropTypes.string,
-  inputRef: PropTypes.func,
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
   type: PropTypes.string,
 };
 

--- a/src/TextArea/index.jsx
+++ b/src/TextArea/index.jsx
@@ -24,7 +24,10 @@ function Text(props) {
 
 Text.propTypes = {
   className: PropTypes.string,
-  inputRef: PropTypes.func,
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
 };
 
 Text.defaultProps = {

--- a/src/asInput/index.jsx
+++ b/src/asInput/index.jsx
@@ -36,7 +36,10 @@ export const inputProps = {
   inputGroupPrepend: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.element), PropTypes.element]),
   inputGroupAppend: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.element), PropTypes.element]),
   type: PropTypes.string,
-  inputRef: PropTypes.func,
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
 };
 
 export const defaultProps = {


### PR DESCRIPTION
Ensuring that proptype validation if inputRef in asInput includes both functions and objects. This is because creating a previous ref used a function, where React.createRef will create an object