### PR TITLE
fix: include icons directory in npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "files": [
     "/dist",
+    "/icons",
     "/src",
     "/scss"
   ],


### PR DESCRIPTION
Add icons directory which was missing in the package json files array: https://docs.npmjs.com/cli/v6/configuring-npm/package-json#files