### PR TITLE
docs: add netlify open source plan requirements to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Usage on edx.org:
 
 ## Contributing & Development
 
+See the [code of conduct](https://github.com/edx/.github/blob/master/CODE_OF_CONDUCT.md).
+
 To add a new component, create a file `src/MyComponent/index.jsx`. Define your component (using the same `<MyComponent>` as the class name) in this file. Example:
 
 ```

--- a/www/src/components/layout.jsx
+++ b/www/src/components/layout.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { StaticQuery, graphql } from 'gatsby';
+import { Nav } from '~paragon-react';
 
 import Navigation from './navigation';
 
@@ -24,6 +25,24 @@ const Layout = ({ children }) => (
         <div className="pgn-doc__main-content">
           {children}
         </div>
+        <footer className="pgn-doc_footer border-top border-light d-flex align-items-center">
+          <Nav className="flex-grow-1">
+            <Nav.Item>
+              <Nav.Link href="https://github.com/edx/paragon">Contribute on Github</Nav.Link>
+            </Nav.Item>
+            <Nav.Item>
+              <Nav.Link href="https://github.com/edx/.github/blob/master/CODE_OF_CONDUCT.md">Code of Conduct</Nav.Link>
+            </Nav.Item>
+            <Nav.Item>
+              <Nav.Link href="https://open.edx.org/">Open edX</Nav.Link>
+            </Nav.Item>
+          </Nav>
+          <p className="m-0 text-muted">
+            <a href="https://www.netlify.com">
+              <img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Deploys by Netlify" />
+            </a>
+          </p>
+        </footer>
       </div>
     )}
   />

--- a/www/src/scss/_layout.scss
+++ b/www/src/scss/_layout.scss
@@ -56,3 +56,7 @@
   margin: 0 -6rem;
   padding: 0 6rem;
 }
+
+.pgn-doc_footer {
+  padding: 1rem 2rem;
+}


### PR DESCRIPTION
Satisfy the requirements in the Netlify Open Source Plan Policy: https://www.netlify.com/legal/open-source-policy/

- Adds a link to our code of conduct in the Readme and Documentation Site
- Adds a Netlify badge to the doc site footer

![image](https://user-images.githubusercontent.com/1615421/91576846-e1cb3f00-e915-11ea-9ef2-5a41bb5aab2a.png)
