### PR TITLE
fix: add missing bootstrap variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3670,9 +3670,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.2.tgz",
-      "integrity": "sha512-vlGn0bcySYl/iV+BGA544JkkZP5LB3jsmkeKLFQakCOwCM3AOk7VkldBz4jrzSe+Z0Ezn99NVXa1o45cQY4R6A=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
+      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw=="
     },
     "bottleneck": {
       "version": "2.19.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
     "airbnb-prop-types": "^2.12.0",
-    "bootstrap": "^4.4.1",
+    "bootstrap": "^4.6.0",
     "classnames": "^2.2.6",
     "email-prop-type": "^3.0.0",
     "font-awesome": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
     "airbnb-prop-types": "^2.12.0",
-    "bootstrap": "^4.6.0",
+    "bootstrap": "4.6.0",
     "classnames": "^2.2.6",
     "email-prop-type": "^3.0.0",
     "font-awesome": "^4.7.0",

--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -574,6 +574,7 @@ $table-cell-padding:          .75rem !default;
 $table-cell-padding-sm:       .3rem !default;
 $table-caption-color:         $text-muted !default;
 $table-border-color:          $border-color !default;
+$table-th-font-weight:        null !default;
 
 // Z-index master list
 //

--- a/src/Dropdown/_variables.scss
+++ b/src/Dropdown/_variables.scss
@@ -4,6 +4,7 @@
 // Dropdown menu container and contents.
 
 $dropdown-min-width:                10rem !default;
+$dropdown-padding-x:                0 !default;
 $dropdown-padding-y:                .5rem !default;
 $dropdown-spacer:                   .125rem !default;
 $dropdown-font-size:                $font-size-base !default;

--- a/src/Navbar/_variables.scss
+++ b/src/Navbar/_variables.scss
@@ -18,6 +18,8 @@ $navbar-toggler-padding-x:          .75rem !default;
 $navbar-toggler-font-size:          $font-size-lg !default;
 $navbar-toggler-border-radius:      $btn-border-radius !default;
 
+$navbar-nav-scroll-max-height:      75vh !default;
+
 $navbar-dark-color:                 rgba($white, .5) !default;
 $navbar-dark-hover-color:           rgba($white, .75) !default;
 $navbar-dark-active-color:          $white !default;

--- a/src/Pagination/_variables.scss
+++ b/src/Pagination/_variables.scss
@@ -28,3 +28,6 @@ $pagination-active-border-color:    $pagination-active-bg !default;
 $pagination-disabled-color:         theme-color("gray", "light-text") !default;
 $pagination-disabled-bg:            $white !default;
 $pagination-disabled-border-color:  theme-color("gray", "disabled-border") !default;
+
+$pagination-border-radius-sm:       $border-radius-sm !default;
+$pagination-border-radius-lg:       $border-radius-lg !default;


### PR DESCRIPTION
Bootstrap has continued to add and use new SCSS variables since Bootstrap 4.4.1. Since we no longer pull in all of Bootstraps variables (in order for us to colocate them with component styles) this is causing SASS compilation errors.

This PR pulls in all new variables as of bootstrap 4.6.0 and pins the version.