### PR TITLE
fix: update npm version in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ notifications:
     on_success: never
     on_failure: always
 before_install:
-- npm install -g npm@5
+- npm install -g npm@6
 - npm install -g greenkeeper-lockfile@1
 install:
   - npm install


### PR DESCRIPTION
Builds complain of npm version 5 in concert with node 12. Use npm 6 for travis.