### PR TITLE
feat: add extra small font size

### DIFF
--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -238,6 +238,7 @@ $lead-font-size:              $font-size-base * 1.25 !default;
 $lead-font-weight:            null !default;
 
 $small-font-size:             87.5% !default;
+$x-small-font-size:             75% !default;
 
 $text-muted:                  theme-color("gray", "light-text") !default;
 

--- a/scss/core/extensions/_utilities.scss
+++ b/scss/core/extensions/_utilities.scss
@@ -11,3 +11,7 @@ $color-levels: 100, 200, 300, 400, 500, 600, 700, 800, 900;
     }
   }
 }
+
+.x-small {
+  font-size: $x-small-font-size;
+}

--- a/www/src/pages/foundations/typography.jsx
+++ b/www/src/pages/foundations/typography.jsx
@@ -19,13 +19,16 @@ const measuredTypeProps = {
     const fontFamily = measurements['font-family'] ?
       measurements['font-family'].split(',')[0] : null;
     const weight = weightLabels[measurements['font-weight']];
+    // only one significant digit if needed
+    const fontSize = Math.round(Number.parseFloat(measurements['font-size']) * 10) / 10;
+    const lineHeight = Math.round(Number.parseFloat(measurements['line-height']) * 10) / 10;
 
     return (
       <p className="m-0 text-muted">
         <span className="mr-2">
           {fontFamily} {weight}
         </span>
-        {measurements['font-size']} / {measurements['line-height']}
+        {fontSize}px / {lineHeight}px
       </p>
     );
   },
@@ -43,7 +46,7 @@ export default function () {
         <tbody>
           <tr>
             <th colSpan="3">
-              <h2>Headings</h2>
+              <h2 className="mt-3">Headings</h2>
               <p className="font-weight-normal">Headings all share a line-height of 1.25em</p>
             </th>
           </tr>
@@ -73,8 +76,7 @@ export default function () {
         <tbody>
           <tr>
             <th colSpan="3">
-              <h2>Body</h2>
-              <p className="font-weight-normal">Body text line-heights are 1.5em</p>
+              <h2 className="mt-3">Body</h2>
             </th>
           </tr>
           <tr>
@@ -124,7 +126,7 @@ export default function () {
         <tbody>
           <tr>
             <th colSpan="3">
-              <h2>Forms</h2>
+              <h2 className="mt-3">Forms</h2>
               <p className="font-weight-normal">Form text line-heights are the same as headings: 1.25em.</p>
             </th>
           </tr>

--- a/www/src/pages/foundations/typography.jsx
+++ b/www/src/pages/foundations/typography.jsx
@@ -109,6 +109,16 @@ export default function () {
               <code>.small</code>
             </td>
           </tr>
+          <tr>
+            <td colSpan="2">
+              <MeasuredItem {...measuredTypeProps}>
+                <p className="x-small m-0">Extra Small Body</p>
+              </MeasuredItem>
+            </td>
+            <td>
+              <code>.x-small</code>
+            </td>
+          </tr>
         </tbody>
 
         <tbody>


### PR DESCRIPTION
[PAR-260](https://openedx.atlassian.net/browse/PAR-260)
Adds a `.x-small` css utility class for extra small type size. Introduces a theme variable: `$x-small-font-size: 75% !default;`

The screenshot below is the appearance of the typography section with https://github.com/edx/brand-edx.org/pull/26 brand update applied.
![image](https://user-images.githubusercontent.com/1615421/105365262-11802980-5bcc-11eb-88f1-eeeff378f74e.png)
