### PR TITLE
feat: add additional typography styles

### DIFF
--- a/scss/core/_typography.scss
+++ b/scss/core/_typography.scss
@@ -38,9 +38,13 @@
 p > a[href]:not(.btn),
 a.inline-link {
   text-decoration: $inline-link-decoration;
+  text-decoration-line: $inline-link-decoration;
+  text-decoration-color: $inline-link-decoration-color;
   color: $inline-link-color;
   &:hover {
     color: $inline-link-hover-color;
     text-decoration: $inline-link-hover-decoration;
+    text-decoration-line: $inline-link-hover-decoration;
+    text-decoration-color: $inline-link-hover-decoration-color;
   }
 }

--- a/scss/core/_typography.scss
+++ b/scss/core/_typography.scss
@@ -34,3 +34,7 @@
   font-family: $font-family-monospace;
   margin-bottom: 0 !important;
 }
+
+.inline-link {
+  text-decoration: underline;
+}

--- a/scss/core/_typography.scss
+++ b/scss/core/_typography.scss
@@ -28,3 +28,9 @@
 @media (max-width: map-get($grid-breakpoints, "sm")) {
   @include mobile-type;
 }
+
+.heading-label {
+  text-transform: uppercase;
+  font-family: $font-family-monospace;
+  margin-bottom: 0 !important;
+}

--- a/scss/core/_typography.scss
+++ b/scss/core/_typography.scss
@@ -37,14 +37,38 @@
 
 p > a[href]:not(.btn),
 a.inline-link {
+  color: $inline-link-color;
   text-decoration: $inline-link-decoration;
   text-decoration-line: $inline-link-decoration;
   text-decoration-color: $inline-link-decoration-color;
-  color: $inline-link-color;
   &:hover {
     color: $inline-link-hover-color;
     text-decoration: $inline-link-hover-decoration;
     text-decoration-line: $inline-link-hover-decoration;
     text-decoration-color: $inline-link-hover-decoration-color;
+  }
+}
+
+a.muted-link {
+  color: $muted-link-color;
+  text-decoration: $muted-link-decoration;
+
+  &:hover {
+    color: $muted-link-hover-color;
+    text-decoration: $muted-link-hover-decoration;
+  }
+
+  p > &[href]:not(.btn),
+  &.inline-link {
+    color: $muted-inline-link-color;
+    text-decoration: $muted-inline-link-decoration;
+    text-decoration-line: $muted-inline-link-decoration;
+    text-decoration-color: $muted-inline-link-decoration-color;
+    &:hover {
+      color: $muted-inline-link-hover-color;
+      text-decoration: $muted-inline-link-hover-decoration;
+      text-decoration-line: $muted-inline-link-hover-decoration;
+      text-decoration-color: $muted-inline-link-hover-decoration-color;
+    }
   }
 }

--- a/scss/core/_typography.scss
+++ b/scss/core/_typography.scss
@@ -35,6 +35,12 @@
   margin-bottom: 0 !important;
 }
 
-.inline-link {
-  text-decoration: underline;
+p > a[href]:not(.btn),
+a.inline-link {
+  text-decoration: $inline-link-decoration;
+  color: $inline-link-color;
+  &:hover {
+    color: $inline-link-hover-color;
+    text-decoration: $inline-link-hover-decoration;
+  }
 }

--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -395,6 +395,10 @@ $link-color:                              theme-color("primary") !default;
 $link-decoration:                         none !default;
 $link-hover-color:                        darken($link-color, 15%) !default;
 $link-hover-decoration:                   underline !default;
+$inline-link-color:                       theme-color("primary") !default;
+$inline-link-decoration:                  underline !default;
+$inline-link-hover-color:                 darken($link-color, 15%) !default;
+$inline-link-hover-decoration:            none !default;
 // Darken percentage for links with `.text-*` class (e.g. `.text-success`)
 $emphasized-link-hover-darken-percentage: 15% !default;
 

--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -391,14 +391,16 @@ $body-color:                theme-color("gray", "dark-text") !default;
 //
 // Style anchor elements.
 
-$link-color:                              theme-color("primary") !default;
+$link-color:                              $info-500 !default;
 $link-decoration:                         none !default;
 $link-hover-color:                        darken($link-color, 15%) !default;
 $link-hover-decoration:                   underline !default;
-$inline-link-color:                       theme-color("primary") !default;
+$inline-link-color:                       $info-500 !default;
 $inline-link-decoration:                  underline !default;
-$inline-link-hover-color:                 darken($link-color, 15%) !default;
-$inline-link-hover-decoration:            none !default;
+$inline-link-decoration-color:            rgba($inline-link-color, .3) !default;
+$inline-link-hover-color:                 darken($inline-link-color, 15%) !default;
+$inline-link-hover-decoration:            underline !default;
+$inline-link-hover-decoration-color:      rgba($inline-link-hover-color, 1) !default;
 // Darken percentage for links with `.text-*` class (e.g. `.text-success`)
 $emphasized-link-hover-darken-percentage: 15% !default;
 

--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -401,6 +401,18 @@ $inline-link-decoration-color:            rgba($inline-link-color, .3) !default;
 $inline-link-hover-color:                 darken($inline-link-color, 15%) !default;
 $inline-link-hover-decoration:            underline !default;
 $inline-link-hover-decoration-color:      rgba($inline-link-hover-color, 1) !default;
+
+$muted-link-color:                              $primary-500 !default;
+$muted-link-decoration:                         none !default;
+$muted-link-hover-color:                        darken($muted-link-color, 15%) !default;
+$muted-link-hover-decoration:                   underline !default;
+$muted-inline-link-color:                       $primary-500 !default;
+$muted-inline-link-decoration:                  underline !default;
+$muted-inline-link-decoration-color:            rgba($muted-inline-link-color, .3) !default;
+$muted-inline-link-hover-color:                 darken($muted-inline-link-color, 15%) !default;
+$muted-inline-link-hover-decoration:            underline !default;
+$muted-inline-link-hover-decoration-color:      rgba($muted-inline-link-hover-color, 1) !default;
+
 // Darken percentage for links with `.text-*` class (e.g. `.text-success`)
 $emphasized-link-hover-darken-percentage: 15% !default;
 

--- a/www/src/pages/foundations/typography.jsx
+++ b/www/src/pages/foundations/typography.jsx
@@ -58,12 +58,12 @@ export default function () {
             <tr>
               <td>
                 <MeasuredItem {...measuredTypeProps}>
-                  <p className={`m-0 h${headingSize}`}>Header {headingSize}</p>
+                  <p className={`m-0 h${headingSize}`}>Heading {headingSize}</p>
                 </MeasuredItem>
               </td>
               <td className="mobile-type">
                 <MeasuredItem {...measuredTypeProps}>
-                  <p className={`m-0 h${headingSize}`}>Header {headingSize}</p>
+                  <p className={`m-0 h${headingSize}`}>Heading {headingSize}</p>
                 </MeasuredItem>
               </td>
               <td>
@@ -71,6 +71,17 @@ export default function () {
               </td>
             </tr>
           ))}
