### PR TITLE
fix(modal): focus trapping with `react-focus-on` and `tabbable`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3167,6 +3167,14 @@
       "integrity": "sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk=",
       "dev": true
     },
+    "aria-hidden": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.1.1.tgz",
+      "integrity": "sha512-M7zYxCcOQPOaxGHoMTKUFD2UNcVFTp9ycrdStLcTPLf8zgTXC3+YcGe+UuzSh5X1BX/0/PtS8xTNy4xyH/6xtw==",
+      "requires": {
+        "tslib": "^1.0.0"
+      }
+    },
     "aria-query": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
@@ -4945,6 +4953,11 @@
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
     },
+    "detect-node-es": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.0.0.tgz",
+      "integrity": "sha512-S4AHriUkTX9FoFvL4G8hXDcx6t3gp2HpfCza3Q0v6S78gul2hKWifLQbeW+ZF89+hSm2ZIc/uF3J97ZgytgTRg=="
+    },
     "diff-sequences": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
@@ -6395,6 +6408,11 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
+    "focus-lock": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.7.0.tgz",
+      "integrity": "sha512-LI7v2mH02R55SekHYdv9pRHR9RajVNyIJ2N5IEkWbg7FT5ZmJ9Hw4mWxHeEUcd+dJo0QmzztHvDvWcc7prVFsw=="
+    },
     "font-awesome": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
@@ -6551,6 +6569,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
     },
     "get-stdin": {
       "version": "7.0.0",
@@ -13692,6 +13715,14 @@
         "warning": "^4.0.3"
       }
     },
+    "react-clientside-effect": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz",
+      "integrity": "sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==",
+      "requires": {
+        "@babel/runtime": "^7.0.0"
+      }
+    },
     "react-dom": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
@@ -13702,6 +13733,32 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
+      }
+    },
+    "react-focus-lock": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.4.1.tgz",
+      "integrity": "sha512-c5ZP56KSpj9EAxzScTqQO7bQQNPltf/W1ZEBDqNDOV1XOIwvAyHX0O7db9ekiAtxyKgnqZjQlLppVg94fUeL9w==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^0.7.0",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.2",
+        "use-callback-ref": "^1.2.1",
+        "use-sidecar": "^1.0.1"
+      }
+    },
+    "react-focus-on": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.5.0.tgz",
+      "integrity": "sha512-RqGAHOxhRAaMSVHIN5IpY7YL6AJkD/DMa/+iPDV7aB6XWRQfg3v2q35egIZgMWP2xhXaRVai3B80dpVWyj4Rcw==",
+      "requires": {
+        "aria-hidden": "^1.1.1",
+        "react-focus-lock": "^2.3.1",
+        "react-remove-scroll": "^2.4.0",
+        "react-style-singleton": "^2.1.0",
+        "use-callback-ref": "^1.2.3",
+        "use-sidecar": "^1.0.1"
       }
     },
     "react-is": {
@@ -13734,6 +13791,27 @@
       "resolved": "https://registry.npmjs.org/react-proptype-conditional-require/-/react-proptype-conditional-require-1.0.4.tgz",
       "integrity": "sha1-acLVdB5t9eCPIw82u8KUTuEiJVU="
     },
+    "react-remove-scroll": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.4.0.tgz",
+      "integrity": "sha512-BZIO3GaEs0Or1OhA5C//n1ibUP1HdjJmqUVUsOCMxwoIpaCocbB9TFKwHOkBa/nyYy3slirqXeiPYGwdSDiseA==",
+      "requires": {
+        "react-remove-scroll-bar": "^2.1.0",
+        "react-style-singleton": "^2.1.0",
+        "tslib": "^1.0.0",
+        "use-callback-ref": "^1.2.3",
+        "use-sidecar": "^1.0.1"
+      }
+    },
+    "react-remove-scroll-bar": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.1.0.tgz",
+      "integrity": "sha512-5X5Y5YIPjIPrAoMJxf6Pfa7RLNGCgwZ95TdnVPgPuMftRfO8DaC7F4KP1b5eiO8hHbe7u+wZNDbYN5WUTpv7+g==",
+      "requires": {
+        "react-style-singleton": "^2.1.0",
+        "tslib": "^1.0.0"
+      }
+    },
     "react-responsive": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-6.1.2.tgz",
