### PR TITLE
fix: update style of buttons in toast

### DIFF
--- a/src/IconButton/_IconButton.scss
+++ b/src/IconButton/_IconButton.scss
@@ -13,17 +13,21 @@ $icon-button-margin: .75rem !default;
 $icon-button-refwrapper-size: $icon-button-hover-size + $icon-button-margin !default;
 
 $icon-color-invert: white !default;
+$icon-button-bg: transparent !default;
+$icon-button-invert-bg: transparent !default;
 
 .iconbutton-hover {
     width: $icon-button-hover-size;
     height: $icon-button-hover-size;
     border-radius: $icon-button-hover-size;
     display: flex;
+    flex-shrink: 0;
     justify-content: center;
     align-items: center;
     text-align: center;
     position: relative;
-    margin: 0;
+    border: none;
+
     cursor: pointer;
 
     &:active {
@@ -33,7 +37,7 @@ $icon-color-invert: white !default;
     @each $name, $color in $icon-button-colors {
         &__#{$name} {
             @include button-focus($color);
-            background-color: $icon-color-invert;
+            background-color: $icon-button-bg;
             color: $color;
         }
         &__#{$name}:hover {
@@ -42,7 +46,7 @@ $icon-color-invert: white !default;
         }
         &__#{$name}--invert {
             @include button-focus($icon-color-invert);
-            background-color: $color;
+            background-color: $icon-button-invert-bg;
             color: $icon-color-invert;
 
             &:hover {
@@ -50,14 +54,5 @@ $icon-color-invert: white !default;
                 color: $color;
             }
         }
-    }
-}
-
-.iconbutton-refwrapper {
-    height: $icon-button-refwrapper-size;
-    width: $icon-button-refwrapper-size;
-    padding: $icon-button-margin * 0.5;
-    button {
-        border: none;
     }
 }

--- a/src/IconButton/index.jsx
+++ b/src/IconButton/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -10,25 +11,30 @@ const IconButton = ({
   iconClassNames,
   onClick,
   variant,
+  ...attrs
 }) => {
   const invertedHoverClass = invertColors ? `iconbutton-hover__${variant}--invert` : '';
   const invertedIconClass = invertColors ? `iconbutton__${variant}--invert` : '';
 
   return (
-    <div className="iconbutton-refwrapper">
-      <button
-        aria-label={alt}
-        className={`iconbutton-hover ${invertedHoverClass} iconbutton-hover__${variant}`}
-        onClick={onClick}
-        type="button"
-      >
-        <FontAwesomeIcon
-          className={`iconbutton iconbutton__${variant} ${invertedIconClass} ${iconClassNames}`}
-          icon={icon}
-          alt={alt}
-        />
-      </button>
-    </div>
+    <button
+      {...attrs}
+      aria-label={alt}
+      className={classNames(
+        'iconbutton-hover',
+        invertedHoverClass,
+        `iconbutton-hover__${variant}`,
+        attrs.className,
+      )}
+      onClick={onClick}
+      type="button"
+    >
+      <FontAwesomeIcon
+        className={`iconbutton iconbutton__${variant} ${invertedIconClass} ${iconClassNames}`}
+        icon={icon}
+        alt={alt}
+      />
+    </button>
   );
 };
 

--- a/src/Toast/Toast.test.jsx
+++ b/src/Toast/Toast.test.jsx
@@ -19,7 +19,7 @@ describe('<Toast />', () => {
       >
         Success message.
       </Toast>));
