### PR TITLE
docs: use brand-edx.org theme for themed doc site

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -4,17 +4,12 @@ const path = require('path');
 const sass = require('node-sass');
 const css = require('css');
 
-const themeLocation = 'USE_BRAND_THEME' in process.env
-  ? path.resolve(__dirname, '../scss/edx')
-  : path.resolve(__dirname, 'src/scss/stub-theme');
-
 exports.onCreateWebpackConfig = ({ actions }) => {
   actions.setWebpackConfig({
     resolve: {
       alias: {
         '~paragon-react': path.resolve(__dirname, '../src'),
         '~paragon-style': path.resolve(__dirname, '../scss'),
-        '~paragon-theme': themeLocation,
         // Prevent multiple copies of react getting loaded
         // paragon react components would naturally import
         // react and react-dom from the node_modules folder

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -1259,9 +1259,9 @@
       }
     },
     "@edx/brand": {
-      "version": "npm:@edx/brand-edx.org@1.2.3",
-      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-1.2.3.tgz",
-      "integrity": "sha512-nRSI+RJWs3f/EECeJwX28TMu23+QMt3TF4kpWC6N39nSXKroCaAP8d2haYl1rJFBZxfxlUB+TRyywB49PRdDNQ=="
+      "version": "npm:@edx/brand-openedx@1.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
+      "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
     },
     "@emotion/cache": {
       "version": "10.0.29",

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -1258,6 +1258,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@edx/brand": {
+      "version": "npm:@edx/brand-edx.org@1.2.3",
+      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-1.2.3.tgz",
+      "integrity": "sha512-nRSI+RJWs3f/EECeJwX28TMu23+QMt3TF4kpWC6N39nSXKroCaAP8d2haYl1rJFBZxfxlUB+TRyywB49PRdDNQ=="
+    },
     "@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",

--- a/www/package.json
+++ b/www/package.json
@@ -3,6 +3,7 @@
   "description": "Paragon Pattern Library Documentation",
   "version": "1.0.0",
   "dependencies": {
+    "@edx/brand": "npm:@edx/brand-edx.org@^1.2.3",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@mdx-js/mdx": "^1.6.16",
     "@mdx-js/react": "^1.6.16",
@@ -35,10 +36,11 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build --prefix-paths",
-    "build:with-theme": "USE_BRAND_THEME=1 gatsby build --prefix-paths",
+    "build:with-theme": "THEME=npm:@edx/brand-edx.org@1.x npm run install-theme && gatsby build --prefix-paths",
     "clean": "gatsby clean",
     "develop": "gatsby develop",
-    "develop:with-theme": "USE_BRAND_THEME=1 gatsby develop",
+    "install-theme": "npm install \"@edx/brand@${THEME}\"",
+    "develop:with-theme": "THEME=npm:@edx/brand-edx.org@1.x npm run install-theme && gatsby develop",
     "lint": "eslint --ext .js --ext .jsx .",
     "start": "npm run develop",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/www/package.json
+++ b/www/package.json
@@ -3,7 +3,7 @@
   "description": "Paragon Pattern Library Documentation",
   "version": "1.0.0",
   "dependencies": {
-    "@edx/brand": "npm:@edx/brand-edx.org@^1.2.3",
+    "@edx/brand": "npm:@edx/brand-openedx@1.x",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@mdx-js/mdx": "^1.6.16",
     "@mdx-js/react": "^1.6.16",
@@ -39,7 +39,7 @@
     "build:with-theme": "THEME=npm:@edx/brand-edx.org@1.x npm run install-theme && gatsby build --prefix-paths",
     "clean": "gatsby clean",
     "develop": "gatsby develop",
-    "install-theme": "npm install \"@edx/brand@${THEME}\"",
+    "install-theme": "npm install \"@edx/brand@${THEME}\" --no-save",
     "develop:with-theme": "THEME=npm:@edx/brand-edx.org@1.x npm run install-theme && gatsby develop",
     "lint": "eslint --ext .js --ext .jsx .",
     "start": "npm run develop",

--- a/www/src/scss/index.scss
+++ b/www/src/scss/index.scss
@@ -1,12 +1,9 @@
 @import "~font-awesome/css/font-awesome.min.css";
 
-// These imports are non-standard because of how this documentation
-// site consumes Paragon inside the same project. Refer to the docs
-// for the standard method of inclusion.
-@import "~paragon-theme/fonts.scss";
-@import "~paragon-theme/_variables.scss";
+@import "~@edx/brand/paragon/fonts.scss";
+@import "~@edx/brand/paragon/variables.scss";
 @import "~paragon-style/core/core.scss";
-@import "~paragon-theme/_overrides.scss";
+@import "~@edx/brand/paragon/overrides.scss";
 
 @import "./layout";
 @import "./hero";

--- a/www/src/scss/stub-theme/_overrides.scss
+++ b/www/src/scss/stub-theme/_overrides.scss
@@ -1,2 +1,0 @@
-// Use this file to define style overrides for @edx/paragon
-// This file is included after all Paragon styles, but should generally avoid using private mixins in Paragon.

--- a/www/src/scss/stub-theme/_variables.scss
+++ b/www/src/scss/stub-theme/_variables.scss
@@ -1,6 +1,0 @@
-// Variables
-//
-// Variables should follow the `$component-state-property-size` formula for
-// consistent naming. Ex: $nav-link-disabled-color and $modal-content-box-shadow-xs.
-//
-// See @edx/paragon/scss/core/_variables.scss for options.

--- a/www/src/scss/stub-theme/fonts.scss
+++ b/www/src/scss/stub-theme/fonts.scss
@@ -1,1 +1,0 @@
-// Add webfont definitions here


### PR DESCRIPTION
- Use npm aliases for swapping the themes
- Now uses the brand-openedx theme by default