### PR TITLE
Add component status and proptype descriptions

### DIFF
--- a/src/Breadcrumb/index.jsx
+++ b/src/Breadcrumb/index.jsx
@@ -31,12 +31,20 @@ const Breadcrumbs = ({
 };
 
 Breadcrumbs.propTypes = {
+  /** an array of objects with the properties `label` and `url` as strings. */
   links: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string,
     url: PropTypes.string,
   })).isRequired,
+  /** allows to add a label that is not a link to the end of the breadcrumb.
+   * Defaults to `undefined`.
+ */
   activeLabel: PropTypes.string,
+  /** allows to add a custom element between the breadcrumb items.
+   * Defaults to `>` rendered using the `Icon` component. */
   spacer: PropTypes.element,
+  /** allows to add a custom function to be called `onClick` of a breadcrumb link.
+   * The use case for this is for adding custom analytics to the component. */
   clickHandler: PropTypes.func,
 };
 

--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -85,17 +85,30 @@ class Button extends React.Component {
 }
 
 export const buttonPropTypes = {
+  /** Used to determine the type of button to be rendered.  See [Bootstrap's buttons documentation](https://getbootstrap.com/docs/4.0/components/buttons/) for a list of applicable button types. For example, `buttonType="light"`. The default is `undefined`. */
   buttonType: PropTypes.string,
+  /** Specifies Bootstrap class names to apply to the button. See [Bootstrap's buttons documentation](https://getbootstrap.com/docs/4.0/components/buttons/) for a list of applicable class names. The default is an empty array. */
   className: PropTypes.string,
+  /** Specifies the text that is displayed within the button. */
   children: PropTypes.node.isRequired,
+  // eslint-disable-next-line max-len
+  /** A function that defines a reference for the button. An example `inputRef` from the calling component could look something like: `inputRef={(input) => { this.button = input; }}`. The default is an empty function. */
   inputRef: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),
   ]),
+  /** Used to determine if the button is a "Close" style button to leverage bootstrap styling. Example use case is with the Status Alert [dismiss button](https://getbootstrap.com/docs/4.0/components/alerts/#dismissing). The default is false. */
   isClose: PropTypes.bool,
+  // eslint-disable-next-line max-len
+  /** A function that would specify what the button should do when the `onBlur` event is triggered. For example, the button could change in color or `buttonType` when focus is changed. The default is an empty function. */
   onBlur: PropTypes.func,
+  // eslint-disable-next-line max-len
+  /** A function that would specify what the button should do when the `onClick` event is triggered. For example, the button could launch a `Modal`. The default is an empty function. */
   onClick: PropTypes.func,
+  // eslint-disable-next-line max-len
+  /** A function that would specify what the button should do when the `onKeyDown` event is triggered.  For example, this could handle using the `Escape` key to trigger the button's action. The default is an empty function. */
   onKeyDown: PropTypes.func,
+  /** Used to set the `type` attribute on the `button` tag.  The default type is `button`. */
   type: PropTypes.string,
 };
 

