### PR TITLE
fix: ignore deprecation warnings for bootstrap v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2737,9 +2737,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
-      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
+      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA=="
     },
     "bottleneck": {
       "version": "2.19.1",
@@ -8664,7 +8664,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.10.1",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "airbnb-prop-types": "^2.12.0",
-    "bootstrap": "^4.3.1",
+    "bootstrap": "^4.4.1",
     "classnames": "^2.2.6",
     "email-prop-type": "^3.0.0",
     "font-awesome": "^4.7.0",

--- a/scss/core/extensions/_utilities.scss
+++ b/scss/core/extensions/_utilities.scss
@@ -3,8 +3,8 @@
 
 @each $color, $value in $theme-colors {
   @each $level, $color-shift in $color-levels {
-    @include bg-variant(".bg-#{$color}-#{$level}", theme-color($color, $level));
-    @include text-emphasis-variant(".text-#{$color}-#{$level}", theme-color($color, $level));
+    @include bg-variant(".bg-#{$color}-#{$level}", theme-color($color, $level), true);
+    @include text-emphasis-variant(".text-#{$color}-#{$level}", theme-color($color, $level), true);
     .border-#{$color}-#{$level} {
       border-color: theme-color($color, $level) !important;
     }

--- a/src/Fieldset/Fieldset.scss
+++ b/src/Fieldset/Fieldset.scss
@@ -12,6 +12,6 @@
 }
 
 .form-control.is-invalid.is-invalid-nodanger {
-  @include form-control-focus();
+  @include form-control-focus(true);
   border-color: $input-border-color;
 }


### PR DESCRIPTION
Eliminate this noise from builds:
```
WARNING: The `form-control-focus()` mixin has been deprecated as of v4.4.0. It will be removed entirely in v5.
         on line 8 of node_modules/bootstrap/scss/mixins/_deprecate.scss, in mixin `deprecate`
         from line 26 of node_modules/bootstrap/scss/mixins/_forms.scss, in mixin `form-control-focus`
         from line 15 of node_modules/@edx/paragon/src/Fieldset/Fieldset.scss
         from line 3 of node_modules/@edx/paragon/src/index.scss
         from line 1 of node_modules/@edx/paragon/scss/core/_components.scss
         from line 45 of node_modules/@edx/paragon/scss/core/core.scss
         from line 2 of src/sass/base/_paragon.scss
         from line 4 of stdin
WARNING: The `bg-variant` mixin has been deprecated as of v4.4.0. It will be removed entirely in v5.
         on line 8 of node_modules/bootstrap/scss/mixins/_deprecate.scss, in mixin `deprecate`
         from line 15 of node_modules/bootstrap/scss/mixins/_background-variant.scss, in mixin `bg-variant`
         from line 6 of node_modules/@edx/paragon/scss/core/extensions/_utilities.scss
         from line 2 of node_modules/@edx/paragon/scss/core/_extensions.scss
         from line 46 of node_modules/@edx/paragon/scss/core/core.scss
         from line 2 of src/sass/base/_paragon.scss
         from line 4 of stdin
WARNING: `text-emphasis-variant()` has been deprecated as of v4.4.0. It will be removed entirely in v5.
         on line 8 of node_modules/bootstrap/scss/mixins/_deprecate.scss, in mixin `deprecate`
         from line 16 of node_modules/bootstrap/scss/mixins/_text-emphasis.scss, in mixin `text-emphasis-variant`
         from line 7 of node_modules/@edx/paragon/scss/core/extensions/_utilities.scss
         from line 2 of node_modules/@edx/paragon/scss/core/_extensions.scss
         from line 46 of node_modules/@edx/paragon/scss/core/core.scss
         from line 2 of src/sass/base/_paragon.scss
         from line 4 of stdin