### PR TITLE
fix: update the usage of button internal to Table

### DIFF
--- a/src/Table/index.jsx
+++ b/src/Table/index.jsx
@@ -68,7 +68,7 @@ class Table extends React.Component {
     if (this.props.tableSortable && column.columnSortable) {
       heading = (
         <Button
-          className="btn-header"
+          variant="header"
           onClick={() => this.onSortClick(column.key)}
         >
           <span>


### PR DESCRIPTION
Fixes in appropriate primary button styling
![image](https://user-images.githubusercontent.com/1615421/89682029-09555b80-d8c4-11ea-9973-c35add0ba505.png)

Should now appear like this:
<img width="869" alt="Screen Shot 2020-08-07 at 3 37 55 PM" src="https://user-images.githubusercontent.com/1615421/89682002-fc386c80-d8c3-11ea-8265-65db72753cdf.png">