--- a/src/CheckBox/index.jsx
+++ b/src/CheckBox/index.jsx
@@ -51,8 +51,12 @@ class Check extends React.Component {
 
 
 Check.propTypes = {
+  // eslint-disable-next-line max-len
+  /** (`Boolean`): `true` if the state should be checked, `false` otherwise. This prop can be used to manage the Checkbox more directly, overriding the default Checkbox checked state. */
   checked: PropTypes.bool,
+  /** (`Boolean`): `true` if the checkbox should be disabled, `false` otherwise */
   onChange: PropTypes.func,
+  /** function to be called when the checkbox changes state */
   inputRef: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),

--- a/src/CheckBoxGroup/index.jsx
+++ b/src/CheckBoxGroup/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-
 function CheckBoxGroup(props) {
   return (
     <div className="form-group">
@@ -11,6 +10,9 @@ function CheckBoxGroup(props) {
 }
 
 CheckBoxGroup.propTypes = {
+  // eslint-disable-next-line max-len
+  /** represents the CheckBox components defined within the CheckBoxGroup component and is not a specific named prop that needs to be passed in. At least one CheckBox must be defined within the group. Example: `<CheckBoxGroup><CheckBox .../></CheckBoxGroup>`
+   */
   children: PropTypes.arrayOf(PropTypes.element).isRequired,
 };
 

--- a/src/Hyperlink/index.jsx
+++ b/src/Hyperlink/index.jsx
@@ -55,15 +55,30 @@ Hyperlink.defaultProps = {
 };
 
 Hyperlink.propTypes = {
+  /** specifies the URL */
   destination: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
+  /** specifies where the link should open. The default behavior is `_self`, which means that the URL will be loaded into the same browsing context as the current one. If the target is `_blank` (opening a new window) `rel='noopener'` will be added to the anchor tag to prevent any potential [reverse tabnabbing attack](https://www.owasp.org/index.php/Reverse_Tabnabbing).
+   */
   target: PropTypes.string,
+  /** specifies the callback function when the link is clicked */
   onClick: PropTypes.func,
-  externalLinkAlternativeText: isRequiredIf(PropTypes.string, props => props.target === '_blank'),
-  externalLinkTitle: isRequiredIf(PropTypes.string, props => props.target === '_blank'),
+  // eslint-disable-next-line max-len
+  /** specifies the text for links with a `_blank` target (which loads the URL in a new browsing context). */
+  externalLinkAlternativeText: isRequiredIf(
+    PropTypes.string,
+    props => props.target === '_blank',
+  ),
+  // eslint-disable-next-line max-len
+  /** specifies the title for links with a `_blank` target (which loads the URL in a new browsing context). */
+  externalLinkTitle: isRequiredIf(
+    PropTypes.string,
+    props => props.target === '_blank',
+  ),
 };
 
 export default withDeprecatedProps(Hyperlink, 'Hyperlink', {
+  /** specifies the text or element that a URL should be associated with */
   content: {
     deprType: DEPR_TYPES.MOVED,
     newName: 'children',

--- a/src/Icon/index.jsx
+++ b/src/Icon/index.jsx
@@ -24,9 +24,18 @@ function Icon(props) {
 }
 
 Icon.propTypes = {
+  // eslint-disable-next-line max-len
+  /** the `id` property of the Icon element, by default this value is generated with the `newId` function with the `prefix` of `Icon`. */
   id: PropTypes.string,
+  // eslint-disable-next-line max-len
+  /** array of class names that will define what the Icon looks like. For example, a list of FontAwesome style names. */
   className: PropTypes.string.isRequired,
+  // eslint-disable-next-line max-len
+  /** a boolean that determines the value of `aria-hidden` attribute on the Icon span, this value is `true` by default. */
   hidden: PropTypes.bool,
+  // eslint-disable-next-line max-len
+  /** a string that will be used on a secondary span leveraging the `sr-only` style for screenreader only text, this value is `undefined` by default. This value is recommended for use unless the Icon is being used in a way that is purely decorative or provides no additional context for screen reader users. This field should be thought of the same way an `alt` attribute would be used for `image` tags.
+   */
   screenReaderText: PropTypes.string,
 };
 

--- a/src/Input/index.jsx
+++ b/src/Input/index.jsx
@@ -43,13 +43,18 @@ class Input extends React.Component {
     if (this.inputEl.getAttribute('aria-label') !== null) return;
 
     // eslint-disable-next-line no-console
-    if (console) console.warn('Input[a11y]: There is no associated label for this Input');
+    if (console) {
+      console.warn('Input[a11y]: There is no associated label for this Input');
+    }
   }
 
   renderOptions(options) {
     return options.map((option) => {
       const {
-        value, label, group, ...attributes
+        value,
+        label,
+        group,
+        ...attributes
       } = option;
 
       if (group) {
@@ -59,13 +64,21 @@ class Input extends React.Component {
           </optgroup>
         );
       }
-      return <option key={value} value={value} {...attributes}>{label}</option>;
+      return (
+        <option key={value} value={value} {...attributes}>
+          {label}
+        </option>
+      );
     }, this);
   }
 
   render() {
     const {
-      type, className, options, forwardedRef, ...attributes // eslint-disable-line react/prop-types
+      type,
+      className,
+      options,
+      forwardedRef, // eslint-disable-line react/prop-types
+      ...attributes // eslint-disable-line react/prop-types
     } = this.props;
 
     const htmlTag = this.getHTMLTagForType();
@@ -81,8 +94,9 @@ class Input extends React.Component {
   }
 }
 
-
 Input.propTypes = {
+  /** specifies the type of component.
+   * One of select, textarea, or any valid type for an html input tag. */
   type: PropTypes.oneOf([
     'textarea',
     'select',
@@ -109,7 +123,9 @@ Input.propTypes = {
     'url',
     'week',
   ]).isRequired,
+  /** specifies the className in addition to a bootstrap class name. */
   className: PropTypes.string,
+  /** should be used to specify the options of an Input of type select */
   options: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -126,7 +142,6 @@ Input.defaultProps = {
   className: undefined,
   options: [],
 };
-
 
 // eslint-disable-next-line react/no-multi-comp
 const InputWithRefForwarding = React.forwardRef((props, ref) => (

--- a/src/ListBox/index.jsx
+++ b/src/ListBox/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import classNames from 'classnames';
 import { nonNegativeInteger } from 'airbnb-prop-types';
 import PropTypes from 'prop-types';
@@ -102,9 +103,14 @@ export default class ListBox extends React.Component {
 }
 
 ListBox.propTypes = {
+  /** specifies the ListBoxOption component(s) that will be displayed within the ListBox element. You can pass in one or more ListBoxOption components.
+ */
   children: PropTypes.node.isRequired,
+  /** specifies Bootstrap class names to apply to the ListBox component. The default is an empty string. */
   className: PropTypes.string,
+  /** Although the ListBox component keeps track of which ListBoxOption is selected, `selectedOptionIndex` provides a mechanism for an override, if necessary. An example would be to clear the selectedOption when moving between views. Note that override is not permanent and that clicking on a ListBoxOption or interacting with the ListBox with the keyboard will change the selected ListBoxOption relative to the original override. The default is undefined. */
   selectedOptionIndex: nonNegativeInteger,
+  /** used to specify the element type of the rendered ListBox component. The default is div. Example alternatives include ol, ul, span, etc. */
   tag: PropTypes.string,
 };
 

--- a/src/MailtoLink/index.jsx
+++ b/src/MailtoLink/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import React from 'react'; // eslint-disable-line no-unused-vars
 import PropTypes from 'prop-types';
 import emailPropType from 'email-prop-type';
@@ -56,13 +57,21 @@ MailtoLink.defaultProps = {
 
 MailtoLink.propTypes = {
   children: PropTypes.node.isRequired,
+  /** specifies the email's recipients */
   to: PropTypes.oneOfType([PropTypes.arrayOf(emailPropType), emailPropType]),
+  /** specifies the email's carbon copy recipients */
   cc: PropTypes.oneOfType([PropTypes.arrayOf(emailPropType), emailPropType]),
+  /** specifies the email's blind carbon copy recipients */
   bcc: PropTypes.oneOfType([PropTypes.arrayOf(emailPropType), emailPropType]),
+  /** specifies the email's subject */
   subject: PropTypes.string,
+  /** specifies the email's body */
   body: PropTypes.string,
+  /** specifies where the link should open. The default behavior is `_self`, which means that the URL will be loaded into the same browsing context as the current one */
   target: PropTypes.string,
+  /** specifies the callback function when the link is clicked */
   onClick: PropTypes.func,
+  /** The object that contains the `alternativeText` and `title` fields which specify the text and title for links with a `_blank` target (which loads the URL in a new browsing context). */
   externalLink: PropTypes.shape({
     alternativeText: isRequiredIf(PropTypes.string, props => props.target === '_blank'),
     title: isRequiredIf(PropTypes.string, props => props.target === '_blank'),

--- a/src/Modal/index.jsx
+++ b/src/Modal/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import React from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
@@ -256,19 +257,28 @@ class Modal extends React.Component {
 }
 
 Modal.propTypes = {
+  /** specifies whether the modal renders open or closed on the initial render. It defaults to false. */
   open: PropTypes.bool,
+  /** is the selector for an element in the dom which the modal should be rendered under. It uses querySelector to find the first element that matches that selector, and then creates a react portal to a div underneath the parent element.
+ */
   parentSelector: PropTypes.string,
+  /** a string or an element that is rendered inside of the modal title, above the modal body. */
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  /** a string or an element that is rendered inside of the modal body, between the title and the footer. */
   body: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  /** an array of either elements or shapes that take the form of the buttonPropTypes. See the [buttonPropTypes](https://github.com/edx/paragon/blob/master/src/Button/index.jsx#L40) for a list of acceptable props to pass as part of a button. */
   buttons: PropTypes.arrayOf(PropTypes.oneOfType([
     PropTypes.element,
     PropTypes.object, // TODO: Only accept nodes in the future
   ])),
+  /** specifies the display text of the default Close button. It defaults to "Close". */
   closeText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  /** a function that is called on close. It can be used to perform actions upon closing of the modal, such as restoring focus to the previous logical focusable element. */
   onClose: PropTypes.func.isRequired,
   variant: PropTypes.shape({
     status: PropTypes.string,
   }),
+  /** specifies whether a close button is rendered in the modal header. It defaults to true. */
   renderHeaderCloseButton: PropTypes.bool,
 };
 

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import { between } from 'airbnb-prop-types';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -385,9 +386,36 @@ Pagination.defaultProps = {
 };
 
 Pagination.propTypes = {
+  /** specifies a callback function that is executed when the user selects a page button or the `Previous`/`Next` buttons. For example:
+
+```jsx
+<Pagination onPageSelect={(pageNumber) => { console.log(pageNumber); } />
+``` */
   onPageSelect: PropTypes.func.isRequired,
+  /** specifies the total number of pages in the `Pagination` component. */
   pageCount: PropTypes.number.isRequired,
+  /** specifies the `aria-label` for the `<nav>` element that wraps the pagination button list. */
   paginationLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  /** specifies the labels to use for the `Previous`/`Next` buttons as well as the various parts of `aria-label` on the page buttons for accessibility. All button labels accept both string or elements. The button label options are as follows:
+
+* `previous`: Text for the `Previous` button;
+* `next`: Text for the `Next` button;
+* `page`: Text in the `aria-label` on page buttons to describe the button (e.g., "**Page** 1");
+* `currentPage`: Text to depict the selected page in the `aria-label`
+on page buttons (e.g., "Page 1, **Current Page**");
+* `pageOfCount`: Text that separates the current page and total page count
+for the mobile UI (e.g., "Page 1 **of** 20").
+
+The default is:
+```javascript
+{
+    previous: 'Previous',
+    next: 'Next',
+    page: 'Page',
+    currentPage: 'Current Page',
+    pageOfCount: 'of',
+}
+``` */
   buttonLabels: PropTypes.shape({
     previous: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     next: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
@@ -395,8 +423,11 @@ Pagination.propTypes = {
     currentPage: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     pageOfCount: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   }),
+  /** specifies any class name(s) for the `Pagination` component. The default is an empty string. */
   className: PropTypes.string,
+  /** specifies the page that the `Pagination` component will automatically select. The default is `1`. */
   currentPage: PropTypes.number,
+  /** specifies the number of page buttons to display in between the `Previous` and `Next` buttons. This number also includes any ellipses in the total count. Also, to ensure that at least one clickable page button is shown when both ellipses are displayed, this value must be greater than `4`.  The default is `7`. */
   maxPagesDisplayed: between({ gt: 4 }),
 };
 

--- a/src/RadioButtonGroup/index.jsx
+++ b/src/RadioButtonGroup/index.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-multi-comp */
-
+/* eslint-disable max-len */
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -169,13 +169,21 @@ RadioButtonGroup.defaultProps = {
 
 RadioButtonGroup.propTypes = {
   children: PropTypes.arrayOf(PropTypes.element).isRequired,
+  /** specifies the `aria-label` value for the `RadioButtonGroup` */
   label: PropTypes.string.isRequired,
+  /** specifies the `name` value for the `RadioButtonGroup` so that no more than one `RadioButton` can be selected at any given time */
   name: PropTypes.string.isRequired,
+  /** specifies the callback for the `onBlur` event for each `RadioButton` within the group. The default value is a no-op function. */
   onBlur: PropTypes.func,
+  /** specifies the callback for the onChange event for each RadioButton within the group. The default value is a no-op function. */
   onChange: PropTypes.func,
+  /** specifies the callback for the `onClick` event for each `RadioButton` within the group. The default value is a no-op function. */
   onClick: PropTypes.func,
+  /** specifies the callback for the `onFocus` event for each `RadioButton` within the group. The default value is a no-op function. */
   onFocus: PropTypes.func,
+  /** specifies the callback for the `onKeyDown` event for each `RadioButton` within the group. The default value is a no-op function. */
   onKeyDown: PropTypes.func,
+  /** specifies which `RadioButton` is initially selected. The default value is `undefined` which signifies that no `RadioButton` is initially selected. */
   selectedIndex: PropTypes.number,
 };
 

--- a/src/SearchField/index.jsx
+++ b/src/SearchField/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -169,17 +170,46 @@ SearchField.defaultProps = {
 };
 
 SearchField.propTypes = {
+  /** specifies a callback function for when the `SearchField` is submitted by the user. For example:
+
+```jsx
+<SearchField onSubmit={(value) => { console.log(value); } />
+``` */
   onSubmit: PropTypes.func.isRequired,
+  /** specifies the label to use for the input field (e.g., for i18n translations). The default is "Search:". */
   inputLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  /** specifies a callback function for when the user loses focus in the `SearchField` component. The default is an empty function. For example:
+
+```jsx
+<SearchField onBlur={(value) => { console.log(value); }} />
+``` */
   onBlur: PropTypes.func,
+  /** specifies a callback function for when the value in `SearchField` is changed by the user. The default is an empty function. For example:
+  ```jsx
+<SearchField onBlur={(value) => { console.log(value); }} />
+```
+  */
   onChange: PropTypes.func,
+  /** specifies a callback function for when the value in `SearchField` is changed by the user. The default is an empty function. For example:
+  ```jsx
+<SearchField onClear={(value) => { console.log(value); }} />
+```
+  */
   onClear: PropTypes.func,
+  /** specifies a callback function for when the user focuses in the `SearchField` component. The default is an empty function. For example:
+
+```jsx
+<SearchField onFocus={(value) => { console.log(value); } />
+``` */
   onFocus: PropTypes.func,
+  /** specifies the placeholder text for the input. The default is an empty string. */
   placeholder: PropTypes.string,
+  /** specifies the screenreader text for both the clear and search buttons (e.g., for i18n translations). The default is `{ clearButton: 'Clear search', searchButton: 'Submit search' }`. */
   screenReaderText: PropTypes.shape({
     clearButton: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
     searchButton: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   }),
+  /** specifies the initial value for the input. The default is an empty string. */
   value: PropTypes.string,
 };
 

--- a/src/StatefulButton/index.jsx
+++ b/src/StatefulButton/index.jsx
@@ -7,9 +7,38 @@ import Button from '../Button';
 
 const propTypes = {
   className: PropTypes.string,
+  /**
+   * Each state has:
+
+- A label (required)
+- An icon
+- an option to be disabled
+
+Control the state with the `state` prop. Example usage:
+
+```jsx
+<StatefulButton
+  state="pending"
+  labels={{
+    default: 'Download',
+    pending: 'Downloading',
+    complete: 'Downloaded',
+  }}
+  icons={{
+    default: <Icon className="fa fa-download" />,
+    pending: <Icon className="fa fa-spinner fa-spin" />,
+    complete: <Icon className="fa fa-check" />,
+  }}
+  disabledStates=['pending']
+  className='btn-primary mr-2'
+/>
+``` */
   state: PropTypes.string,
+  /** Required. Each state has a `label`. */
   labels: PropTypes.objectOf(PropTypes.node).isRequired,
+  /** Required. Each state has an `icon`. */
   icons: PropTypes.objectOf(PropTypes.node),
+  /** Required. Each state has a `disabledState` */
   disabledStates: PropTypes.arrayOf(PropTypes.string),
   onClick: PropTypes.func,
 };

--- a/src/StatusAlert/index.jsx
+++ b/src/StatusAlert/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -107,13 +108,18 @@ class StatusAlert extends React.Component {
 }
 
 StatusAlert.propTypes = {
+  /** specifies the type of alert that is being diplayed. It defaults to "warning".  See the other available [bootstrap](https://v4-alpha.getbootstrap.com/components/alerts/) options. */
   alertType: PropTypes.string,
+  /** is a string array that defines the classes to be used within the status alert. */
   className: PropTypes.string,
   dialog: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  /** specifies if the status alert will include the dismissible X button to close the alert. It defaults to true. */
   dismissible: PropTypes.bool,
   /* eslint-disable react/require-default-props */
   closeButtonAriaLabel: PropTypes.string,
+  /** is a function that is called on close. It can be used to perform actions upon closing of the status alert, such as restoring focus to the previous logical focusable element.  It is only required if `dismissible` is set to `true` and not required if the alert is not `dismissible`. */
   onClose: isRequiredIf(PropTypes.func, props => props.dismissible),
+  /** specifies whether the status alert renders open or closed on the initial render. It defaults to false. */
   open: PropTypes.bool,
 };
 

--- a/src/Table/index.jsx
+++ b/src/Table/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import React from 'react';
 import classNames from 'classnames';
 import isRequiredIf from 'react-proptype-conditional-require';
@@ -160,7 +161,27 @@ Table.propTypes = {
     PropTypes.element,
   ]),
   className: PropTypes.string,
+  /** specifies the order and contents of the table's columns and provides display strings for each column's heading. It is composed of an ordered array of objects. Each object contains the following keys:
+
+1. `label` (string or element; required) contains the display string for each column's heading.
+2. `key` (string; required) maps that label to its corresponding datum for each row in `data`, to ensure table data are displayed in their appropriate columns.
+3. `columnSortable` (boolean; optional) specifies at the column-level whether the column is sortable. If `columnSortable` is `true`, a sort button will be rendered in the column table heading. It is only required if `tableSortable` is set to `true`.
+4. `onSort` (function; conditionally required) specifies what function is called when a sortable column is clicked. It is only required if the column's `columnSortable` is set to `true`.
+5. `hideHeader` (boolean; optional) specifies at the column-level whether the column label is visible. A column that is sortable cannot have its label be hidden.
+6. `width` (string; conditionally required) only if `hasFixedColumnWidths` is set to `true`, the `<td>` elements' `class` attributes will be set to this value. This allows restricting columns to specific widths. See [Bootstrap's grid documentation](https://getbootstrap.com/docs/4.0/layout/grid/) for `col` class names that can be used.
+
+The order of objects in `columns` specifies the order of the columns in the table. */
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  /** specifies the order and contents of the table's columns and provides display strings for each column's heading. It is composed of an ordered array of objects. Each object contains the following keys:
+
+1. `label` (string or element; required) contains the display string for each column's heading.
+2. `key` (string; required) maps that label to its corresponding datum for each row in `data`, to ensure table data are displayed in their appropriate columns.
+3. `columnSortable` (boolean; optional) specifies at the column-level whether the column is sortable. If `columnSortable` is `true`, a sort button will be rendered in the column table heading. It is only required if `tableSortable` is set to `true`.
+4. `onSort` (function; conditionally required) specifies what function is called when a sortable column is clicked. It is only required if the column's `columnSortable` is set to `true`.
+5. `hideHeader` (boolean; optional) specifies at the column-level whether the column label is visible. A column that is sortable cannot have its label be hidden.
+6. `width` (string; conditionally required) only if `hasFixedColumnWidths` is set to `true`, the `<td>` elements' `class` attributes will be set to this value. This allows restricting columns to specific widths. See [Bootstrap's grid documentation](https://getbootstrap.com/docs/4.0/layout/grid/) for `col` class names that can be used.
+
+The order of objects in `columns` specifies the order of the columns in the table. */
   columns: PropTypes.arrayOf(PropTypes.shape({
     key: PropTypes.string.isRequired,
     label: PropTypes.oneOfType([
@@ -172,13 +193,37 @@ Table.propTypes = {
     hideHeader: PropTypes.bool,
     width: isRequiredIf(PropTypes.string, props => props.hasFixedColumnWidths),
   })).isRequired,
+  /** Specifies Bootstrap class names to apply to the table heading. Options are detailed in [Bootstrap's docs](https://getbootstrap.com/docs/4.0/content/tables/#table-head-options).
+ */
   headingClassName: PropTypes.arrayOf(PropTypes.string),
+  /** Specifies whether the table is sortable. This setting supercedes column-level sortability, so if it is `false`, no sortable components will be rendered. */
   tableSortable: PropTypes.bool,
+  /** Specifies whether the table's columns have fixed widths. Every element in `columns` must define a `width` if this is `true`.
+ */
   hasFixedColumnWidths: PropTypes.bool,
   /* eslint-disable react/require-default-props */
+  /** Specifies the key of the column that is sorted by default. It is only required if `tableSortable` is set to `true`. */
   defaultSortedColumn: isRequiredIf(PropTypes.string, props => props.tableSortable),
   /* eslint-disable react/require-default-props */
+  /** Specifies the direction the `defaultSortedColumn` is sorted in by default; it will typically be either 'asc' or 'desc'. It is only required if `tableSortable` is set to `true`. */
   defaultSortDirection: isRequiredIf(PropTypes.string, props => props.tableSortable),
+  /** Specifies the screen reader only text that accompanies the sort buttons for sortable columns. It takes the form of an object containing the following keys:
+
+1. `asc`: (string) specifies the screen reader only text for sort buttons in the ascending state.
+2. `desc`: (string) specifies the screen reader only text for sort buttons in the descending state.
+3. `defaultText`: (string) specifies the screen reader only text for sort buttons that are not engaged.
+
+It is only required if `tableSortable` is set to `true`.
+
+Default:
+
+```javascript
+{
+  asc: 'sort ascending',
+  desc: 'sort descending',
+  defaultText: 'click to sort',
+}
+``` */
   sortButtonsScreenReaderText: isRequiredIf(
     PropTypes.shape({
       asc: PropTypes.string,
@@ -187,6 +232,8 @@ Table.propTypes = {
     }),
     props => props.tableSortable,
   ),
+  /** Specifies the key for the column that should act as a row header. Rather than rendering as `<td>` elements,
+cells in this column will render as `<th scope="row">`  */
   rowHeaderColumnKey: PropTypes.string,
 };
 

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -1,8 +1,7 @@
 // TODO: @jaebradley fix these eslint errors
-
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/anchor-is-valid */
-
+/* eslint-disable max-len */
 import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -107,7 +106,10 @@ class Tabs extends React.Component {
 }
 // TODO: custom validator that ensures labels and panels are the same length
 Tabs.propTypes = {
+  /** specifies the list of elements that will be displayed within each of the tabbed views.  It is the content relevant to each label. Children should not be passed as Props, but should instead be nested between the opening and closing `<Tabs> </Tabs>` tags. */
   labels: PropTypes.arrayOf(PropTypes.node).isRequired,
+  /** specifies the list of headings that will appear on all of the tabs that will be created.
+ */
   children: PropTypes.arrayOf(PropTypes.element).isRequired,
 };
 

--- a/src/TextArea/index.jsx
+++ b/src/TextArea/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -24,6 +25,8 @@ function Text(props) {
 
 Text.propTypes = {
   className: PropTypes.string,
+  /** specifies all of the properties that are necessary from the included `asInput` component.  Please see details for input requirements within that component.
+  */
   inputRef: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.element) }),

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -5603,7 +5603,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5624,12 +5625,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5644,17 +5647,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5771,7 +5777,8 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5783,6 +5790,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5797,6 +5805,7 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5804,12 +5813,14 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5828,6 +5839,7 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5908,7 +5920,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5920,6 +5933,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6005,7 +6019,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6041,6 +6056,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6060,6 +6076,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6103,12 +6120,14 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "optional": true
         }
       }
     },
@@ -7483,6 +7502,18 @@
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
+    "html-to-react": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.3.4.tgz",
+      "integrity": "sha512-/tWDdb/8Koi/QEP5YUY1653PcDpBnnMblXRhotnTuhFDjI1Fc6Wzox5d4sw73Xk5rM2OdM5np4AYjT/US/Wj7Q==",
+      "requires": {
+        "domhandler": "^2.4.2",
+        "escape-string-regexp": "^1.0.5",
+        "htmlparser2": "^3.10.0",
+        "lodash.camelcase": "^4.3.0",
+        "ramda": "^0.26"
+      }
+    },
     "html-void-elements": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.4.tgz",
@@ -7744,12 +7775,14 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "optional": true
         },
         "slice-ansi": {
           "version": "1.0.0",
@@ -7775,6 +7808,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -8683,6 +8717,11 @@
       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
       "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -8788,7 +8827,8 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -8811,6 +8851,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -8980,6 +9021,21 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "mdast-add-list-metadata": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz",
+      "integrity": "sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==",
+      "requires": {
+        "unist-util-visit-parents": "1.1.2"
+      },
+      "dependencies": {
+        "unist-util-visit-parents": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz",
+          "integrity": "sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q=="
+        }
       }
     },
     "mdast-squeeze-paragraphs": {
@@ -11268,6 +11324,11 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
+    "ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -11646,6 +11707,73 @@
               "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
               "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
             }
+          }
+        }
+      }
+    },
+    "react-markdown": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.1.0.tgz",
+      "integrity": "sha512-EOHsEAN+aoP8UVz7vTHx6Z63GJfhrO9KItKlfsiBtVVS9tmSWtUaBTw73+2SObrWiOiE2Cs9qUBL7ORsvVhOrA==",
+      "requires": {
+        "html-to-react": "^1.3.4",
+        "mdast-add-list-metadata": "1.0.1",
+        "prop-types": "^15.7.2",
+        "remark-parse": "^5.0.0",
+        "unified": "^6.1.5",
+        "unist-util-visit": "^1.3.0",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        },
+        "remark-parse": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
+          "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+          "requires": {
+            "collapse-white-space": "^1.0.2",
+            "is-alphabetical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-whitespace-character": "^1.0.0",
+            "is-word-character": "^1.0.0",
+            "markdown-escapes": "^1.0.0",
+            "parse-entities": "^1.1.0",
+            "repeat-string": "^1.5.4",
+            "state-toggle": "^1.0.0",
+            "trim": "0.0.1",
+            "trim-trailing-lines": "^1.0.0",
+            "unherit": "^1.0.4",
+            "unist-util-remove-position": "^1.0.0",
+            "vfile-location": "^2.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "unified": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
+          "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+          "requires": {
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "trough": "^1.0.0",
+            "vfile": "^2.0.0",
+            "x-is-string": "^0.1.0"
+          }
+        },
+        "vfile": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
+          "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+          "requires": {
+            "is-buffer": "^1.1.4",
+            "replace-ext": "1.0.0",
+            "unist-util-stringify-position": "^1.0.0",
+            "vfile-message": "^1.0.0"
           }
         }
       }

--- a/www/package.json
+++ b/www/package.json
@@ -21,7 +21,8 @@
     "react-docgen": "^4.1.1",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.0",
-    "react-live": "^2.1.2"
+    "react-live": "^2.1.2",
+    "react-markdown": "^4.1.0"
   },
   "keywords": [
     "paragon",

--- a/www/src/components/ComponentMetadataQueryFragment.js
+++ b/www/src/components/ComponentMetadataQueryFragment.js
@@ -17,6 +17,10 @@ export const query = graphql`
       required
       docblock
       doclets
+      description {
+        id
+        text
+      }
     }
   }
 `;

--- a/www/src/components/PropsTable.jsx
+++ b/www/src/components/PropsTable.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ReactMarkdown from 'react-markdown';
 
 
 const renderType = ({ name, value }) => { // eslint-disable-line
@@ -64,7 +65,7 @@ const PropsTable = (props) => {
             <tr key={key}>
               <td>
                 <span className="d-block">{name}</span>
-                {description ? <p className="text-muted mb-0">{description.text}</p> : null}
+                {description ? <ReactMarkdown className="text-muted mb-0">{description.text}</ReactMarkdown> : null}
               </td>
               <td>{type ? renderType(type) : ''}</td>
               <td>{required ? 'required' : 'optional'}</td>

--- a/www/src/components/SingleComponentStatus.jsx
+++ b/www/src/components/SingleComponentStatus.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Table } from '~paragon-react';
+
+import { ComponentStatus } from './doc-elements';
+
+export default ({ frontmatter }) => (
+  <>
+    {frontmatter && (
+      <Table
+        className="pgn-doc__status-table"
+        data={[
+          {
+            name: (
+              <div>
+                <h6>
+                  <ComponentStatus noLeftMargin status={frontmatter.status} />
+                </h6>
+                <pre>{frontmatter.notes}</pre>
+              </div>
+            ),
+            designStatus: <ComponentStatus status={frontmatter.designStatus} />,
+            devStatus: <ComponentStatus status={frontmatter.devStatus} />,
+          },
+        ]}
+        columns={[
+          {
+            label: 'Status',
+            key: 'name',
+            width: 'col-3',
+          },
+          {
+            label: 'Design',
+            key: 'designStatus',
+            width: 'col-3',
+          },
+          {
+            label: 'Development',
+            key: 'devStatus',
+            width: 'col-3',
+          },
+        ]}
+      />
+    )}
+  </>
+);

--- a/www/src/components/doc-elements.jsx
+++ b/www/src/components/doc-elements.jsx
@@ -2,10 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 // eslint-disable-next-line import/prefer-default-export
-export function ComponentStatus({ status }) {
+export function ComponentStatus({ status, noLeftMargin }) {
   if (!status) return null;
   return (
-    <span className={`status-indicator ${status.toLowerCase().replace(' ', '-')}`}>
+    <span
+      className={`status-indicator ${noLeftMargin &&
+        'status-no-left-margin'} ${status.toLowerCase().replace(' ', '-')}`}
+    >
       <span>{status}</span>
     </span>
   );

--- a/www/src/pages/components/breadcrumbs.mdx
+++ b/www/src/pages/components/breadcrumbs.mdx
@@ -1,21 +1,29 @@
 ---
-title: "Breadcrumbs"
-type: "component"
-status: "Needs Work"
-designStatus: "To Do"
-devStatus: "To Do"
+title: 'Breadcrumbs'
+type: 'component'
+status: 'Needs Work'
+designStatus: 'To Do'
+devStatus: 'To Do'
 notes: |
-    Reassess default separator icons and any other style changes.
-    Has overly complex implementation.
-    Must remove baked in English labels.
-    Eliminate unnecessary props.
+  Reassess default separator icons and any other style changes.
+  Has overly complex implementation.
+  Must remove baked in English labels.
+  Eliminate unnecessary props.
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { Breadcrumb } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # Breadcrumbs
+
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### Basic Usage
 
@@ -58,9 +66,13 @@ import PropsTable from '../../components/PropsTable';
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "Breadcrumbs" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "Breadcrumbs" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/button.mdx
+++ b/www/src/pages/components/button.mdx
@@ -1,19 +1,25 @@
 ---
-title: "Button"
-type: "component"
-status: "Stable"
-designStatus: "Done"
-devStatus: "Done"
-notes: ""
+title: 'Button'
+type: 'component'
+status: 'Stable'
+designStatus: 'Done'
+devStatus: 'Done'
+notes: ''
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
-import { Input, Button } from '~paragon-react';
+import get from 'lodash/get';
+import { Button } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
-
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # Button
 
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### Basic Usage
 
@@ -52,6 +58,7 @@ import PropsTable from '../../components/PropsTable';
   <Button className="btn-inverse-danger">Danger</Button>
 </div>
 ```
+
 ##### Link Variant
 
 ```jsx live=true
@@ -65,9 +72,13 @@ import PropsTable from '../../components/PropsTable';
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "Button" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "Button" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/checkbox.mdx
+++ b/www/src/pages/components/checkbox.mdx
@@ -1,44 +1,53 @@
 ---
-title: "Checkbox"
-type: "component"
-status: "Deprecate Soon"
-designStatus: "TBD"
-devStatus: "To Do"
+title: 'Checkbox'
+type: 'component'
+status: 'Deprecate Soon'
+designStatus: 'TBD'
+devStatus: 'To Do'
 notes: |
-    Replaced by Input and ValidationFormGroup
+  Replaced by Input and ValidationFormGroup
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
+import { CheckBox } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
-# Check
+# Checkbox
 
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### Basic usage
+
 ```jsx live=true
-<CheckBox
-  name="checkbox"
-  label="check me out!"
+<CheckBox 
+  name="checkbox" 
+  label="check me out!" 
 />
 ```
 
 ##### Disabled
 
 ```jsx live=true
-<CheckBox
-  name="checkbox"
-  label="you cannot check me out"
-  disabled
+<CheckBox 
+  name="checkbox" 
+  label="you cannot check me out" 
+  disabled 
 />
 ```
 
 ##### Default checked
 
 ```jsx live=true
-<CheckBox
-  name="checkbox"
-  label="(un)check me out"
-  checked
+<CheckBox 
+  name="checkbox" 
+  label="(un)check me out" 
+  checked 
 />
 ```
 
@@ -96,9 +105,13 @@ class CheckBoxWrapper extends React.Component {
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "Check" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "Check" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/checkboxgroup.mdx
+++ b/www/src/pages/components/checkboxgroup.mdx
@@ -1,49 +1,59 @@
 ---
-title: "CheckboxGroup"
-type: "component"
-status: "Needs Work"
-designStatus: "To Do"
-devStatus: "To Do"
+title: 'CheckboxGroup'
+type: 'component'
+status: 'Needs Work'
+designStatus: 'To Do'
+devStatus: 'To Do'
 notes: |
-    Refactor to use Input component and refresh checkbox designs
+  Refactor to use Input component and refresh checkbox designs
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { CheckBoxGroup } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # CheckBoxGroup
 
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### Basic Usage
 
 ```jsx live=true
 <CheckBoxGroup>
-  <CheckBox
-    id="checkbox1"
-    name="basicCheckBox1"
-    label="CheckBox 1"
+  <CheckBox 
+    id="checkbox1" 
+    name="basicCheckBox1" 
+    label="CheckBox 1" 
   />
-  <CheckBox
-    id="checkbox2"
-    name="basicCheckBox2"
-    label="CheckBox 2"
+  <CheckBox 
+    id="checkbox2" 
+    name="basicCheckBox2" 
+    label="CheckBox 2" 
   />
-  <CheckBox
-    id="checkbox3"
-    name="basicCheckBox3"
-    label="CheckBox 3"
+  <CheckBox 
+    id="checkbox3" 
+    name="basicCheckBox3" 
+    label="CheckBox 3" 
   />
 </CheckBoxGroup>
 ```
 
-
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "CheckBoxGroup" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "CheckBoxGroup" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/collapsible.mdx
+++ b/www/src/pages/components/collapsible.mdx
@@ -8,11 +8,19 @@ notes:
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { Collapsible } from '~paragon-react';
 import { Icons } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # Collapsible
+
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ### Basic Usage
 

--- a/www/src/pages/components/dropdown.mdx
+++ b/www/src/pages/components/dropdown.mdx
@@ -1,19 +1,27 @@
 ---
-title: "Dropdown"
-type: "component"
-status: "Needs Work"
-designStatus: "Done"
-devStatus: "In Progress"
+title: 'Dropdown'
+type: 'component'
+status: 'Needs Work'
+designStatus: 'Done'
+devStatus: 'In Progress'
 notes: |
-    Simplifying implementation.
-    Fix event handling bug.
+  Simplifying implementation.
+  Fix event handling bug.
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { Dropdown } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # Dropdown
+
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### basic usage
 
@@ -30,7 +38,6 @@ import PropsTable from '../../components/PropsTable';
 </Dropdown>
 ```
 
-
 ##### with icon element
 
 ```jsx live=true
@@ -46,7 +53,6 @@ import PropsTable from '../../components/PropsTable';
   </Dropdown.Menu>
 </Dropdown>
 ```
-
 
 ##### with caret/chevron
 
@@ -99,7 +105,6 @@ import PropsTable from '../../components/PropsTable';
 />
 ```
 
-
 ##### (Deprecated) menu items as elements
 
 ```jsx live=true
@@ -112,7 +117,6 @@ import PropsTable from '../../components/PropsTable';
   ]}
 />
 ```
-
 
 ##### (Deprecated) with icon element
 
@@ -140,23 +144,35 @@ import PropsTable from '../../components/PropsTable';
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    dropdown: componentMetadata(displayName: { eq: "Dropdown" }) { ...ComponentDocGenData }
-    dropdownItem: componentMetadata(displayName: { eq: "DropdownItem" }) { ...ComponentDocGenData }
-    dropdownButton: componentMetadata(displayName: { eq: "DropdownButton" }) { ...ComponentDocGenData }
-    dropdownMenu: componentMetadata(displayName: { eq: "DropdownMenu" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      dropdown: componentMetadata(displayName: { eq: "Dropdown" }) {
+        ...ComponentDocGenData
+      }
+      dropdownItem: componentMetadata(displayName: { eq: "DropdownItem" }) {
+        ...ComponentDocGenData
+      }
+      dropdownButton: componentMetadata(displayName: { eq: "DropdownButton" }) {
+        ...ComponentDocGenData
+      }
+      dropdownMenu: componentMetadata(displayName: { eq: "DropdownMenu" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ dropdown, dropdownItem, dropdownButton, dropdownMenu }) => {
     return (
       <div>
         {dropdown ? <PropsTable propMetaData={dropdown.props} /> : null}
         <h4>Dropdown.Button</h4>
-        {dropdownButton ? <PropsTable propMetaData={dropdownButton.props} /> : null}
+        {dropdownButton ? (
+          <PropsTable propMetaData={dropdownButton.props} />
+        ) : null}
         <h4>Dropdown.Menu</h4>
         {dropdownMenu ? <PropsTable propMetaData={dropdownMenu.props} /> : null}
         <h4>Dropdown.Item</h4>
         {dropdownItem ? <PropsTable propMetaData={dropdownItem.props} /> : null}
       </div>
-    )
+    );
   }}
 />

--- a/www/src/pages/components/fieldset.mdx
+++ b/www/src/pages/components/fieldset.mdx
@@ -1,65 +1,64 @@
 ---
-title: "Fieldset"
-type: "component"
-status: "Deprecate Soon"
-designStatus: "TBD"
-devStatus: "To Do"
+title: 'Fieldset'
+type: 'component'
+status: 'Deprecate Soon'
+designStatus: 'TBD'
+devStatus: 'To Do'
 notes: |
-    Unneeded. Used in one place (studio-frontend/src/components/EditImageModal/index.jsx)
+  Unneeded. Used in one place (studio-frontend/src/components/EditImageModal/index.jsx)
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { Fieldset } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # Fieldset
 
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### basic usage
 
 ```jsx live=true
 <form>
-  <Fieldset
-    legend="Name"
-  >
-    <InputText
-      name="firstName"
-      label="First Name"
-      value=""
+  <Fieldset legend="Name">
+    <InputText 
+      name="firstName" 
+      label="First Name" 
+      value="" 
     />
-    <InputText
-      name="lastName"
-      label="Last Name"
-      value=""
+    <InputText 
+      name="lastName" 
+      label="Last Name" 
+      value="" 
     />
   </Fieldset>
 </form>
 ```
-
 
 ##### invalid
 
 ```jsx live=true
 <form>
-  <Fieldset
-    legend="Name"
-    invalidMessage="This is invalid!"
-    isValid={false}
-  >
+  <Fieldset legend="Name" invalidMessage="This is invalid!" isValid={false}>
     <InputText
-      name="firstName"
-      label="First Name"
-      value=""
+      name="firstName" 
+      label="First Name" 
+      value="" 
     />
-    <InputText
-      name="lastName"
-      label="Last Name"
-      value=""
+    <InputText 
+      name="lastName" 
+      label="Last Name" 
+      value="" 
     />
   </Fieldset>
 </form>
 ```
-
 
 ##### invalid with danger theme
 
@@ -74,25 +73,23 @@ import PropsTable from '../../components/PropsTable';
     }}
     variantIconDescription="Error"
   >
-    <InputText
-      name="firstName"
-      label="First Name"
-      value=""
+    <InputText 
+      name="firstName" 
+      label="First Name" 
+      value="" 
     />
-    <InputText
-      name="lastName"
-      label="Last Name"
-      value=""
+    <InputText 
+      name="lastName" 
+      label="Last Name" 
+      value="" 
     />
   </Fieldset>
 </form>
 ```
 
-
 ##### Validated Form
 
 ```jsx live=true
-
 class ValidatedForm extends React.Component {
   constructor(props) {
     super(props);
@@ -107,7 +104,10 @@ class ValidatedForm extends React.Component {
   }
 
   handleSubmit(event) {
-    if (this.firstInputRef.value.length === 0 && this.secondInputRef.value.length === 0) {
+    if (
+      this.firstInputRef.value.length === 0 &&
+      this.secondInputRef.value.length === 0
+    ) {
       this.setState({
         isValid: false,
       });
@@ -121,9 +121,7 @@ class ValidatedForm extends React.Component {
 
   render() {
     return (
-      <form
-        onSubmit={this.handleSubmit}
-      >
+      <form onSubmit={this.handleSubmit}>
         <Fieldset
           legend="Name"
           invalidMessage="Please enter at least one name."
@@ -137,20 +135,20 @@ class ValidatedForm extends React.Component {
             name="firstName"
             label="First Name"
             value=""
-            inputRef={(ref) => { this.firstInputRef = ref; }}
+            inputRef={ref => {
+              this.firstInputRef = ref;
+            }}
           />
           <InputText
             name="lastName"
             label="Last Name"
             value=""
-            inputRef={(ref) => { this.secondInputRef = ref; }}
+            inputRef={ref => {
+              this.secondInputRef = ref;
+            }}
           />
         </Fieldset>
-        <input
-          type="submit"
-          className="btn btn-primary"
-          value="Submit"
-        />
+        <input type="submit" className="btn btn-primary" value="Submit" />
       </form>
     );
   }
@@ -160,9 +158,13 @@ class ValidatedForm extends React.Component {
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "Fieldset" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "Fieldset" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/hyperlink.mdx
+++ b/www/src/pages/components/hyperlink.mdx
@@ -1,19 +1,27 @@
 ---
-title: "Hyperlink"
-type: "component"
-status: "Needs Work"
-designStatus: "Done"
-devStatus: "To Do"
+title: 'Hyperlink'
+type: 'component'
+status: 'Needs Work'
+designStatus: 'Done'
+devStatus: 'To Do'
 notes: |
-    Improve prop naming. Deprecate content prop.
-    Use React.forwardRef for ref forwarding.
+  Improve prop naming. Deprecate content prop.
+  Use React.forwardRef for ref forwarding.
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { Hyperlink } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # Hyperlink
+
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### minimal usage
 
@@ -24,7 +32,9 @@ import PropsTable from '../../components/PropsTable';
 ##### with blank target
 
 ```jsx live=true
-<Hyperlink destination="https://www.edx.org" target="_blank">edX.org</Hyperlink>
+<Hyperlink destination="https://www.edx.org" target="_blank">
+  edX.org
+</Hyperlink>
 ```
 
 ##### with onClick
@@ -33,7 +43,7 @@ import PropsTable from '../../components/PropsTable';
 <Hyperlink
   destination="https://www.edx.org"
   target="_blank"
-  onClick={(e) => {
+  onClick={e => {
     e.preventDefault();
     console.log('click');
   }}
@@ -57,9 +67,13 @@ import PropsTable from '../../components/PropsTable';
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "Hyperlink" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "Hyperlink" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/icon.mdx
+++ b/www/src/pages/components/icon.mdx
@@ -1,24 +1,36 @@
 ---
-title: "Icon"
-type: "component"
-status: "Reassessing"
-designStatus: "TBD"
-devStatus: "TBD"
-notes: "Reconcile purpose of this component with use of FontAwesome"
+title: 'Icon'
+type: 'component'
+status: 'Reassessing'
+designStatus: 'TBD'
+devStatus: 'TBD'
+notes: 'Reconcile purpose of this component with use of FontAwesome'
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { Icon } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # Icon
+
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "Icon" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "Icon" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/input.mdx
+++ b/www/src/pages/components/input.mdx
@@ -1,29 +1,35 @@
 ---
-title: "Input"
-type: "component"
-status: "Stable"
-designStatus: "Done"
-devStatus: "Done"
-notes: ""
+title: 'Input'
+type: 'component'
+status: 'Stable'
+designStatus: 'Done'
+devStatus: 'Done'
+notes: ''
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
-import { Input, Button } from '~paragon-react';
+import get from 'lodash/get';
+import { Input } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # Input
+
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 A component for all user input. It is responsible for rendering select, textarea, and inputs of any type with the appropriate bootstrap class name.
 
 Extra props supplied to Input will be passed through to the html node.
-
 
 ##### Text
 
 ```jsx live=true
 <Input type="text" defaultValue="Some text input" />
 ```
-
 
 ##### Select
 
@@ -49,7 +55,6 @@ Extra props supplied to Input will be passed through to the html node.
 />
 ```
 
-
 ##### Textarea
 
 ```jsx live=true
@@ -59,13 +64,11 @@ Extra props supplied to Input will be passed through to the html node.
 />
 ```
 
-
 ##### Date
 
 ```jsx live=true
 <Input type="date" />
 ```
-
 
 ##### File
 
@@ -73,20 +76,22 @@ Extra props supplied to Input will be passed through to the html node.
 <Input type="file" />
 ```
 
-
 ##### Range
 
 ```jsx live=true
 <Input type="range" />
 ```
 
-
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "Input" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "Input" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/inputselect.mdx
+++ b/www/src/pages/components/inputselect.mdx
@@ -1,19 +1,28 @@
 ---
-title: "InputSelect"
-type: "component"
-status: "Deprecate Soon"
-designStatus: "TBD"
-devStatus: "To Do"
+title: 'InputSelect'
+type: 'component'
+status: 'Deprecate Soon'
+designStatus: 'TBD'
+devStatus: 'To Do'
 notes: |
-    Replaced by Input and ValidationFormGroup
+  Replaced by Input and ValidationFormGroup
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { InputSelect } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # InputSelect
 
+
+
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### basic usage
 
@@ -23,14 +32,13 @@ import PropsTable from '../../components/PropsTable';
   label="Fruits"
   value="strawberry"
   options={[
-    'apple',
-    'orange',
-    'strawberry',
+    'apple', 
+    'orange', 
+    'strawberry', 
     'banana',
   ]}
 />
 ```
-
 
 ##### separate labels and values
 
@@ -49,7 +57,6 @@ import PropsTable from '../../components/PropsTable';
   ]}
 />
 ```
-
 
 ##### separate option groups
 
@@ -87,23 +94,14 @@ import PropsTable from '../../components/PropsTable';
 />
 ```
 
-
 ##### with validation
 
 ```jsx live=true
 <InputSelect
   name="color"
   label="Favorite Color"
-  options={[
-    '',
-    'red',
-    'orange',
-    'yellow',
-    'green',
-    'blue',
-    'purple',
-  ]}
-  validator={(value) => {
+  options={['', 'red', 'orange', 'yellow', 'green', 'blue', 'purple']}
+  validator={value => {
     let feedback = { isValid: true };
     if (!value) {
       feedback = {
@@ -116,7 +114,6 @@ import PropsTable from '../../components/PropsTable';
 />
 ```
 
-
 ##### disabled usage
 
 ```jsx live=true
@@ -125,16 +122,15 @@ import PropsTable from '../../components/PropsTable';
   label="Fruits"
   aria-label="Fruits"
   value="strawberry"
-  options={[
-    'apple',
-    'orange',
-    'strawberry',
+  options={['
+    apple', 
+    'orange', 
+    'strawberry', 
     'banana',
   ]}
   disabled
 />
 ```
-
 
 ##### with disabled option
 
@@ -154,9 +150,13 @@ import PropsTable from '../../components/PropsTable';
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "InputSelect" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "InputSelect" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/inputtext.mdx
+++ b/www/src/pages/components/inputtext.mdx
@@ -1,43 +1,38 @@
 ---
-title: "InputText"
-type: "component"
-status: "Deprecate Soon"
-designStatus: "TBD"
-devStatus: "To Do"
+title: 'InputText'
+type: 'component'
+status: 'Deprecate Soon'
+designStatus: 'TBD'
+devStatus: 'To Do'
 notes: |
-    Replaced by Input and ValidationFormGroup
+  Replaced by Input and ValidationFormGroup
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { InputText } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # InputText
 
-
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### minimal usage
 
 ```jsx live=true
-<InputText
-  name="name"
-  label="First Name"
-  value="Foo Bar"
-/>
+<InputText name="name" label="First Name" value="Foo Bar" />
 ```
-
 
 ##### read only
 
 ```jsx live=true
-<InputText
-  name="inputState"
-  label="Input State"
-  value="Read Only"
-  readOnly
-/>
+<InputText name="inputState" label="Input State" value="Read Only" readOnly />
 ```
-
 
 ##### validation
 
@@ -47,7 +42,7 @@ import PropsTable from '../../components/PropsTable';
   name="username"
   label="Username"
   description="The unique name that identifies you throughout the site."
-  validator={(value) => {
+  validator={value => {
     let feedback = { isValid: true };
     if (value.length < 3) {
       feedback = {
@@ -60,7 +55,6 @@ import PropsTable from '../../components/PropsTable';
 />
 ```
 
-
 ##### validation with danger theme
 
 ```jsx live=true
@@ -68,7 +62,7 @@ import PropsTable from '../../components/PropsTable';
   name="username"
   label="Username"
   description="The unique name that identifies you throughout the site."
-  validator={(value) => {
+  validator={value => {
     let feedback = { isValid: true };
     if (value.length < 3) {
       feedback = {
@@ -83,7 +77,6 @@ import PropsTable from '../../components/PropsTable';
 />
 ```
 
-
 ##### label as element
 
 ```jsx live=true
@@ -94,17 +87,17 @@ import PropsTable from '../../components/PropsTable';
 />
 ```
 
-
 ##### focus test
 
 ```jsx live=true
-
 class FocusInputWrapper extends React.Component {
   constructor(props) {
     super(props);
     this.state = { open: true };
 
-    this.resetStatusAlertWrapperState = this.resetStatusAlertWrapperState.bind(this);
+    this.resetStatusAlertWrapperState = this.resetStatusAlertWrapperState.bind(
+      this,
+    );
   }
 
   resetStatusAlertWrapperState() {
@@ -125,14 +118,15 @@ class FocusInputWrapper extends React.Component {
           id="data"
           name="data"
           label="Data Input"
-          inputRef={(input) => { this.inputForm = input; }}
+          inputRef={input => {
+            this.inputForm = input;
+          }}
         />
       </div>
     );
   }
 }
 ```
-
 
 ##### different textual input types
 
@@ -225,7 +219,6 @@ class FocusInputWrapper extends React.Component {
 </form>
 ```
 
-
 ##### price with step
 
 ```jsx live=true
@@ -233,24 +226,17 @@ class FocusInputWrapper extends React.Component {
   name="price"
   label="Price"
   type="number"
-  value={3.50}
+  value={3.5}
   min={0}
   step={0.01}
 />
 ```
 
-
 ##### displayed inline
 
 ```jsx live=true
-<InputText
-  name="username"
-  label="Username"
-  value="foobar"
-  inline
-/>
+<InputText name="username" label="Username" value="foobar" inline />
 ```
-
 
 ##### with input group addons
 
@@ -260,44 +246,28 @@ class FocusInputWrapper extends React.Component {
     name="username"
     label="Username"
     value="foobar"
-    inputGroupPrepend={(
-      <div className="input-group-text">
-        {'@'}
-      </div>
-    )}
+    inputGroupPrepend={<div className="input-group-text">{'@'}</div>}
   />
   <InputText
     name="username"
     label="Username"
     value="foobar"
-    inputGroupAppend={(
-      <div className="input-group-text">
-        {'@example.com'}
-      </div>
-    )}
+    inputGroupAppend={<div className="input-group-text">{'@example.com'}</div>}
   />
   <InputText
     name="money"
     label="Money"
     type="number"
     value={1000}
-    inputGroupPrepend={(
-      <div className="input-group-text">
-        {'$'}
-      </div>
-    )}
-    inputGroupAppend={(
-      <div className="input-group-text">
-        {'.00'}
-      </div>
-    )}
+    inputGroupPrepend={<div className="input-group-text">{'$'}</div>}
+    inputGroupAppend={<div className="input-group-text">{'.00'}</div>}
   />
   <InputText
     name="search"
     label="Search"
     value="what is paragon"
     inputGroupAppend={(
-      <Button
+      <Button 
         buttonType="outline-secondary"
       >
         Go
@@ -316,7 +286,7 @@ class FocusInputWrapper extends React.Component {
           screenReaderText="Checkmark"
         />
       </div>,
-      <Button
+      <Button 
         buttonType="outline-secondary"
       >
         Go
@@ -327,7 +297,7 @@ class FocusInputWrapper extends React.Component {
     name="password"
     label="Password"
     value="secret"
-    inputGroupAppend={(
+    inputGroupAppend={
       <div className="input-group-text">
         <Icon
           id="checkmark"
@@ -335,7 +305,7 @@ class FocusInputWrapper extends React.Component {
           screenReaderText="Checkmark"
         />
       </div>
-    )}
+    }
   />
 </form>
 ```
@@ -343,9 +313,13 @@ class FocusInputWrapper extends React.Component {
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "Text" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "Text" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/listbox.mdx
+++ b/www/src/pages/components/listbox.mdx
@@ -1,19 +1,25 @@
 ---
-title: "ListBox"
-type: "component"
-status: "Deprecate Soon"
-designStatus: "TBD"
-devStatus: "To Do"
-notes: "Not used anywhere in code on Github. Consult design."
+title: 'ListBox'
+type: 'component'
+status: 'Deprecate Soon'
+designStatus: 'TBD'
+devStatus: 'To Do'
+notes: 'Not used anywhere in code on Github. Consult design.'
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { ListBox } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # ListBox
 
-
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### basic usage
 
@@ -33,7 +39,6 @@ import PropsTable from '../../components/PropsTable';
   </ListBoxOption>
 </ListBox>
 ```
-
 
 ##### using tag prop
 
@@ -56,7 +61,6 @@ import PropsTable from '../../components/PropsTable';
   </ListBox>
 </React.Fragment>
 ```
-
 
 ##### using onSelect prop
 
@@ -106,12 +110,17 @@ class ListBoxWrapperForOnSelect extends React.Component {
       <React.Fragment>
         <span aria-live="polite">
           Selected Fruit:
-          {this.state.selectedOptionIndex === undefined ?
-            <span className="sr-only">none</span> :
-            <span arialabelledby={`list-box-option-${this.state.selectedOptionIndex}`} >
+          {this.state.selectedOptionIndex === undefined ? (
+            <span className="sr-only">none</span>
+          ) : (
+            <span
+              arialabelledby={`list-box-option-${
+                this.state.selectedOptionIndex
+              }`}
+            >
               {this.getSelectedFruitEmoji(this.state.selectedOption)}
             </span>
-          }
+          )}
         </span>
         <ListBox style={{ width: '200px' }}>
           {children}
@@ -121,7 +130,6 @@ class ListBoxWrapperForOnSelect extends React.Component {
   }
 }
 ```
-
 
 ##### using selectedOptionIndex prop
 
@@ -170,10 +178,7 @@ class ListBoxWrapperForSelectedOptionIndex extends React.Component {
 
     return (
       <React.Fragment>
-        <Button
-          buttonType="primary"
-          onClick={this.onButtonClick}
-        >
+        <Button buttonType="primary" onClick={this.onButtonClick}>
           Click me to reset your selected fruit!
         </Button>
         <ListBox
@@ -191,9 +196,13 @@ class ListBoxWrapperForSelectedOptionIndex extends React.Component {
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "ListBox" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "ListBox" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/mailtolink.mdx
+++ b/www/src/pages/components/mailtolink.mdx
@@ -1,57 +1,54 @@
 ---
-title: "MailtoLink"
-type: "component"
-status: "Needs Work"
-designStatus: "Done"
-devStatus: "To Do"
+title: 'MailtoLink'
+type: 'component'
+status: 'Needs Work'
+designStatus: 'Done'
+devStatus: 'To Do'
 notes: |
-    Remove unnecessary props. 
-    Remove baked in English strings.
-    Use React.forwardRef for ref forwarding
+  Remove unnecessary props. 
+  Remove baked in English strings.
+  Use React.forwardRef for ref forwarding
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { MailtoLink } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # MailtoLink
 
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### minimal usage
 
 ```jsx live=true
-<MailtoLink
-  to="edx@example.com"
->
-  edx@example.com
-</MailtoLink>
+<MailtoLink to="edx@example.com">edx@example.com</MailtoLink>
 ```
-
 
 ##### with blank target
 
 ```jsx live=true
-<MailtoLink
-  to="edx@example.com"
-  target="_blank"
->
+<MailtoLink to="edx@example.com" target="_blank">
   edx@example.com
 </MailtoLink>
 ```
 
-
 ##### with onClick
 
 ```jsx live=true
-<MailtoLink
-  to="edx@example.com"
-  target="_blank"
+<MailtoLink 
+  to="edx@example.com" 
+  target="_blank" 
   onClick={onClick}
 >
   edx@example.com
 </MailtoLink>
 ```
-
 
 ##### with subject and body
 
@@ -65,18 +62,16 @@ import PropsTable from '../../components/PropsTable';
 </MailtoLink>
 ```
 
-
 ##### with cc and bcc
 
 ```jsx live=true
-<MailtoLink
-  cc="edx@example.com"
+<MailtoLink 
+  cc="edx@example.com" 
   bcc="edx@example.com"
 >
   Moar mail, this time with cc and bcc
 </MailtoLink>
 ```
-
 
 ##### with multiple cc and bcc
 
@@ -89,13 +84,16 @@ import PropsTable from '../../components/PropsTable';
 </MailtoLink>
 ```
 
-
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "MailtoLink" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "MailtoLink" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/modal.mdx
+++ b/www/src/pages/components/modal.mdx
@@ -1,21 +1,27 @@
 ---
-title: "Modal"
-type: "component"
-status: "Needs Work"
-designStatus: "Done"
-devStatus: "To Do"
+title: 'Modal'
+type: 'component'
+status: 'Needs Work'
+designStatus: 'Done'
+devStatus: 'To Do'
 notes: |
-     Overly complex implementation
-     Too opinionated in design/structure
+  Overly complex implementation
+  Too opinionated in design/structure
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
-import { MailtoLink } from '~paragon-react';
+import get from 'lodash/get';
+import { Modal } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
-
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # Modal
 
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### Example Usage
 
@@ -45,25 +51,27 @@ class ModalWrapper extends React.Component {
         <Modal
           open={this.state.open}
           title="Modal title."
-          body={(
+          body={
             <div>
               <p>Enter your e-mail address to receive free cat facts!</p>
-              <InputText
-                name="e-mail"
-                label="E-Mail Address"
+              <InputText 
+                name="e-mail" 
+                label="E-Mail Address" 
               />
             </div>
-          )}
+          }
           parentSelector={this.props.parentSelector}
           onClose={this.resetModalWrapperState}
           buttons={[
-            <Button buttonType="success">Green button!</Button>,
+            <Button buttonType="success">Green button!</Button>
           ]}
         />
         <Button
           onClick={this.openModal}
           buttonType="light"
-          inputRef={(input) => { this.button = input; }}
+          inputRef={input => {
+            this.button = input;
+          }}
         >
           Click me to open a modal!
         </Button>
@@ -72,7 +80,6 @@ class ModalWrapper extends React.Component {
   }
 }
 ```
-
 
 ##### configurable buttons
 
@@ -93,7 +100,6 @@ class ModalWrapper extends React.Component {
 />
 ```
 
-
 ##### configurable title and body
 
 ```jsx
@@ -102,12 +108,11 @@ class ModalWrapper extends React.Component {
   title="Custom title!"
   body="Custom body!"
   buttons={[
-    <Button buttonType="dark">Dark button!</Button>,
+    <Button buttonType="dark">Dark button!</Button>
   ]}
   onClose={() => {}}
 />
 ```
-
 
 ##### configurable buttons that perform actions
 
@@ -117,8 +122,8 @@ class ModalWrapper extends React.Component {
   title="Modal title."
   body="Modal body."
   buttons={[
-    <Button
-      buttonType="light"
+    <Button 
+      buttonType="light" 
       onClick={action('button-click')}
     >
       Click me and check the console!
@@ -127,7 +132,6 @@ class ModalWrapper extends React.Component {
   onClose={() => {}}
 />
 ```
-
 
 ##### configurable close button string
 
@@ -141,7 +145,6 @@ class ModalWrapper extends React.Component {
 />
 ```
 
-
 ##### configurable close button element
 
 ```jsx
@@ -150,10 +153,11 @@ class ModalWrapper extends React.Component {
   title="Modal title."
   body="Modal body."
   closeText={
-    <Icon
-      className="fa fa-ship"
-      screenReaderText="Close"
-    />}
+    <Icon 
+      className="fa fa-ship" 
+      screenReaderText="Close" 
+    />
+  }
   onClose={() => {}}
 />
 ```
@@ -161,9 +165,13 @@ class ModalWrapper extends React.Component {
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "Modal" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "Modal" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/pagination.mdx
+++ b/www/src/pages/components/pagination.mdx
@@ -1,21 +1,28 @@
 ---
-title: "Pagination"
-type: "component"
-status: "Needs Work"
-designStatus: "Done"
-devStatus: "To Do"
+title: 'Pagination'
+type: 'component'
+status: 'Needs Work'
+designStatus: 'Done'
+devStatus: 'To Do'
 notes: |
-    Breaks if given 5000 pages.
-    Overly complex implementation.
-    Remove baked in english strings 
+  Breaks if given 5000 pages.
+  Overly complex implementation.
+  Remove baked in english strings
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { Pagination } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # Pagination
 
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### basic usage
 
@@ -23,10 +30,9 @@ import PropsTable from '../../components/PropsTable';
 <Pagination
   paginationLabel="pagination navigation"
   pageCount={20}
-  onPageSelect={() => console.log("page selected")}
+  onPageSelect={() => console.log('page selected')}
 />
 ```
-
 
 ##### with initial page selected
 
@@ -35,10 +41,9 @@ import PropsTable from '../../components/PropsTable';
   paginationLabel="pagination navigation"
   pageCount={20}
   currentPage={15}
-  onPageSelect={() => console.log("page selected")}
+  onPageSelect={() => console.log('page selected')}
 />
 ```
-
 
 ##### with max pages displayed
 
@@ -46,11 +51,10 @@ import PropsTable from '../../components/PropsTable';
 <Pagination
   paginationLabel="pagination navigation"
   pageCount={20}
-  onPageSelect={() => console.log("page selected")}
+  onPageSelect={() => console.log('page selected')}
   maxPagesDisplayed={9}
 />
 ```
-
 
 ##### with custom string labels
 
@@ -58,7 +62,7 @@ import PropsTable from '../../components/PropsTable';
 <Pagination
   paginationLabel="pagination navigation"
   pageCount={20}
-  onPageSelect={() => console.log("page selected")}
+  onPageSelect={() => console.log('page selected')}
   buttonLabels={{
     previous: 'Anterior',
     next: 'Siguiente',
@@ -69,14 +73,13 @@ import PropsTable from '../../components/PropsTable';
 />
 ```
 
-
 ##### with custom element labels
 
 ```jsx live=true
 <Pagination
   paginationLabel="pagination navigation"
   pageCount={20}
-  onPageSelect={() => console.log("page selected")}
+  onPageSelect={() => console.log('page selected')}
   buttonLabels={{
     previous: <span>Anterior</span>,
     next: <span>Siguiente</span>,
@@ -87,13 +90,16 @@ import PropsTable from '../../components/PropsTable';
 />
 ```
 
-
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "Pagination" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "Pagination" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/radiobuttongroup.mdx
+++ b/www/src/pages/components/radiobuttongroup.mdx
@@ -1,29 +1,35 @@
 ---
-title: "RadioButtonGroup"
-type: "component"
-status: "Needs Work"
-designStatus: "To Do"
-devStatus: "To Do"
+title: 'RadioButtonGroup'
+type: 'component'
+status: 'Needs Work'
+designStatus: 'To Do'
+devStatus: 'To Do'
 notes: |
-    Refactor to use Input component
-    and refresh checkbox designs
+  Refactor to use Input component
+  and refresh checkbox designs
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { RadioButtonGroup } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # RadioButtonGroup
 
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### unselected minimal usage
 
 ```jsx live=true
-
 <RadioButtonGroup
   name="rbg"
   label="Radio Button Group"
-  onBlur={() => console.log("blurred")}
+  onBlur={() => console.log('blurred')}
   onChange={() => console.log('onChange')}
   onClick={() => console.log('onClick')}
   onFocus={() => console.log('onFocus')}
@@ -35,15 +41,13 @@ import PropsTable from '../../components/PropsTable';
 </RadioButtonGroup>
 ```
 
-
 ##### selected minimal usage
 
 ```jsx live=true
-
 <RadioButtonGroup
   name="rbg-2"
   label="Radio Button Group"
-  onBlur={() => console.log("blurred")}
+  onBlur={() => console.log('blurred')}
   onChange={() => console.log('onChange')}
   onClick={() => console.log('onClick')}
   onFocus={() => console.log('onFocus')}
@@ -56,13 +60,16 @@ import PropsTable from '../../components/PropsTable';
 </RadioButtonGroup>
 ```
 
-
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "RadioButtonGroup" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "RadioButtonGroup" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/responsive.mdx
+++ b/www/src/pages/components/responsive.mdx
@@ -1,24 +1,63 @@
 ---
-title: "Responsive Components"
-type: "component"
-status: "Reassessing"
-designStatus: "Done"
-devStatus: "TBD"
+title: 'Responsive Components'
+type: 'component'
+status: 'Reassessing'
+designStatus: 'Done'
+devStatus: 'TBD'
 notes: |
-    Consider a different strategy: export breakpoint constants and a passthrough to react-responsive. Current components are less flexible than needed ( from x-small to medium is not possible without strange repetition).
+  Consider a different strategy: export breakpoint constants and a passthrough to react-responsive. Current components are less flexible than needed ( from x-small to medium is not possible without strange repetition).
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
+import { Responsive } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # Responsive
 
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
+
 ##### Props
+Provides several wrapper components that support hiding/showing components for specific screen sizes based on [Bootstrap's responsive breakpoints](https://getbootstrap.com/docs/4.0/layout/overview/#responsive-breakpoints). This enables `Paragon` components to create mobile-specific UIs (e.g., simplifying the UX of `Pagination` for mobile devices).
+
+The following responsive components are available:
+
+1. `ExtraSmall` (max-width: 575)
+2. `Small` (min-width: 576; max-width: 767)
+3. `Medium` (min-width: 768; max-width: 991)
+4. `Large` (min-width: 992; max-width: 1199)
+5. `ExtraLarge` (min-width: 1200)
+6. `LargerThanExtraSmall` (min-width: 576)
+
+## Example Usage
+
+```jsx
+<ExtraSmall>
+    <p>This text will only show on extra small screens.</p>
+</ExtraSmall>
+
+<Large>
+    <p>This text will only show on large screens.</p>
+</Large>
+
+<LargerThanExtraSmall>
+    <p>This text will only show on screens larger than extra small.</p>
+</LargerThanExtraSmall>
+```
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "Responsive" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "Responsive" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/searchfield.mdx
+++ b/www/src/pages/components/searchfield.mdx
@@ -1,28 +1,34 @@
 ---
-title: "SearchField"
-type: "component"
-status: "Needs Work"
-designStatus: "To Do"
-devStatus: "To Do"
+title: 'SearchField'
+type: 'component'
+status: 'Needs Work'
+designStatus: 'To Do'
+devStatus: 'To Do'
 notes: |
-    Needs more flexibility. Too opinionated in design/structure.
+  Needs more flexibility. Too opinionated in design/structure.
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { SearchField } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # SearchField
 
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### basic usage
 
 ```jsx live=true
-<SearchField
-  onSubmit={() => console.log('search-submitted')}
+<SearchField 
+  onSubmit={() => console.log('search-submitted')} 
 />
 ```
-
 
 ##### with placeholder
 
@@ -33,7 +39,6 @@ import PropsTable from '../../components/PropsTable';
 />
 ```
 
-
 ##### with value
 
 ```jsx live=true
@@ -43,7 +48,6 @@ import PropsTable from '../../components/PropsTable';
   value="foobar"
 />
 ```
-
 
 ##### with callbacks
 
@@ -56,7 +60,6 @@ import PropsTable from '../../components/PropsTable';
   onClear={() => console.log('search-cleared')}
 />
 ```
-
 
 ##### with custom label and screenreader text
 
@@ -71,13 +74,16 @@ import PropsTable from '../../components/PropsTable';
 />
 ```
 
-
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "SearchField" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "SearchField" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/statefulbutton.mdx
+++ b/www/src/pages/components/statefulbutton.mdx
@@ -1,23 +1,30 @@
 ---
-title: "StatefulButton"
-type: "component"
-status: "Stable"
-designStatus: "Done"
-devStatus: "Done"
-notes: ""
+title: 'StatefulButton'
+type: 'component'
+status: 'Stable'
+designStatus: 'Done'
+devStatus: 'Done'
+notes: ''
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { StatefulButton } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # StatefulButton
 
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### basic usage
 
 ```jsx live=true
-() => {  
+() => {
   const props = {
     labels: {
       default: 'Saved',
@@ -33,9 +40,8 @@ import PropsTable from '../../components/PropsTable';
       <StatefulButton state="complete" {...props} />
     </div>
   );
-}
+};
 ```
-
 
 ##### custom icons and disable during state
 
@@ -62,9 +68,8 @@ import PropsTable from '../../components/PropsTable';
       <StatefulButton state="complete" {...downloadButtonProps} />
     </React.Fragment>
   );
-}
+};
 ```
-
 
 ##### custom states
 
@@ -88,16 +93,19 @@ import PropsTable from '../../components/PropsTable';
       <StatefulButton state="edited" {...buttonProps} />
     </React.Fragment>
   );
-}
+};
 ```
-
 
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "StatefulButton" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "StatefulButton" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/statusalert.mdx
+++ b/www/src/pages/components/statusalert.mdx
@@ -1,57 +1,60 @@
 ---
-title: "StatusAlert"
-type: "component"
-status: "Needs Work"
-designStatus: "Done"
-devStatus: "In Progress"
+title: 'StatusAlert'
+type: 'component'
+status: 'Needs Work'
+designStatus: 'Done'
+devStatus: 'In Progress'
 notes: |
-    Used deprecated lifecycle method
-    Should be controlled or uncontrolled – not both.
-    Props need renaming. Should use children over prop.
+  Used deprecated lifecycle method
+  Should be controlled or uncontrolled – not both.
+  Props need renaming. Should use children over prop.
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { StatusAlert } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # StatusAlert
 
-
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### basic usage
 
 ```jsx live=true
-<StatusAlert
-  dialog="You have a status alert!"
-  onClose={() => {}}
-  open
+<StatusAlert 
+  dialog="You have a status alert!" 
+  onClose={() => {}} 
+  open 
 />
 ```
-
 
 ##### success alert
 
 ```jsx live=true
-<StatusAlert
-  alertType="success"
-  dialog="Success!"
-  onClose={() => {}}
-  open
+<StatusAlert 
+  alertType="success" 
+  dialog="Success!" 
+  onClose={() => {}} 
+  open 
 />
 ```
-
 
 ##### danger alert
 
 ```jsx live=true
-<StatusAlert
-  alertType="danger"
-  dialog="Error!"
-  onClose={() => {}}
-  open
+<StatusAlert 
+  alertType="danger" 
+  dialog="Error!" 
+  onClose={() => {}} 
+  open 
 />
 ```
-
 
 ##### informational alert
 
@@ -63,7 +66,6 @@ import PropsTable from '../../components/PropsTable';
   open
 />
 ```
-
 
 ##### alert with a custom aria-label on the close button
 
@@ -77,7 +79,6 @@ import PropsTable from '../../components/PropsTable';
 />
 ```
 
-
 ##### Non-dismissible alert
 
 ```jsx live=true
@@ -89,17 +90,17 @@ import PropsTable from '../../components/PropsTable';
 />
 ```
 
-
 ##### alert invoked via a button
 
 ```jsx live=true
-
 class StatusAlertWrapper extends React.Component {
   constructor(props) {
     super(props);
 
     this.openStatusAlert = this.openStatusAlert.bind(this);
-    this.resetStatusAlertWrapperState = this.resetStatusAlertWrapperState.bind(this);
+    this.resetStatusAlertWrapperState = this.resetStatusAlertWrapperState.bind(
+      this,
+    );
 
     this.state = { open: false };
   }
@@ -125,7 +126,9 @@ class StatusAlertWrapper extends React.Component {
         <Button
           onClick={this.openStatusAlert}
           buttonType="light"
-          inputRef={(input) => { this.button = input; }}
+          inputRef={input => {
+            this.button = input;
+          }}
         >
           Click me to open a Status Alert!
         </Button>
@@ -135,13 +138,12 @@ class StatusAlertWrapper extends React.Component {
 }
 ```
 
-
 ##### alert with a link
 
 ```jsx live=true
 <StatusAlert
   alertType="info"
-  dialog={(
+  dialog={
     <div>
       <span>Love cats? </span>
       <a
@@ -152,19 +154,22 @@ class StatusAlertWrapper extends React.Component {
         Click me!
       </a>
     </div>
-  )}
+  }
   onClose={() => {}}
   open
 />
 ```
 
-
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "StatusAlert" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "StatusAlert" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/table.mdx
+++ b/www/src/pages/components/table.mdx
@@ -1,19 +1,26 @@
 ---
-title: "Table"
-type: "component"
-status: "Reassessing"
-designStatus: "TBD"
-devStatus: "TBD"
+title: 'Table'
+type: 'component'
+status: 'Reassessing'
+designStatus: 'TBD'
+devStatus: 'TBD'
 notes: |
-    Potentially does too much work. Consider if should be multiple components: Table, TableHeader, SortableTable, etc.
+  Potentially does too much work. Consider if should be multiple components: Table, TableHeader, SortableTable, etc.
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { Table } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # Table
 
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### unstyled
 
@@ -48,7 +55,8 @@ import PropsTable from '../../components/PropsTable';
     {
       name: 'Long Cat',
       color: 'russian white',
-      famous_for: 'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
+      famous_for:
+        'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
     },
   ]}
   columns={[
@@ -78,7 +86,6 @@ import PropsTable from '../../components/PropsTable';
   caption="Famous Internet Cats"
 />
 ```
-
 
 ##### table-striped
 
@@ -113,7 +120,8 @@ import PropsTable from '../../components/PropsTable';
     {
       name: 'Long Cat',
       color: 'russian white',
-      famous_for: 'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
+      famous_for:
+        'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
     },
   ]}
   columns={[
@@ -144,7 +152,6 @@ import PropsTable from '../../components/PropsTable';
   className="table-striped"
 />
 ```
-
 
 ##### default heading
 
@@ -179,7 +186,8 @@ import PropsTable from '../../components/PropsTable';
     {
       name: 'Long Cat',
       color: 'russian white',
-      famous_for: 'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
+      famous_for:
+        'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
     },
   ]}
   columns={[
@@ -210,7 +218,6 @@ import PropsTable from '../../components/PropsTable';
   headingClassName={['thead-default']}
 />
 ```
-
 
 ##### responsive
 
@@ -245,7 +252,8 @@ import PropsTable from '../../components/PropsTable';
     {
       name: 'Long Cat',
       color: 'russian white',
-      famous_for: 'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
+      famous_for:
+        'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
     },
   ]}
   columns={[
@@ -276,7 +284,6 @@ import PropsTable from '../../components/PropsTable';
   className="table-responsive"
 />
 ```
-
 
 ##### sortable
 
@@ -311,7 +318,8 @@ import PropsTable from '../../components/PropsTable';
     {
       name: 'Long Cat',
       color: 'russian white',
-      famous_for: 'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
+      famous_for:
+        'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
     },
   ];
 
@@ -339,7 +347,7 @@ import PropsTable from '../../components/PropsTable';
       width: 'col-3',
     },
   ];
-  
+
   const sort = function sort(firstElement, secondElement, key, direction) {
     const directionIsAsc = direction === 'asc';
 
@@ -353,159 +361,170 @@ import PropsTable from '../../components/PropsTable';
 
   const catDataSortable = catData.slice();
 
-  return (<Table
-    data={catDataSortable.sort((firstElement, secondElement) => sort(firstElement, secondElement, catColumns[0].key, 'desc'))}
-    columns={catColumns.map(column => ({
-      ...column,
-      onSort(direction) {
-        catDataSortable.sort((firstElement, secondElement) =>
-          sort(firstElement, secondElement, column.key, direction));
-      },
-    }))}
-    caption="Famous Internet Cats"
-    tableSortable
-    defaultSortedColumn={catColumns[0].key}
-    defaultSortDirection="desc"
-  />);
-}
+  return (
+    <Table
+      data={catDataSortable.sort((firstElement, secondElement) =>
+        sort(firstElement, secondElement, catColumns[0].key, 'desc'),
+      )}
+      columns={catColumns.map(column => ({
+        ...column,
+        onSort(direction) {
+          catDataSortable.sort((firstElement, secondElement) =>
+            sort(firstElement, secondElement, column.key, direction),
+          );
+        },
+      }))}
+      caption="Famous Internet Cats"
+      tableSortable
+      defaultSortedColumn={catColumns[0].key}
+      defaultSortDirection="desc"
+    />
+  );
+};
 ```
 
 ##### fixed
 
 ```jsx live=true
-  <Table
-    data={[
-      {
-        name: 'Lil Bub',
-        color: 'brown tabby',
-        famous_for: 'weird tongue',
-      },
-      {
-        name: 'Grumpy Cat',
-        color: 'siamese',
-        famous_for: 'serving moods',
-      },
-      {
-        name: 'Smoothie',
-        color: 'orange tabby',
-        famous_for: 'modeling',
-      },
-      {
-        name: 'Maru',
-        color: 'brown tabby',
-        famous_for: 'being a lovable oaf',
-      },
-      {
-        name: 'Keyboard Cat',
-        color: 'orange tabby',
-        famous_for: 'piano virtuoso',
-      },
-      {
-        name: 'Long Cat',
-        color: 'russian white',
-        famous_for: 'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
-      },
-    ]}
-    columns={[
-      {
-        label: 'Name',
-        key: 'name',
-        columnSortable: true,
-        onSort: () => {},
-        width: 'col-3',
-      },
-      {
-        label: 'Famous For',
-        key: 'famous_for',
-        columnSortable: false,
-        onSort: () => {},
-        width: 'col-6',
-      },
-      {
-        label: 'Coat Color',
-        key: 'color',
-        columnSortable: false,
-        hideHeader: true,
-        onSort: () => {},
-        width: 'col-3',
-      },
-    ]}
-    caption="Famous Internet Cats"
-    hasFixedColumnWidths
-  />
+<Table
+  data={[
+    {
+      name: 'Lil Bub',
+      color: 'brown tabby',
+      famous_for: 'weird tongue',
+    },
+    {
+      name: 'Grumpy Cat',
+      color: 'siamese',
+      famous_for: 'serving moods',
+    },
+    {
+      name: 'Smoothie',
+      color: 'orange tabby',
+      famous_for: 'modeling',
+    },
+    {
+      name: 'Maru',
+      color: 'brown tabby',
+      famous_for: 'being a lovable oaf',
+    },
+    {
+      name: 'Keyboard Cat',
+      color: 'orange tabby',
+      famous_for: 'piano virtuoso',
+    },
+    {
+      name: 'Long Cat',
+      color: 'russian white',
+      famous_for:
+        'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
+    },
+  ]}
+  columns={[
+    {
+      label: 'Name',
+      key: 'name',
+      columnSortable: true,
+      onSort: () => {},
+      width: 'col-3',
+    },
+    {
+      label: 'Famous For',
+      key: 'famous_for',
+      columnSortable: false,
+      onSort: () => {},
+      width: 'col-6',
+    },
+    {
+      label: 'Coat Color',
+      key: 'color',
+      columnSortable: false,
+      hideHeader: true,
+      onSort: () => {},
+      width: 'col-3',
+    },
+  ]}
+  caption="Famous Internet Cats"
+  hasFixedColumnWidths
+/>
 ```
-
 
 ##### row header
 
 ```jsx live=true
-  <Table
-    data={[
-      {
-        name: 'Lil Bub',
-        color: 'brown tabby',
-        famous_for: 'weird tongue',
-      },
-      {
-        name: 'Grumpy Cat',
-        color: 'siamese',
-        famous_for: 'serving moods',
-      },
-      {
-        name: 'Smoothie',
-        color: 'orange tabby',
-        famous_for: 'modeling',
-      },
-      {
-        name: 'Maru',
-        color: 'brown tabby',
-        famous_for: 'being a lovable oaf',
-      },
-      {
-        name: 'Keyboard Cat',
-        color: 'orange tabby',
-        famous_for: 'piano virtuoso',
-      },
-      {
-        name: 'Long Cat',
-        color: 'russian white',
-        famous_for: 'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
-      },
-    ]}
-    columns={[
-      {
-        label: 'Name',
-        key: 'name',
-        columnSortable: true,
-        onSort: () => {},
-        width: 'col-3',
-      },
-      {
-        label: 'Famous For',
-        key: 'famous_for',
-        columnSortable: false,
-        onSort: () => {},
-        width: 'col-6',
-      },
-      {
-        label: 'Coat Color',
-        key: 'color',
-        columnSortable: false,
-        hideHeader: true,
-        onSort: () => {},
-        width: 'col-3',
-      },
-    ]}
-    caption="Famous Internet Cats"
-    rowHeaderColumnKey="name"
-  />
+<Table
+  data={[
+    {
+      name: 'Lil Bub',
+      color: 'brown tabby',
+      famous_for: 'weird tongue',
+    },
+    {
+      name: 'Grumpy Cat',
+      color: 'siamese',
+      famous_for: 'serving moods',
+    },
+    {
+      name: 'Smoothie',
+      color: 'orange tabby',
+      famous_for: 'modeling',
+    },
+    {
+      name: 'Maru',
+      color: 'brown tabby',
+      famous_for: 'being a lovable oaf',
+    },
+    {
+      name: 'Keyboard Cat',
+      color: 'orange tabby',
+      famous_for: 'piano virtuoso',
+    },
+    {
+      name: 'Long Cat',
+      color: 'russian white',
+      famous_for:
+        'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
+    },
+  ]}
+  columns={[
+    {
+      label: 'Name',
+      key: 'name',
+      columnSortable: true,
+      onSort: () => {},
+      width: 'col-3',
+    },
+    {
+      label: 'Famous For',
+      key: 'famous_for',
+      columnSortable: false,
+      onSort: () => {},
+      width: 'col-6',
+    },
+    {
+      label: 'Coat Color',
+      key: 'color',
+      columnSortable: false,
+      hideHeader: true,
+      onSort: () => {},
+      width: 'col-3',
+    },
+  ]}
+  caption="Famous Internet Cats"
+  rowHeaderColumnKey="name"
+/>
 ```
+
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "Table" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "Table" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/tabs.mdx
+++ b/www/src/pages/components/tabs.mdx
@@ -1,43 +1,53 @@
 ---
-title: "Tabs"
-type: "component"
-status: "Needs Work"
-designStatus: "Done"
-devStatus: "In Progress"
+title: 'Tabs'
+type: 'component'
+status: 'Needs Work'
+designStatus: 'Done'
+devStatus: 'In Progress'
 notes: |
-    Overly complex implementation. New styles break layout.
+  Overly complex implementation. New styles break layout.
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { Tabs } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # Tabs
 
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### Basic Usage
 
 ```jsx live=true
-  <Tabs
-    labels={[
-      'Panel 1',
-      'Panel 2',
-      'Panel 3',
-    ]}
-  >
-    <div>Hello I am the first panel</div>
-    <div>Hello I am the second panel</div>
-    <div>Hello I am the third panel</div>
-  </Tabs>
+<Tabs 
+  labels={[
+    'Panel 1', 
+    'Panel 2', 
+    'Panel 3'
+  ]}
+>
+  <div>Hello I am the first panel</div>
+  <div>Hello I am the second panel</div>
+  <div>Hello I am the third panel</div>
+</Tabs>
 ```
-
 
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "Tabs" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "Tabs" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/textarea.mdx
+++ b/www/src/pages/components/textarea.mdx
@@ -1,30 +1,36 @@
 ---
-title: "TextArea"
-type: "component"
-status: "Deprecate Soon"
-designStatus: "TBD"
-devStatus: "To Do"
+title: 'TextArea'
+type: 'component'
+status: 'Deprecate Soon'
+designStatus: 'TBD'
+devStatus: 'To Do'
 notes: |
-    Replaced by Input and ValidationFormGroup
+  Replaced by Input and ValidationFormGroup
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { TextArea } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # TextArea
 
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 ##### minimal usage
 
 ```jsx live=true
-<TextArea
-  name="name"
-  label="First Name"
-  value="Foo Bar"
+<TextArea 
+  name="name" 
+  label="First Name" 
+  value="Foo Bar" 
 />
 ```
-
 
 ##### scrollable
 
@@ -36,7 +42,6 @@ import PropsTable from '../../components/PropsTable';
 />
 ```
 
-
 ##### validation
 
 ```jsx live=true
@@ -44,7 +49,7 @@ import PropsTable from '../../components/PropsTable';
   name="username"
   label="Username"
   description="The unique name that identifies you throughout the site."
-  validator={(value) => {
+  validator={value => {
     let feedback = { isValid: true };
     if (value.length < 3) {
       feedback = {
@@ -57,7 +62,6 @@ import PropsTable from '../../components/PropsTable';
 />
 ```
 
-
 ##### label as element
 
 ```jsx live=true
@@ -68,13 +72,16 @@ import PropsTable from '../../components/PropsTable';
 />
 ```
 
-
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "Text" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "Text" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/transitionreplace.mdx
+++ b/www/src/pages/components/transitionreplace.mdx
@@ -1,17 +1,25 @@
 ---
-title: "TransitionReplace"
-type: "component"
-status: "Stable"
-designStatus: "Done"
-devStatus: "Done"
-notes: ""
+title: 'TransitionReplace'
+type: 'component'
+status: 'Stable'
+designStatus: 'Done'
+devStatus: 'Done'
+notes: ''
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { TransitionReplace } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # TransitionReplace
+
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 Manages a transition when replacing content. By default this component will transition the height and do a cross-fade. The transition can be customized.
 
@@ -21,7 +29,6 @@ TransitionReplace expects only one child at any time. Swap content inside the co
 
 ```jsx live=true
 () => {
-
   const [isEditing, setIsEditing] = useState(false);
 
   return (
@@ -32,7 +39,7 @@ TransitionReplace expects only one child at any time. Swap content inside the co
             <label htmlFor="name">First Name</label>
             <Input type="text" value="some name" />
           </form>
-        ): (
+        ) : (
           <div key="other">
             <h4 className="mt-0">First Name</h4>
             <p>Some name</p>
@@ -40,10 +47,12 @@ TransitionReplace expects only one child at any time. Swap content inside the co
           </div>
         )}
       </TransitionReplace>
-      <Button className="btn-primary" onClick={() => setIsEditing(!isEditing)}>Toggle</Button>
+      <Button className="btn-primary" onClick={() => setIsEditing(!isEditing)}>
+        Toggle
+      </Button>
     </div>
   );
-}
+};
 ```
 
 **IMPORTANT NOTE: You must provide the `key` prop for all children**, even when only rendering a single item. This is how React will determine that a child is new rather than just updated.
@@ -72,44 +81,38 @@ TransitionReplace uses [CSSTransition from the ReactTransitionGroup package](htt
 
 If you change the timing in CSS you should also match it using the `enterDuration` and `exitDuration` props.
 
-
 #### Note:
 
 Children are not required. When this component is empty, the a child inserted into it will not transition the height (from zero). No "replacement" transition will occur and new content will pop in like a normal insert. This behaviour makes it easier to work with asyncronously loaded content (for example: during the first load you don't have to do any special handling).
-
 
 ##### Example
 
 ```jsx live=true
 function DemoTransitionReplace() {
   const contentOptions = [
-    (
-      <blockquote className="h2 m-0" key={0}>
-        <p>You know the golden rule, don’t you boy? Those who have the gold make the rules.</p>
-        <footer>— Crazy hunch-backed old guy in Aladdin</footer>
-      </blockquote>
-    ),
-    (
-      <blockquote className="m-0" key={1}>
-        <p>People say nothing is impossible, but I do nothing every day.</p>
-        <footer>— A. A. Milne</footer>
-      </blockquote>
-    ),
-    (
-      <blockquote className="h2 m-0" key={2}>
-        <p>
-          I won’t go into a big spiel about reincarnation, but the first time I was in the
-          Gucci store in Chicago was the closest I’ve ever felt to home.
-        </p>
-        <footer>— Kanye</footer>
-      </blockquote>
-    ),
-    (
-      <blockquote className="m-0" key={3}>
-        <p>The first time I see a jogger smiling, I’ll consider it.</p>
-        <footer>— Joan Rivers</footer>
-      </blockquote>
-    ),
+    <blockquote className="h2 m-0" key={0}>
+      <p>
+        You know the golden rule, don’t you boy? Those who have the gold make
+        the rules.
+      </p>
+      <footer>— Crazy hunch-backed old guy in Aladdin</footer>
+    </blockquote>,
+    <blockquote className="m-0" key={1}>
+      <p>People say nothing is impossible, but I do nothing every day.</p>
+      <footer>— A. A. Milne</footer>
+    </blockquote>,
+    <blockquote className="h2 m-0" key={2}>
+      <p>
+        I won’t go into a big spiel about reincarnation, but the first time I
+        was in the Gucci store in Chicago was the closest I’ve ever felt to
+        home.
+      </p>
+      <footer>— Kanye</footer>
+    </blockquote>,
+    <blockquote className="m-0" key={3}>
+      <p>The first time I see a jogger smiling, I’ll consider it.</p>
+      <footer>— Joan Rivers</footer>
+    </blockquote>,
   ];
 
   const [currentContentIndex, setCurrentContentIndex] = useState(0);
@@ -119,7 +122,9 @@ function DemoTransitionReplace() {
 
   return (
     <div>
-      <button className="btn btn-primary mb-2" onClick={changeContent}>Next Quote</button>
+      <button className="btn btn-primary mb-2" onClick={changeContent}>
+        Next Quote
+      </button>
       <div
         style={{
           background: '#eee',
@@ -139,9 +144,13 @@ function DemoTransitionReplace() {
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "TransitionReplace" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "TransitionReplace" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/pages/components/validationformgroup.mdx
+++ b/www/src/pages/components/validationformgroup.mdx
@@ -1,35 +1,43 @@
 ---
-title: "ValidationFormGroup"
-type: "component"
-status: "Stable"
-designStatus: "Done"
-devStatus: "Done"
-notes: ""
+title: 'ValidationFormGroup'
+type: 'component'
+status: 'Stable'
+designStatus: 'Done'
+devStatus: 'Done'
+notes: ''
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
+import get from 'lodash/get';
 import { ValidationFormGroup } from '~paragon-react';
 import PropsTable from '../../components/PropsTable';
+import SingleComponentStatus from '../../components/singleComponentStatus';
 
 # ValidationFormGroup
 
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
 
 Handles bootstrap style field validation and handles related aria attributes.
 
 Manages the rendering of bootstrap-style:
+
 - Help text
 - Valid and invalid feedback
 
 For children of type input, textarea, and select:
+
 - Appends bootstrap validation class names
 - Appends aria-describedby attributes (for help text and feedback)
-
 
 ##### basic usage
 
 ```jsx live=true
-<ValidationFormGroup
-  for="firstName"
+<ValidationFormGroup 
+  for="firstName" 
   helpText="This is your name."
 >
   <label htmlFor="firstName">First Name</label>
@@ -43,13 +51,12 @@ For children of type input, textarea, and select:
 </ValidationFormGroup>
 ```
 
-
 ##### invalid message
 
 ```jsx live=true
-<ValidationFormGroup
-  for="firstName"
-  invalid
+<ValidationFormGroup 
+  for="firstName" 
+  invalid 
   invalidMessage="Wrong!"
 >
   <label htmlFor="firstName">First Name</label>
@@ -63,13 +70,12 @@ For children of type input, textarea, and select:
 </ValidationFormGroup>
 ```
 
-
 ##### valid message
 
 ```jsx live=true
-<ValidationFormGroup
-  for="firstName"
-  valid
+<ValidationFormGroup 
+  for="firstName" 
+  valid 
   validMessage="What a nice name!"
 >
   <label htmlFor="firstName">First Name</label>
@@ -82,7 +88,6 @@ For children of type input, textarea, and select:
   />
 </ValidationFormGroup>
 ```
-
 
 ##### with any kind of input
 
@@ -112,9 +117,13 @@ For children of type input, textarea, and select:
 ##### Props
 
 <StaticQuery
-  query={graphql`query {
-    componentMetadata(displayName: { eq: "ValidationFormGroup" }) { ...ComponentDocGenData }
-  }`}
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "ValidationFormGroup" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
   render={({ componentMetadata }) => {
     if (componentMetadata == null) return null;
     return <PropsTable propMetaData={componentMetadata.props} />;

--- a/www/src/scss/_status-table.scss
+++ b/www/src/scss/_status-table.scss
@@ -1,7 +1,8 @@
 .pgn-doc__status-table,
 .pgn-doc__table {
   border: none;
-  td, th {
+  td,
+  th {
     border: none;
     &:first-child {
       padding-left: 0;
@@ -17,7 +18,7 @@
     top: 0;
   }
   td {
-    border-top: solid 1px rgba(0,0,0,0.17);
+    border-top: solid 1px rgba(0, 0, 0, 0.17);
   }
   pre {
     white-space: pre-wrap;
@@ -30,26 +31,29 @@
       margin-left: 1rem;
       font-weight: 400;
     }
+    .status-no-left-margin {
+      margin-left: 0;
+    }
   }
 
   .status-indicator {
     display: inline-flex;
     align-items: center;
     text-transform: uppercase;
-    font-size: .85em;
+    font-size: 0.85em;
     line-height: 1rem;
     white-space: nowrap;
     &.planned {
       &:before {
         background-color: gray;
-        border-color: #78D965;
+        border-color: #78d965;
       }
     }
 
     &.updates-planned {
       &:before {
         background-color: gray;
-        border-color: #78D965;
+        border-color: #78d965;
       }
     }
 
@@ -92,12 +96,12 @@
       content: ' ';
       background-color: silver;
       display: inline-block;
-      width: .75rem;
+      width: 0.75rem;
       margin-top: 0px;
-      height: .75rem;
-      box-sizing:border-box;
-      border:solid 2px transparent;
-      margin-right: .375rem;
+      height: 0.75rem;
+      box-sizing: border-box;
+      border: solid 2px transparent;
+      margin-right: 0.375rem;
       border-radius: 1rem;
     }
   }


### PR DESCRIPTION
This PR puts the status at the top of each components doc page, along with descriptions for most of the propTypes. Some of the Readmes were missing descriptions for proptypes, but this should migrate 99% of documentation that was on the old website.

Thanks to prettier running amok, some formatting changes are present in this PR, but I removed all of the ones that clashed with eslint, and (hopefully) kept the ones that improve readability.