+          <tr>
+            <td colSpan="2">
+              <MeasuredItem {...measuredTypeProps}>
+                <p className="heading-label">Heading Label</p>
+              </MeasuredItem>
+              A heading label is usually paired with and proceeds a Heading.
+            </td>
+            <td>
+              <code>.heading-label</code>
+            </td>
+          </tr>
         </tbody>
         <tbody>
           <tr>

--- a/www/src/pages/foundations/typography.jsx
+++ b/www/src/pages/foundations/typography.jsx
@@ -188,7 +188,7 @@ export default function () {
               <a className="muted-link" href="#">Muted, Standalone Link</a>
             </td>
             <td>
-              <small>The default style for <code>a</code> tags that don't appear in a <code>p</code> tag.</small>
+              <small><code>.muted-link</code> not in a <code>p</code> tag.</small>
             </td>
           </tr>
           <tr>
@@ -196,7 +196,7 @@ export default function () {
               <p>An <a className="muted-link inline-link" href="#">muted, inline link</a> in a sentence.</p>
             </td>
             <td>
-              <small>For links inside a <code>p</code> or with the <code>.inline-link</code> class name.</small>
+              <small>For <code>.muted-link</code> links inside a <code>p</code> or with the <code>.inline-link</code> class name.</small>
             </td>
           </tr>
         </tbody>

--- a/www/src/pages/foundations/typography.jsx
+++ b/www/src/pages/foundations/typography.jsx
@@ -183,6 +183,22 @@ export default function () {
               <small>For links inside a <code>p</code> or with the <code>.inline-link</code> class name.</small>
             </td>
           </tr>
+          <tr>
+            <td colSpan="2">
+              <a className="muted-link" href="#">Muted, Standalone Link</a>
+            </td>
+            <td>
+              <small>The default style for <code>a</code> tags that don't appear in a <code>p</code> tag.</small>
+            </td>
+          </tr>
+          <tr>
+            <td colSpan="2">
+              <p>An <a className="muted-link inline-link" href="#">muted, inline link</a> in a sentence.</p>
+            </td>
+            <td>
+              <small>For links inside a <code>p</code> or with the <code>.inline-link</code> class name.</small>
+            </td>
+          </tr>
         </tbody>
       </table>
 

--- a/www/src/pages/foundations/typography.jsx
+++ b/www/src/pages/foundations/typography.jsx
@@ -161,48 +161,6 @@ export default function () {
             </tr>
           ))}
         </tbody>
-        <tbody>
-          <tr>
-            <th colSpan="3">
-              <h2 className="mt-3">Forms</h2>
-            </th>
-          </tr>
-          <tr>
-            <th colSpan="2">Desktop & Mobile</th>
-            <th>CSS Class</th>
-          </tr>
-          <tr>
-            <td colSpan="2">
-              <MeasuredItem {...measuredTypeProps}>
-                <label className="m-0">Label</label>{/* eslint-disable-line */}
-              </MeasuredItem>
-            </td>
-            <td>
-              <small>Same as h6</small>
-            </td>
-          </tr>
-          <tr>
-            <td colSpan="2">
-              <MeasuredItem {...measuredTypeProps}>
-                <p className="m-0">Helper</p>
-              </MeasuredItem>
-            </td>
-            <td>
-              <small>Same as body</small>
-            </td>
-          </tr>
-          <tr>
-            <td colSpan="2">
-              <MeasuredItem {...measuredTypeProps}>
-                <p className="small m-0">Helper Small</p>
-              </MeasuredItem>
-            </td>
-            <td>
-              <code>.small</code><br />
-              <small>Same as small body</small>
-            </td>
-          </tr>
-        </tbody>
       </table>
 
 

--- a/www/src/pages/foundations/typography.jsx
+++ b/www/src/pages/foundations/typography.jsx
@@ -47,7 +47,6 @@ export default function () {
           <tr>
             <th colSpan="3">
               <h2 className="mt-3">Headings</h2>
-              <p className="font-weight-normal">Headings all share a line-height of 1.25em</p>
             </th>
           </tr>
           <tr>
@@ -127,7 +126,6 @@ export default function () {
           <tr>
             <th colSpan="3">
               <h2 className="mt-3">Forms</h2>
-              <p className="font-weight-normal">Form text line-heights are the same as headings: 1.25em.</p>
             </th>
           </tr>
           <tr>

--- a/www/src/pages/foundations/typography.jsx
+++ b/www/src/pages/foundations/typography.jsx
@@ -161,6 +161,29 @@ export default function () {
             </tr>
           ))}
         </tbody>
+        <tbody>
+          <tr>
+            <th colSpan="3">
+              <h2 className="mt-3">Links</h2>
+            </th>
+          </tr>
+          <tr>
+            <td colSpan="2">
+              <a href="#">Standalone Link</a>
+            </td>
+            <td>
+              <small>The default style for <code>a</code> tags that don't appear in a <code>p</code> tag.</small>
+            </td>
+          </tr>
+          <tr>
+            <td colSpan="2">
+              <p>An <a className="inline-link" href="#">inline link</a> in a sentence.</p>
+            </td>
+            <td>
+              <small>For links inside a <code>p</code> or with the <code>.inline-link</code> class name.</small>
+            </td>
+          </tr>
+        </tbody>
       </table>
 
 

--- a/www/src/pages/foundations/typography.jsx
+++ b/www/src/pages/foundations/typography.jsx
@@ -121,7 +121,35 @@ export default function () {
             </td>
           </tr>
         </tbody>
-
+        <tbody>
+          <tr>
+            <th colSpan="3">
+              <h2 className="mt-3">Display</h2>
+            </th>
+          </tr>
+          <tr>
+            <th>Desktop</th>
+            <th>Mobile</th>
+            <th>CSS Class</th>
+          </tr>
+          {[1, 2, 3, 4].map(displaySize => (
+            <tr>
+              <td>
+                <MeasuredItem {...measuredTypeProps}>
+                  <p className={`m-0 display-${displaySize}`}>Display {displaySize}</p>
+                </MeasuredItem>
+              </td>
+              <td className="mobile-type">
+                <MeasuredItem {...measuredTypeProps}>
+                  <p className={`m-0 display-${displaySize}`}>Display {displaySize}</p>
+                </MeasuredItem>
+              </td>
+              <td>
+                <code>.display-{displaySize}</code>
+              </td>
+            </tr>
+          ))}
+        </tbody>
         <tbody>
           <tr>
             <th colSpan="3">


### PR DESCRIPTION
**Introduce `.inline-link` and `.muted-link` styles**

Adds the concepts of standalone and inline link styling. Adds SCSS variables for theming:
```
$inline-link-color:                       $info-500 !default;
$inline-link-decoration:                  underline !default;
$inline-link-decoration-color:            rgba($inline-link-color, .3) !default;
$inline-link-hover-color:                 darken($inline-link-color, 15%) !default;
$inline-link-hover-decoration:            underline !default;
$inline-link-hover-decoration-color:      rgba($inline-link-hover-color, 1) !default;

$muted-link-color:                              $primary-500 !default;
$muted-link-decoration:                         none !default;
$muted-link-hover-color:                        darken($muted-link-color, 15%) !default;
$muted-link-hover-decoration:                   underline !default;
$muted-inline-link-color:                       $primary-500 !default;
$muted-inline-link-decoration:                  underline !default;
$muted-inline-link-decoration-color:            rgba($muted-inline-link-color, .3) !default;
$muted-inline-link-hover-color:                 darken($muted-inline-link-color, 15%) !default;
$muted-inline-link-hover-decoration:            underline !default;
$muted-inline-link-hover-decoration-color:      rgba($muted-inline-link-hover-color, 1) !default;
```

**Introduce `.heading-label` style**

A label that is usually paired with and proceeds a heading tag. For edX these are set in Roboto Mono and are uppercase.

---

**Documentation updates**

- Remove useless form typography documentation
- Add `.display-{1|2|3|4}` documentation
- Remove incorrect, hard coded information about heading line heights