### PR TITLE
feat: add support for FormControl

### DIFF
--- a/src/ValidationFormGroup/ValidationFormGroup.test.jsx
+++ b/src/ValidationFormGroup/ValidationFormGroup.test.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
 
 import ValidationFormGroup from './index';
+import Input from '../Input';
+import { FormControl, Form } from '..';
 
 describe('ValidationFormGroup', () => {
   const labelAndInputComponents = (
@@ -87,5 +90,56 @@ describe('ValidationFormGroup', () => {
       </ValidationFormGroup>
     )).toJSON();
     expect(tree).toMatchSnapshot();
+  });
+  [
+    { Component: Input, name: 'Input' },
+    { Component: FormControl, name: 'FormControl' },
+    { Component: Form.Control, name: 'Form.Control' },
+  ].forEach(({ Component, name }) => {
+    const formControlId = 'bestForm';
+    const formControlHelp = 'So helpful';
+    const validMessage = 'Valid feedback';
+    const invalidMessage = 'Exterminate, Exterminate';
+
+    it(`renders a ${name} child with the correct aria attributes and helptext`, () => {
+      const wrapper = shallow(
+        <ValidationFormGroup
+          for={formControlId}
+          helpText={formControlHelp}
+          validMessage={validMessage}
+          valid
+        >
+          <Component id={formControlId} />
+        </ValidationFormGroup>,
+      );
+      expect(wrapper.find(Component).props()['aria-describedby']).toEqual(`${formControlId}-help-text ${formControlId}-valid-feedback`);
+      expect(wrapper.find(`#${formControlId}-help-text`).text()).toEqual(formControlHelp);
+    });
+    it(`renders a ${name} child with the correct valid message`, () => {
+      const wrapper = shallow(
+        <ValidationFormGroup
+          for={formControlId}
+          helpText={formControlHelp}
+          validMessage={validMessage}
+          valid
+        >
+          <Component id={formControlId} />
+        </ValidationFormGroup>,
+      );
+      expect(wrapper.find(`#${formControlId}-valid-feedback`).text()).toEqual(validMessage);
+    });
+    it(`renders a ${name} child with the correct invalid message`, () => {
+      const wrapper = shallow(
+        <ValidationFormGroup
+          for={formControlId}
+          helpText={formControlHelp}
+          invalidMessage={invalidMessage}
+          invalid
+        >
+          <Component id={formControlId} />
+        </ValidationFormGroup>,
+      );
+      expect(wrapper.find(`#${formControlId}-invalid-feedback`).text()).toEqual(invalidMessage);
+    });
   });
 });

--- a/src/ValidationFormGroup/index.jsx
+++ b/src/ValidationFormGroup/index.jsx
@@ -2,14 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Input from '../Input';
+import { FormControl } from '..';
 
 const propTypes = {
+  /** Id of the form input that the validation is for */
   for: PropTypes.string.isRequired,
+  /** Additional classnames for this component */
   className: PropTypes.string,
+  /** Determines if invalid styles / message will be shown */
   invalid: PropTypes.bool,
+  /** Determines if invalid styles / message will be shown */
   valid: PropTypes.bool,
+  /** Message to display on valid input */
   validMessage: PropTypes.node,
+  /** Message to display on invalid input */
   invalidMessage: PropTypes.node,
+  /** Help text for the form input */
   helpText: PropTypes.node,
   children: PropTypes.node,
 };
@@ -38,7 +46,7 @@ function ValidationFormGroup(props) {
 
   const renderChildren = () => React.Children.map(children, (child) => {
     // Any non-user input element should pass through unmodified
-    if (['input', 'textarea', 'select', Input].indexOf(child.type) === -1) { return child; }
+    if (['input', 'textarea', 'select', Input, FormControl].indexOf(child.type) === -1) { return child; }
 
     // Add validation class names and describedby values to input element
     return React.cloneElement(child, {

--- a/www/src/pages/components/validationformgroup.mdx
+++ b/www/src/pages/components/validationformgroup.mdx
@@ -1,11 +1,9 @@
 ---
 title: 'ValidationFormGroup'
 type: 'component'
-status: 'Needs Work'
+status: 'Stable'
 designStatus: 'Done'
-devStatus: 'TO DO'
-notes: |
-  Needs update to make it compatible with Form.Control components
+devStatus: 'Done'
 ---
 
 import { StaticQuery, graphql } from 'gatsby';
@@ -93,6 +91,7 @@ For children of type input, textarea, and select:
 ##### with any kind of input
 
 ```jsx live
+<>
 <ValidationFormGroup
   for="weatherToday"
   helpText="Look out the window to see."
@@ -113,6 +112,15 @@ For children of type input, textarea, and select:
     <option>Snowy</option>
   </select>
 </ValidationFormGroup>
+<ValidationFormGroup
+  for="weatherTomorrow"
+  helpText="Incoming weather."
+  invalid
+  invalidMessage="No good!"
+>
+  <Form.Control type='text' value='Cloudy' />
+</ValidationFormGroup>
+</>
 ```
 
 ##### Props


### PR DESCRIPTION
Adds support for FormControl (aka Form.Control) to the ValidationFormGroup
Adds docstrings for ValidationFormGroup props