### PR TITLE
docs: make modal documentation interactive

### DIFF
--- a/src/Modal/index.jsx
+++ b/src/Modal/index.jsx
@@ -20,10 +20,10 @@ class Modal extends React.Component {
 
     this.closeModalButtonId = newId('paragonCloseModalButton');
     this.headerId = newId();
-    this.el = global.createElement('div');
+    this.el = document.createElement('div');
 
     // Sets true for IE11, false otherwise: https://stackoverflow.com/a/22082397/6620612
-    this.isIE11 = !!global.MSInputMethodContext && !!global.documentMode;
+    this.isIE11 = !!global.MSInputMethodContext && !!document.documentMode;
 
     this.state = {
       open: props.open,
@@ -34,7 +34,7 @@ class Modal extends React.Component {
     if (this.firstFocusableElement) {
       this.firstFocusableElement.focus();
     }
-    this.parentElement = global.querySelector(this.props.parentSelector);
+    this.parentElement = document.querySelector(this.props.parentSelector);
     if (this.parentElement === null) {
       throw new Error(`Modal received invalid parentSelector: ${this.props.parentSelector}, no matching element found`);
     }

--- a/src/Modal/index.jsx
+++ b/src/Modal/index.jsx
@@ -20,10 +20,10 @@ class Modal extends React.Component {
 
     this.closeModalButtonId = newId('paragonCloseModalButton');
     this.headerId = newId();
-    this.el = document.createElement('div');
+    this.el = global.createElement('div');
 
     // Sets true for IE11, false otherwise: https://stackoverflow.com/a/22082397/6620612
-    this.isIE11 = !!global.MSInputMethodContext && !!document.documentMode;
+    this.isIE11 = !!global.MSInputMethodContext && !!global.documentMode;
 
     this.state = {
       open: props.open,
@@ -34,7 +34,7 @@ class Modal extends React.Component {
     if (this.firstFocusableElement) {
       this.firstFocusableElement.focus();
     }
-    this.parentElement = document.querySelector(this.props.parentSelector);
+    this.parentElement = global.querySelector(this.props.parentSelector);
     if (this.parentElement === null) {
       throw new Error(`Modal received invalid parentSelector: ${this.props.parentSelector}, no matching element found`);
     }

--- a/www/src/pages/components/modal.mdx
+++ b/www/src/pages/components/modal.mdx
@@ -25,7 +25,7 @@ import SingleComponentStatus from '../../components/SingleComponentStatus';
 
 ##### Example Usage
 
-```jsx
+```jsx live
 class ModalWrapper extends React.Component {
   constructor(props) {
     super(props);
@@ -34,6 +34,8 @@ class ModalWrapper extends React.Component {
     this.resetModalWrapperState = this.resetModalWrapperState.bind(this);
 
     this.state = { open: false };
+    this.button = React.createRef();
+
   }
 
   openModal() {
@@ -42,7 +44,7 @@ class ModalWrapper extends React.Component {
 
   resetModalWrapperState() {
     this.setState({ open: false });
-    this.button.focus();
+    this.button.current.focus();
   }
 
   render() {
@@ -69,9 +71,7 @@ class ModalWrapper extends React.Component {
         <Button
           onClick={this.openModal}
           variant="light"
-          inputRef={input => {
-            this.button = input;
-          }}
+          ref={this.button}
         >
           Click me to open a modal!
         </Button>


### PR DESCRIPTION
Make the Modal doc interactive again by updating the example code's use of refs.

Please note that it's expected the the netlify/paragon-edx/deploy-preview will fail. It depends upon a new script `build:with-theme` that's being added in https://github.com/edx/paragon/pull/573