### PR TITLE
fix: remove border from inline buttons

### DIFF
--- a/scss/core/overrides/_buttons.scss
+++ b/scss/core/overrides/_buttons.scss
@@ -253,11 +253,10 @@ fieldset:disabled a.btn {
 }
 
 .btn-inline {
-  line-height: inherit;
+  line-height: calc(#{$line-height-base}em - #{2 * $btn-border-width});
   font-size: inherit;
   vertical-align: baseline;
   padding: 0 .25em;
-  border: none;
 }
 
 // Specificity overrides

--- a/scss/core/overrides/_buttons.scss
+++ b/scss/core/overrides/_buttons.scss
@@ -257,6 +257,7 @@ fieldset:disabled a.btn {
   font-size: inherit;
   vertical-align: baseline;
   padding: 0 .25em;
+  border: none;
 }
 
 // Specificity overrides


### PR DESCRIPTION
This prevents inline buttons from being a border width taller than surrounding text.