### PR TITLE
fix(prop-types): use PropTypes.element instead of Element

### DIFF
--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -90,7 +90,7 @@ export const buttonPropTypes = {
   children: PropTypes.node.isRequired,
   inputRef: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+    PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
   ]),
   isClose: PropTypes.bool,
   onBlur: PropTypes.func,

--- a/src/CheckBox/index.jsx
+++ b/src/CheckBox/index.jsx
@@ -55,7 +55,7 @@ Check.propTypes = {
   onChange: PropTypes.func,
   inputRef: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+    PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
   ]),
 };
 

--- a/src/InputSelect/index.jsx
+++ b/src/InputSelect/index.jsx
@@ -69,7 +69,7 @@ Select.propTypes = {
   className: PropTypes.string,
   inputRef: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+    PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
   ]),
   options: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.string),

--- a/src/InputText/index.jsx
+++ b/src/InputText/index.jsx
@@ -28,7 +28,7 @@ Text.propTypes = {
   className: PropTypes.string,
   inputRef: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+    PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
   ]),
   type: PropTypes.string,
 };

--- a/src/TextArea/index.jsx
+++ b/src/TextArea/index.jsx
@@ -26,7 +26,7 @@ Text.propTypes = {
   className: PropTypes.string,
   inputRef: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+    PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
   ]),
 };
 

--- a/src/asInput/index.jsx
+++ b/src/asInput/index.jsx
@@ -38,7 +38,7 @@ export const inputProps = {
   type: PropTypes.string,
   inputRef: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+    PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
   ]),
 };
 


### PR DESCRIPTION
Our prop types fix was using `Element` instead of `PropTypes.element` causing our gatsby build to fail. This PR fixes that issue by using `PropTypes.element`.