### PR TITLE
docs: add latest version number to doc landing

### DIFF
--- a/www/src/pages/index.mdx
+++ b/www/src/pages/index.mdx
@@ -14,6 +14,9 @@ import { Input, Button } from '~paragon-react';
   </p>
 </div>
 
+##### Latest Version
+[![npm_version](https://img.shields.io/npm/v/@edx/paragon.svg)](@edx/paragon)
+
 #### Sketch Library
 
 <p>


### PR DESCRIPTION
Add the npm version badge to the documentation landing page.

![image](https://user-images.githubusercontent.com/1615421/92040930-438c0e80-ed45-11ea-8dc3-a8915f995333.png)
