### PR TITLE
fix: pin uncontrollable to preserve es5 output

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "react-table": "^7.6.1",
     "react-transition-group": "^4.0.0",
     "sanitize-html": "^1.20.0",
-    "tabbable": "^4.0.0"
+    "tabbable": "^4.0.0",
+    "uncontrollable": "7.1.1"
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",


### PR DESCRIPTION
Uncontrollable, a React Bootstrap dependency released a new version 7.2.0 yesterday that publishes in es6. This is causing downstream problems in micro-frontends that need to support IE11 and non es6 browsers. Pinning uncontrollable to 7.1.1 in Paragon will likely solve the issue in the near term since React Bootstrap's package.json requires `"uncontrollable": "^7.0.0",`

Issue in uncontrollable here: https://github.com/jquense/uncontrollable/issues/51