### PR TITLE
fix: remove alert link styling

### DIFF
--- a/src/Alert/Alert.scss
+++ b/src/Alert/Alert.scss
@@ -55,6 +55,8 @@
 
 @each $color, $value in $theme-colors {
   .alert-#{$color} {
-    @include alert-variant(theme-color($color, "background"), theme-color($color, "border"), theme-color("gray", "dark-text"));
+    color: inherit;
+    background-color: theme-color($color, "background");
+    border-color: theme-color($color, "border");
   }
 }

--- a/src/Alert/Alert.scss
+++ b/src/Alert/Alert.scss
@@ -48,6 +48,12 @@
   }
 }
 
+.alert-link {
+  text-decoration: underline;
+  &:hover {
+    text-decoration: none;
+  }
+}
 
 // Alternate styles
 //

--- a/src/Alert/_variables.scss
+++ b/src/Alert/_variables.scss
@@ -8,7 +8,7 @@ $alert-padding-y:                   .75rem !default;
 $alert-padding-x:                   1.25rem !default;
 $alert-margin-bottom:               1rem !default;
 $alert-border-radius:               $border-radius !default;
-$alert-link-font-weight:            $font-weight-bold !default;
+$alert-link-font-weight:            $font-weight-normal !default;
 $alert-border-width:                $border-width !default;
 
 $alert-bg-level:                    -10 !default;


### PR DESCRIPTION
Swap bootstraps alert mixin with just the styles required in Paragon. Fixes https://openedx.atlassian.net/browse/PAR-257