-    const toastLink = wrapper.find('a.btn-toast-action');
+    const toastLink = wrapper.find('a.btn');
     expect(toastLink).toHaveLength(1);
   });
   it('renders optional action as button', () => {
@@ -33,7 +33,7 @@ describe('<Toast />', () => {
       >
         Success message.
       </Toast>));
-    const toastButton = wrapper.find('button.btn-toast-action');
+    const toastButton = wrapper.find('button.btn');
     expect(toastButton).toHaveLength(1);
   });
   it('autohide is set to false on onMouseOver and true on onMouseLeave', () => {

--- a/src/Toast/_Toast.scss
+++ b/src/Toast/_Toast.scss
@@ -1,5 +1,3 @@
-$toast-paragraph-padding: .4375rem;
-
 .toast {
   background-color: $toast-background-color;
   box-shadow: $toast-box-shadow;
@@ -28,8 +26,6 @@ $toast-paragraph-padding: .4375rem;
       font-size: $small-font-size;
       margin: 0;
       max-width: 320px;
-      // padding-top: $toast-paragraph-padding * 2;
-      // padding-bottom: $toast-paragraph-padding;
     }
     & + .btn {
       margin-top: 1rem;

--- a/src/Toast/_Toast.scss
+++ b/src/Toast/_Toast.scss
@@ -5,40 +5,34 @@ $toast-paragraph-padding: .4375rem;
   box-shadow: $toast-box-shadow;
   margin: 0;
   min-width: $toast-max-width;
-  padding: .5rem .5rem .5rem 1.25rem;
+  padding: 1.25rem;
   position: relative;
-  radius: $toast-border-radius;
+  border-radius: $toast-border-radius;
   z-index: 2;
-
+  .toast-header-btn-container {
+    margin: -.25rem -.5rem;
+    align-self: flex-start;
+  }
   .btn {
-    margin-top: 1rem;
-    margin-bottom: 0.75rem;
-
-    &-toast-action {
-      background-color: $dark;
-      color: $white;
-      border-color: $white;
-
-      &:hover {
-        background-color: $white;
-        color: $dark;
-        border-color: $white;
-      }
-    }
+    margin-top: .75rem;
+    align-self: flex-start;
   }
 
   .toast-header {
-    align-items: start;
+    align-items: center;
     border-bottom: 0;
     justify-content: space-between;
     padding: 0;
 
     p {
       font-size: $small-font-size;
-      margin: 0 1.5rem 0 0;
+      margin: 0;
       max-width: 320px;
-      padding-top: $toast-paragraph-padding * 2;
-      padding-bottom: $toast-paragraph-padding;
+      // padding-top: $toast-paragraph-padding * 2;
+      // padding-bottom: $toast-paragraph-padding;
+    }
+    & + .btn {
+      margin-top: 1rem;
     }
   }
 

--- a/src/Toast/index.jsx
+++ b/src/Toast/index.jsx
@@ -40,7 +40,7 @@ function Toast({
         </div>
         {action && (
           <Button
-            as={action.href ? 'a' : Button}
+            as={action.href ? 'a' : 'button'}
             href={action.href}
             onClick={action.onClick}
             size="sm"

--- a/src/Toast/index.jsx
+++ b/src/Toast/index.jsx
@@ -27,14 +27,16 @@ function Toast({
           className="toast-header"
         >
           <p className="small">{children}</p>
-          <IconButton
-            alt={closeLabel}
-            className="m-0"
-            icon={faTimes}
-            onClick={() => (onClose())}
-            variant="dark"
-            invertColors
-          />
+          <div className="toast-header-btn-container">
+            <IconButton
+              alt={closeLabel}
+              className="align-self-start"
+              icon={faTimes}
+              onClick={() => (onClose())}
+              variant="primary"
+              invertColors
+            />
+          </div>
         </div>
         {action && (
           <Button
@@ -42,7 +44,7 @@ function Toast({
             href={action.href}
             onClick={action.onClick}
             size="sm"
-            variant="toast-action"
+            variant="inverse-outline-primary"
           >
             {action.label}
           </Button>


### PR DESCRIPTION
Update toast spacing, alignment, and button style.
![image](https://user-images.githubusercontent.com/1615421/101205401-92df2500-363b-11eb-8671-de9ded14827b.png)

Update icon buttons to have transparent backgrounds by default. This is configurable via the new SASS vars:
```
$icon-button-bg: transparent !default;
$icon-button-invert-bg: transparent !default;
```

