### PR TITLE
fix: remove edx bootstrap from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1125,15 +1125,6 @@
         "find-up": "^2.1.0"
       }
     },
-    "@edx/edx-bootstrap": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@edx/edx-bootstrap/-/edx-bootstrap-2.2.2.tgz",
-      "integrity": "sha512-2kheqhGznzG1ebMWhJea0lb/ZLgjfebuPHgGwutVXE8FF9QTmzFUm02nsAz5hxs4w8wERf3x92SWET0OoALzRQ==",
-      "dev": true,
-      "requires": {
-        "bootstrap": "^4.3.1"
-      }
-    },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.21",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.21.tgz",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@commitlint/cli": "^7.5.2",
     "@commitlint/config-angular": "^7.5.0",
     "@commitlint/prompt-cli": "^7.5.0",
-    "@edx/edx-bootstrap": "^2.0.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.5.0",
     "babel-loader": "^8.0.6",


### PR DESCRIPTION
Not sure why this is still in here, but it's not needed.