@@ -13742,6 +13820,16 @@
         "hyphenate-style-name": "^1.0.0",
         "matchmediaquery": "^0.3.0",
         "prop-types": "^15.6.1"
+      }
+    },
+    "react-style-singleton": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.1.0.tgz",
+      "integrity": "sha512-DH4ED+YABC1dhvSDYGGreAHmfuTXj6+ezT3CmHoqIEfxNgEYfIMoOtmbRp42JsUst3IPqBTDL+8r4TF7EWhIHw==",
+      "requires": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^1.0.0"
       }
     },
     "react-test-renderer": {
@@ -15530,6 +15618,11 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "tabbable": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.1.0.tgz",
+      "integrity": "sha512-Y3nSukchqM5UchuZjhj/WyE79Qb4RM/Vx3x3oHO3UYKKpf70Hy3iVRxb61MzCavN74aZsKzvPl4KNG8tQUAjFQ=="
+    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
@@ -15855,8 +15948,7 @@
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-      "dev": true
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -16066,6 +16158,20 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-callback-ref": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.4.tgz",
+      "integrity": "sha512-rXpsyvOnqdScyied4Uglsp14qzag1JIemLeTWGKbwpotWht57hbP78aNT+Q4wdFKQfQibbUX4fb6Qb4y11aVOQ=="
+    },
+    "use-sidecar": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.3.tgz",
+      "integrity": "sha512-ygJwGUBeQfWgDls7uTrlEDzJUUR67L8Rm14v/KfFtYCdHhtjHZx1Krb3DIQl3/Q5dJGfXLEQ02RY8BdNBv87SQ==",
+      "requires": {
+        "detect-node-es": "^1.0.0",
+        "tslib": "^1.9.3"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -40,10 +40,12 @@
     "mailto-link": "^1.0.0",
     "prop-types": "^15.7.2",
     "react-bootstrap": "^1.2.2",
+    "react-focus-on": "^3.5.0",
     "react-proptype-conditional-require": "^1.0.4",
     "react-responsive": "^6.1.1",
     "react-transition-group": "^4.0.0",
-    "sanitize-html": "^1.20.0"
+    "sanitize-html": "^1.20.0",
+    "tabbable": "^5.1.0"
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",

--- a/scss/edx/overrides/_buttons.scss
+++ b/scss/edx/overrides/_buttons.scss
@@ -2,7 +2,7 @@
   text-decoration: $link-decoration;
 
   &.hover,
-  &:hover, {
+  &:hover {
     text-decoration: $link-hover-decoration;
   }
 

--- a/scss/edx/overrides/_modals.scss
+++ b/scss/edx/overrides/_modals.scss
@@ -4,6 +4,6 @@
 }
 
 .modal-footer {
-  padding-bottom: 1.75rem;
+  padding-bottom: 0.75rem;
   padding-top: 0.75rem;
 }

--- a/scss/edx/overrides/_typography.scss
+++ b/scss/edx/overrides/_typography.scss
@@ -23,7 +23,7 @@ h3,
 h4,
 .h2,
 .h3,
-.h4, {
+.h4 {
   font-weight: $font-weight-semi-bold;
 }
 

--- a/src/Icon/index.jsx
+++ b/src/Icon/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 import newId from '../utils/newId';
@@ -13,12 +12,11 @@ function Icon(props) {
         className={props.className}
         aria-hidden={props.hidden}
       />
-      { props.screenReaderText
-        && (
-        <span className={classNames('sr-only')}>
+      {props.screenReaderText && (
+        <span className="sr-only">
           {props.screenReaderText}
         </span>
-        )}
+      )}
     </>
   );
 }
@@ -34,9 +32,9 @@ Icon.propTypes = {
   /** a boolean that determines the value of `aria-hidden` attribute on the Icon span, this value is `true` by default. */
   hidden: PropTypes.bool,
   // eslint-disable-next-line max-len
-  /** a string that will be used on a secondary span leveraging the `sr-only` style for screenreader only text, this value is `undefined` by default. This value is recommended for use unless the Icon is being used in a way that is purely decorative or provides no additional context for screen reader users. This field should be thought of the same way an `alt` attribute would be used for `image` tags.
+  /** a string or an element that will be used on a secondary span leveraging the `sr-only` style for screenreader only text, this value is `undefined` by default. This value is recommended for use unless the Icon is being used in a way that is purely decorative or provides no additional context for screen reader users. This field should be thought of the same way an `alt` attribute would be used for `image` tags.
    */
-  screenReaderText: PropTypes.string,
+  screenReaderText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 };
 
 Icon.defaultProps = {

--- a/src/Modal/Modal.scss
+++ b/src/Modal/Modal.scss
@@ -41,7 +41,12 @@
 }
 
 .modal-content {
-  max-height: 100%;
+  max-height: calc(100vh - (#{$spacer} * 2));
+
+  &:focus {
+    outline: 1px dotted;
+    outline: 5px auto -webkit-focus-ring-color;
+  }
 }
 
 .modal-header {

--- a/src/Modal/index.jsx
+++ b/src/Modal/index.jsx
@@ -249,13 +249,14 @@ class Modal extends React.Component {
   }
 
   render() {
-    if (this.el) {
-      return ReactDOM.createPortal(
-        this.renderModal(),
-        this.el,
-      );
+    if (!this.el) {
+      return null;
     }
-    return null;
+
+    return ReactDOM.createPortal(
+      this.renderModal(),
+      this.el,
+    );
   }
 }
 

--- a/src/Modal/index.jsx
+++ b/src/Modal/index.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import { FocusOn } from 'react-focus-on';
+import { tabbable } from 'tabbable';
 
 import { Button } from '..';
 import Icon from '../Icon';
@@ -14,16 +16,15 @@ class Modal extends React.Component {
     super(props);
 
     this.close = this.close.bind(this);
-    this.handleKeyDown = this.handleKeyDown.bind(this);
-    this.setFirstFocusableElement = this.setFirstFocusableElement.bind(this);
-    this.setCloseButton = this.setCloseButton.bind(this);
 
-    this.closeModalButtonId = newId('paragonCloseModalButton');
     this.headerId = newId();
-    this.el = document.createElement('div');
+    this.modalBodyRef = React.createRef();
 
-    // Sets true for IE11, false otherwise: https://stackoverflow.com/a/22082397/6620612
-    this.isIE11 = !!global.MSInputMethodContext && !!document.documentMode;
+    if (typeof document !== 'undefined') {
+      this.el = document.createElement('div');
+      // Sets true for IE11, false otherwise: https://stackoverflow.com/a/22082397/6620612
+      this.isIE11 = !!global.MSInputMethodContext && !!document.documentMode;
+    }
 
     this.state = {
       open: props.open,
@@ -31,39 +32,24 @@ class Modal extends React.Component {
   }
 
   componentDidMount() {
-    if (this.firstFocusableElement) {
-      this.firstFocusableElement.focus();
-    }
-    this.parentElement = document.querySelector(this.props.parentSelector);
+    const { parentSelector } = this.props;
+    this.parentElement = document.querySelector(parentSelector);
     if (this.parentElement === null) {
-      throw new Error(`Modal received invalid parentSelector: ${this.props.parentSelector}, no matching element found`);
+      throw new Error(`Modal received invalid parentSelector: ${parentSelector}, no matching element found`);
     }
     this.parentElement.appendChild(this.el);
   }
 
-  // eslint-disable-next-line react/no-deprecated
-  componentWillReceiveProps({ open }) {
-    if (open !== this.state.open) {
+  componentDidUpdate(prevProps, prevState) {
+    const { open } = this.props;
+    if (open !== prevProps.open || open !== prevState.open) {
+      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ open });
-    }
-  }
-
-  componentDidUpdate(prevState) {
-    if (this.state.open && !prevState.open) {
-      this.firstFocusableElement.focus();
     }
   }
 
   componentWillUnmount() {
     ReactDOM.unmountComponentAtNode(this.parentElement);
-  }
-
-  setFirstFocusableElement(input) {
-    this.firstFocusableElement = input;
-  }
-
-  setCloseButton(input) {
-    this.closeButton = input;
   }
 
   getVariantIconClassName() {
@@ -108,31 +94,25 @@ class Modal extends React.Component {
     );
   }
 
+  getTabbableBodyElements() {
+    if (this.modalBodyRef?.current) {
+      return tabbable(this.modalBodyRef.current);
+    }
+    return [];
+  }
+
+  isValidVariantStatus() {
+    const { variant } = this.props;
+    return Object.values(Variant.status).includes(variant.status);
+  }
+
   close(e) {
     if (e) {
       e.stopPropagation();
     }
 
-    if (!e || e.target.classList.contains('js-close-modal-on-click')) {
-      this.setState({ open: false });
-      this.props.onClose();
-    }
-  }
-
-  handleKeyDown(e) {
-    if (e.key === 'Escape') {
-      this.close();
-    } else if (e.key === 'Tab') {
-      if (e.shiftKey) {
-        if (e.target === this.firstFocusableElement) {
-          e.preventDefault();
-          this.closeButton.focus();
-        }
-      } else if (e.target === this.closeButton) {
-        e.preventDefault();
-        this.firstFocusableElement.focus();
-      }
-    }
+    this.setState({ open: false });
+    this.props.onClose();
   }
 
   renderButtons() {
@@ -141,7 +121,6 @@ class Modal extends React.Component {
       if (React.isValidElement(button)) {
         return React.cloneElement(button, {
           key: button.props.children,
-          onKeyDown: this.handleKeyDown,
         });
       }
 
@@ -151,7 +130,6 @@ class Modal extends React.Component {
         <Button.Deprecated
           {...buttonProps}
           key={label}
-          onKeyDown={this.handleKeyDown}
         >
           {label}
         </Button.Deprecated>
@@ -160,16 +138,16 @@ class Modal extends React.Component {
   }
 
   renderBody() {
-    const { variant } = this.props;
     let { body } = this.props;
 
     if (typeof body === 'string') {
       body = <p>{body}</p>;
     }
 
-    if (variant.status) {
+    if (this.isValidVariantStatus()) {
       body = this.getVariantGridBody(body);
     }
+
     return body;
   }
 
@@ -179,9 +157,21 @@ class Modal extends React.Component {
       dialogClassName,
       renderDefaultCloseButton,
       renderHeaderCloseButton,
+      buttons,
+      closeText,
+      title,
     } = this.props;
+
+    const hasTabbableElements = (
+      renderDefaultCloseButton
+      || renderHeaderCloseButton
+      || buttons.length > 0
+      || this.getTabbableBodyElements().length > 0
+    );
+    const renderModalFooter = renderDefaultCloseButton || buttons.length > 0;
+
     return (
-      <div>
+      <>
         <div
           className={classNames({
             'modal-backdrop': open,
@@ -193,7 +183,6 @@ class Modal extends React.Component {
         <div
           className={classNames(
             'modal',
-            'js-close-modal-on-click',
             {
               show: open,
               fade: !open,
@@ -202,7 +191,6 @@ class Modal extends React.Component {
             },
           )}
           role="presentation"
-          onMouseDown={this.close}
         >
           <div
             className={classNames(
@@ -214,54 +202,60 @@ class Modal extends React.Component {
             role="dialog"
             aria-modal
             aria-labelledby={this.headerId}
-            {...(!renderHeaderCloseButton ? { tabIndex: '-1' } : {})}
-            {...(!renderHeaderCloseButton ? { ref: this.setFirstFocusableElement } : {})}
           >
-            <div className="modal-content">
-              <div className="modal-header">
-                <h2 className="modal-title" id={this.headerId}>{this.props.title}</h2>
-                {renderHeaderCloseButton && (
-                  <Button.Deprecated
-                    className="p-1 js-close-modal-on-click"
-                    aria-labelledby={this.closeModalButtonId}
-                    onClick={this.close}
-                    inputRef={this.setFirstFocusableElement}
-                    onKeyDown={this.handleKeyDown}
-                  >
-                    <Icon className="fa fa-times js-close-modal-on-click" />
-                  </Button.Deprecated>
+            <FocusOn
+              enabled={open}
+              onClickOutside={this.close}
+              onEscapeKey={this.close}
+            >
+              <div
+                className="modal-content"
+                // if the modal doesn't contain any tabbable elements, make this element programmatically focusable.
+                {...(!hasTabbableElements ? { tabIndex: -1 } : {})}
+              >
+                <div className="modal-header">
+                  <h2 className="modal-title" id={this.headerId}>{title}</h2>
+                  {renderHeaderCloseButton && (
+                    <Button.Deprecated
+                      className="p-1"
+                      onClick={this.close}
+                    >
+                      <Icon className="fa fa-times" screenReaderText={closeText} />
+                    </Button.Deprecated>
+                  )}
+                </div>
+                <div className="modal-body" ref={this.modalBodyRef}>
+                  {this.renderBody()}
+                </div>
+                {renderModalFooter && (
+                  <div className="modal-footer">
+                    {renderDefaultCloseButton && (
+                      <Button
+                        variant="link"
+                        onClick={this.close}
+                      >
+                        {closeText}
+                      </Button>
+                    )}
+                    {this.renderButtons()}
+                  </div>
                 )}
               </div>
-              <div className="modal-body">
-                {this.renderBody()}
-              </div>
-              <div className="modal-footer">
-                {this.renderButtons()}
-                {renderDefaultCloseButton && (
-                  <Button.Deprecated
-                    id={this.closeModalButtonId}
-                    buttonType="secondary"
-                    className="js-close-modal-on-click"
-                    onClick={this.close}
-                    inputRef={this.setCloseButton}
-                    onKeyDown={this.handleKeyDown}
-                  >
-                    {this.props.closeText}
-                  </Button.Deprecated>
-                )}
-              </div>
-            </div>
+            </FocusOn>
           </div>
         </div>
-      </div>
+      </>
     );
   }
 
   render() {
-    return ReactDOM.createPortal(
-      this.renderModal(),
-      this.el,
-    );
+    if (this.el) {
+      return ReactDOM.createPortal(
+        this.renderModal(),
+        this.el,
+      );
+    }
+    return null;
   }
 }
 

--- a/www/src/pages/components/modal.mdx
+++ b/www/src/pages/components/modal.mdx
@@ -25,7 +25,7 @@ import SingleComponentStatus from '../../components/SingleComponentStatus';
 
 ##### Example Usage
 
-```jsx
+```jsx live
 class ModalWrapper extends React.Component {
   constructor(props) {
     super(props);
@@ -42,7 +42,6 @@ class ModalWrapper extends React.Component {
 
   resetModalWrapperState() {
     this.setState({ open: false });
-    this.button && this.button.focus();
   }
 
   render() {
@@ -63,15 +62,12 @@ class ModalWrapper extends React.Component {
           parentSelector={this.props.parentSelector}
           onClose={this.resetModalWrapperState}
           buttons={[
-            <Button variant="success">Green button!</Button>
+            <Button variant="success" data-autofocus>Green button!</Button>
           ]}
         />
         <Button
           onClick={this.openModal}
           variant="light"
-          inputRef={input => {
-            this.button = input;
-          }}
         >
           Click me to open a modal!
         </Button>


### PR DESCRIPTION
This PR updates the `Modal` component to:
* better handle focus management through the use of `react-focus-on` (and `react-focus-lock` under the hood). 
* re-order the default modal footer close button with the custom `buttons` passed in via a prop.
* fixes the docs site for the `Modal` page.
* removes a deprecated lifecycle method.

[Deploy Preview](https://deploy-preview-577--paragon-edx.netlify.app/components/modal)