### PR TITLE
fix: input focus color now accessible

### DIFF
--- a/scss/edx/_variables.scss
+++ b/scss/edx/_variables.scss
@@ -21,3 +21,8 @@ $btn-border-radius-sm:        50rem !default; // rounded pill
 
 $btn-focus-width: 2px !default;
 $btn-focus-gap: 2px !default;
+
+$input-btn-focus-width:       1px !default;
+$input-btn-focus-color:       map-get($theme-color-levels, "primary-300") !default;
+$input-btn-focus-box-shadow:  0 0 0 $input-btn-focus-width $input-btn-focus-color !default;
+


### PR DESCRIPTION
Updated to now be accessible (3:1 contrast).

<img width="402" alt="Screen Shot 2019-08-07 at 12 15 30 PM" src="https://user-images.githubusercontent.com/1615421/62639215-12a49480-b90d-11e9-81e8-54c4b7512989.png">
