### PR TITLE
feat: add inline button size

### DIFF
--- a/scss/core/overrides/_buttons.scss
+++ b/scss/core/overrides/_buttons.scss
@@ -252,6 +252,14 @@ fieldset:disabled a.btn {
   }
 }
 
+.btn-inline {
+  display: inline;
+  line-height: inherit;
+  font-size: inherit;
+  vertical-align: baseline;
+  padding: 0 .25em;
+}
+
 // Specificity overrides
 input[type="submit"],
 input[type="reset"],

--- a/scss/core/overrides/_buttons.scss
+++ b/scss/core/overrides/_buttons.scss
@@ -253,7 +253,6 @@ fieldset:disabled a.btn {
 }
 
 .btn-inline {
-  display: inline;
   line-height: inherit;
   font-size: inherit;
   vertical-align: baseline;

--- a/www/src/pages/components/button.mdx
+++ b/www/src/pages/components/button.mdx
@@ -88,6 +88,24 @@ import SingleComponentStatus from '../../components/SingleComponentStatus';
       Small button
     </Button>
   </div>
+  <div>
+    <Button variant="link" size="inline">Inline button</Button>
+    <Button variant="link" size="inline">Inline button</Button>
+  </div>
+</>
+```
+
+##### When to use the inline size
+
+Use inline size buttons for when a button sits with a line of text.
+
+```jsx live
+<>
+  <p>
+    <span className="mr-1">2 items selected.</span>
+    <Button variant="link" size="inline" className="mr-1">Select all</Button>
+    <Button variant="link" size="inline">Clear</Button>
+  </p>
 </>
 ```
 


### PR DESCRIPTION
A new size for buttons: Inline means the button size is dictated by surrounding text so that it can fit comfortably aligned inline.

![image](https://user-images.githubusercontent.com/1615421/104064840-a2b6cf80-51cc-11eb-9d9e-e663e086814e.png)
