### PR TITLE
feat: add brand core color and tertiary buttons

### DIFF
--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -355,6 +355,11 @@ $btn-focus-box-shadow:        $input-btn-focus-box-shadow !default;
 $btn-disabled-opacity:        .65 !default;
 $btn-active-box-shadow:       none;
 
+$btn-tertiary-color:          $gray-700 !default;
+$btn-tertiary-bg:             transparent !default;
+$btn-tertiary-hover-bg:       $light-500 !default;
+$btn-tertiary-active-bg:      $light-500 !default;
+
 $btn-link-disabled-color:     theme-color("gray", "light-text") !default;
 
 $btn-block-spacing-y:         .5rem !default;

--- a/scss/core/overrides/_buttons.scss
+++ b/scss/core/overrides/_buttons.scss
@@ -118,6 +118,32 @@ fieldset:disabled a.btn {
 }
 
 //
+// Tertiary buttons
+//
+
+.btn-tertiary {
+  $background: $btn-tertiary-bg;
+  $border: transparent;
+  $hover-background: $btn-tertiary-hover-bg;
+  $hover-border: transparent;
+  $active-background: $btn-tertiary-active-bg;
+  $active-border: transparent;
+
+  @include button-variant(
+    $background,
+    $border,
+    $hover-background,
+    $hover-border,
+    $active-background,
+    $active-border
+  );
+
+  color: $btn-tertiary-color;
+
+  @include button-focus(theme-color("primary", "focus"));
+}
+
+//
 // Link buttons
 //
 

--- a/scss/core/variables/_colors.scss
+++ b/scss/core/variables/_colors.scss
@@ -52,6 +52,7 @@ $colors: map-merge(
 );
 
 $primary: $blue !default;
+$brand: $primary !default;
 $success: $green !default;
 $info: $teal !default;
 $danger: $red !default;
@@ -63,6 +64,7 @@ $theme-colors: () !default;
 $theme-colors: map-merge(
   (
     "primary":    $primary,
+    "brand":      $brand,
     "success":    $success,
     "info":       $info,
     "warning":    $warning,
@@ -83,6 +85,16 @@ $primary-600: mix(black, $primary,  10%);
 $primary-700: mix(black, $primary,  20%);
 $primary-800: mix(black, $primary,  25%);
 $primary-900: mix(black, $primary,  30%);
+
+$brand-100: mix(white, $brand,  94%);
+$brand-200: mix(white, $brand,  75%);
+$brand-300: mix(white, $brand,  50%);
+$brand-400: mix(white, $brand,  25%);
+$brand-500: $brand;
+$brand-600: mix(black, $brand,  10%);
+$brand-700: mix(black, $brand,  20%);
+$brand-800: mix(black, $brand,  25%);
+$brand-900: mix(black, $brand,  30%);
 
 $success-100: mix(white, $success,  94%);
 $success-200: mix(white, $success,  75%);
@@ -168,6 +180,16 @@ $theme-color-levels: map-merge(
   "primary-700": $primary-700,
   "primary-800": $primary-800,
   "primary-900": $primary-900,
+
+  "brand-100": $brand-100,
+  "brand-200": $brand-200,
+  "brand-300": $brand-300,
+  "brand-400": $brand-400,
+  "brand-500": $brand-500,
+  "brand-600": $brand-600,
+  "brand-700": $brand-700,
+  "brand-800": $brand-800,
+  "brand-900": $brand-900,
 
   "success-100": $success-100,
   "success-200": $success-200,

--- a/www/src/pages/components/button.mdx
+++ b/www/src/pages/components/button.mdx
@@ -47,7 +47,7 @@ import SingleComponentStatus from '../../components/SingleComponentStatus';
   <Button variant="outline-danger">Danger</Button>{' '}
 </div>
 <div className="mb-3">
-  <Button variant="tertiary">Tertiary</Button>
+  <Button variant="tertiary">Tertiary</Button>{' '}
   <Button variant="light">Light</Button> <Button variant="dark">Dark</Button>{' '}
   <Button variant="outline-light">Light</Button>{' '}
   <Button variant="outline-dark">Dark</Button>

--- a/www/src/pages/components/button.mdx
+++ b/www/src/pages/components/button.mdx
@@ -47,6 +47,7 @@ import SingleComponentStatus from '../../components/SingleComponentStatus';
   <Button variant="outline-danger">Danger</Button>{' '}
 </div>
 <div className="mb-3">
+  <Button variant="tertiary">Tertiary</Button>
   <Button variant="light">Light</Button> <Button variant="dark">Dark</Button>{' '}
   <Button variant="outline-light">Light</Button>{' '}
   <Button variant="outline-dark">Dark</Button>

--- a/www/src/pages/components/button.mdx
+++ b/www/src/pages/components/button.mdx
@@ -34,14 +34,14 @@ import SingleComponentStatus from '../../components/SingleComponentStatus';
 <>
 <div className="mb-3">
   <Button variant="primary">Primary</Button>{' '}
-  <Button variant="secondary">Secondary</Button>{' '}
+  <Button variant="brand">Brand</Button>{' '}
   <Button variant="success">Success</Button>{' '}
   <Button variant="warning">Warning</Button>{' '}
   <Button variant="danger">Danger</Button>{' '}
 </div>
 <div className="mb-3">
   <Button variant="outline-primary">Primary</Button>{' '}
-  <Button variant="outline-secondary">Secondary</Button>{' '}
+  <Button variant="outline-brand">Brand</Button>{' '}
   <Button variant="outline-success">Success</Button>{' '}
   <Button variant="outline-warning">Warning</Button>{' '}
   <Button variant="outline-danger">Danger</Button>{' '}

--- a/www/src/pages/foundations/colors.jsx
+++ b/www/src/pages/foundations/colors.jsx
@@ -12,6 +12,7 @@ const utilityClasses = {
 const colors = [
   { themeName: 'gray', color: 'gray', unusedLevels: [] },
   { themeName: 'primary', color: 'blue', unusedLevels: [] },
+  { themeName: 'brand', color: 'blue', unusedLevels: [] },
   { themeName: 'success', color: 'green', unusedLevels: [] },
   { themeName: 'info', color: 'teal', unusedLevels: [] },
   { themeName: 'danger', color: 'red', unusedLevels: [] },
@@ -106,8 +107,8 @@ export default function ({ data }) {
         // $color_name-level <br/>
         $primary-100<br/>
         $primary-200<br/>
-        $primary-300<br/>
-        $primary-400
+        $brand-100<br/>
+        $brand-200
       </code>
 
       <h6>Mixin (deprecated)</h6>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1615421/99851894-e470b580-2b4d-11eb-95a5-bf0fa492a7ce.png)

Add brand as a core theme-color. By default it is the same as primary.
```
$brand-100, $brand-200, $brand-300, $brand-400, $brand-500, $brand-600, $brand-700, $brand-800, $brand-900
```

Add a tertiary btn variant. It is configurable with these new theme variables:
```
$btn-tertiary-color:          $gray-700 !default;
$btn-tertiary-bg:             transparent !default;
$btn-tertiary-hover-bg:       $light-500 !default;
$btn-tertiary-active-bg:      $light-500 !default;
```