### PR TITLE
fix(searchfield): remove browser "X" icon

### DIFF
--- a/src/SearchField/SearchField.scss
+++ b/src/SearchField/SearchField.scss
@@ -13,6 +13,22 @@
         &:focus {
             box-shadow: none;
         }
+
+        // clear browser 'x' from Internet Explorer
+        &::-ms-clear,
+        &::-ms-reveal {
+            display: none;
+            width : 0;
+            height: 0;
+        }
+  
+        // clear browser 'x' from Chrome
+        &::-webkit-search-decoration,
+        &::-webkit-search-cancel-button,
+        &::-webkit-search-results-button,
+        &::-webkit-search-results-decoration {
+            display: none;
+        }
     }
 
     label.has-label-text {


### PR DESCRIPTION
Turns out `role="searchbox"` on the input still adds the browser native "X" button to clear input. Adding back in the styles to override this behavior and hide the native "X" button.