### PR TITLE
fix(searchfield): update state value when prop value changes

### DIFF
--- a/src/SearchField/SearchFieldAdvanced.jsx
+++ b/src/SearchField/SearchFieldAdvanced.jsx
@@ -33,6 +33,10 @@ const SearchFieldAdvanced = (props) => {
   const submitButtonRef = useRef();
 
   useEffect(() => {
+    setValue(initialValue);
+  }, [initialValue]);
+
+  useEffect(() => {
     if (isInitialMount.current) {
       isInitialMount.current = false;
     } else {


### PR DESCRIPTION
When using the `SearchField`, I realized the `value` prop I was passing in was not properly updating on successive component re-renders. To fix, I needed to set the state `value` anytime the prop `value` changes to force the prop `value` to be used.