### PR TITLE
feat: dependency injection of analytics from external packages (e.g., frontend-platform)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3901,6 +3901,12 @@
         "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
@@ -3929,6 +3935,12 @@
         "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -4977,9 +4989,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.0.tgz",
+      "integrity": "sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ==",
       "dev": true
     },
     "core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^24.5.0",
     "babel-loader": "^8.0.6",
+    "core-js": "^3.9.0",
     "coveralls": "^3.0.3",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.11.2",
@@ -89,6 +90,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-test-renderer": "^16.8.6",
+    "regenerator-runtime": "^0.13.7",
     "sass-loader": "^7.1.0",
     "semantic-release": "^17.0.0"
   },

--- a/src/AvatarButton/__snapshots__/AvatarButton.test.jsx.snap
+++ b/src/AvatarButton/__snapshots__/AvatarButton.test.jsx.snap
@@ -5,6 +5,7 @@ Array [
   <button
     className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-sm btn btn-tertiary btn-sm"
     disabled={false}
+    onClick={[Function]}
     type="button"
   >
     <span
@@ -21,6 +22,7 @@ Array [
   <button
     className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md btn btn-tertiary btn-md"
     disabled={false}
+    onClick={[Function]}
     type="button"
   >
     <span
@@ -37,6 +39,7 @@ Array [
   <button
     className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-lg btn btn-tertiary btn-lg"
     disabled={false}
+    onClick={[Function]}
     type="button"
   >
     <span
@@ -53,6 +56,7 @@ Array [
   <button
     className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-sm pgn__avatar-button-hide-label btn btn-tertiary btn-sm"
     disabled={false}
+    onClick={[Function]}
     type="button"
   >
     <span
@@ -68,6 +72,7 @@ Array [
   <button
     className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md pgn__avatar-button-hide-label btn btn-tertiary btn-md"
     disabled={false}
+    onClick={[Function]}
     type="button"
   >
     <span
@@ -83,6 +88,7 @@ Array [
   <button
     className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-lg pgn__avatar-button-hide-label btn btn-tertiary btn-lg"
     disabled={false}
+    onClick={[Function]}
     type="button"
   >
     <span

--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -1,5 +1,51 @@
-import Button from 'react-bootstrap/Button';
+import React, { createRef, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import ButtonBase from 'react-bootstrap/Button';
+
+import { useHandleLogClick } from '../hooks/analytics';
+
 import ButtonDeprecated from './deprecated';
+
+const Button = React.forwardRef(({
+  children,
+  analyticEvents,
+  ...attrs
+}, forwardedRef) => {
+  const ref = useMemo(() => forwardedRef || createRef(), [forwardedRef]);
+
+  const handleLogClick = useHandleLogClick({
+    event: analyticEvents?.onClick,
+    onClick: attrs?.onClick,
+    ref,
+  });
+
+  return (
+    <ButtonBase
+      ref={ref}
+      {...attrs}
+      onClick={handleLogClick}
+    >
+      {children}
+    </ButtonBase>
+  );
+});
+
+Button.propTypes = {
+  children: PropTypes.node.isRequired,
+  onClick: PropTypes.func,
+  analyticEvents: PropTypes.shape({
+    onClick: PropTypes.shape({
+      name: PropTypes.string,
+      properties: PropTypes.shape({}),
+      dispatchers: PropTypes.arrayOf(PropTypes.func),
+    }),
+  }),
+};
+
+Button.defaultProps = {
+  onClick: undefined,
+  analyticEvents: undefined,
+};
 
 Button.Deprecated = ButtonDeprecated;
 

--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -1,4 +1,4 @@
-import React, { createRef, useMemo } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import ButtonBase from 'react-bootstrap/Button';
 
@@ -9,14 +9,13 @@ import ButtonDeprecated from './deprecated';
 const Button = React.forwardRef(({
   children,
   analyticEvents,
+  onClick,
   ...attrs
 }, forwardedRef) => {
-  const ref = useMemo(() => forwardedRef || createRef(), [forwardedRef]);
-
-  const handleLogClick = useHandleLogClick({
+  const [handleLogClick, ref] = useHandleLogClick({
     event: analyticEvents?.onClick,
-    onClick: attrs?.onClick,
-    ref,
+    onClick,
+    forwardedRef,
   });
 
   return (
@@ -32,7 +31,9 @@ const Button = React.forwardRef(({
 
 Button.propTypes = {
   children: PropTypes.node.isRequired,
+  /** specifies the callback function when the button is clicked */
   onClick: PropTypes.func,
+  /** specifies the analytic events to dispatch for when the user interacts with this component, e.g. `onClick`. */
   analyticEvents: PropTypes.shape({
     onClick: PropTypes.shape({
       name: PropTypes.string,

--- a/src/Hyperlink/Hyperlink.test.jsx
+++ b/src/Hyperlink/Hyperlink.test.jsx
@@ -60,7 +60,7 @@ describe('event handlers are triggered correctly', () => {
 
   beforeEach(() => { spy = jest.fn(); });
 
-  it('should fire onClick', async () => {
+  it('should fire onClick', () => {
     const wrapper = mount(<Hyperlink {...props} onClick={spy} />);
     expect(spy).toHaveBeenCalledTimes(0);
     wrapper.simulate('click');

--- a/src/Hyperlink/Hyperlink.test.jsx
+++ b/src/Hyperlink/Hyperlink.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import classNames from 'classnames';
 
-import Hyperlink from './index';
+import Hyperlink from '.';
 
 const content = 'content';
 const destination = 'destination';
@@ -29,7 +29,6 @@ describe('correct rendering', () => {
     expect(wrapper.prop('children')).toEqual([content, undefined]);
     expect(wrapper.prop('href')).toEqual(destination);
     expect(wrapper.prop('target')).toEqual('_self');
-    expect(wrapper.prop('onClick')).toEqual(onClick);
 
     expect(wrapper.find('span')).toHaveLength(0);
     expect(wrapper.find('i')).toHaveLength(0);
@@ -38,13 +37,12 @@ describe('correct rendering', () => {
   it('renders external Hyperlink', () => {
     const wrapper = mount(<Hyperlink {...externalLinkProps} />);
 
-    expect(wrapper.find('span')).toHaveLength(2);
+    expect(wrapper.find('span')).toHaveLength(1);
 
-    const icon = wrapper.find('span').at(1);
+    const icon = wrapper.find('span').at(0);
 
     expect(icon.prop('aria-hidden')).toEqual(false);
-    expect(icon.prop('className'))
-      .toEqual(classNames('fa', 'fa-external-link'));
+    expect(icon.prop('className')).toEqual(classNames('fa', 'fa-external-link'));
     expect(icon.prop('aria-label')).toEqual(externalLinkAlternativeText);
     expect(icon.prop('title')).toEqual(externalLinkTitle);
   });
@@ -62,7 +60,7 @@ describe('event handlers are triggered correctly', () => {
 
   beforeEach(() => { spy = jest.fn(); });
 
-  it('should fire onClick', () => {
+  it('should fire onClick', async () => {
     const wrapper = mount(<Hyperlink {...props} onClick={spy} />);
     expect(spy).toHaveBeenCalledTimes(0);
     wrapper.simulate('click');

--- a/src/Hyperlink/index.jsx
+++ b/src/Hyperlink/index.jsx
@@ -1,4 +1,4 @@
-import React, { createRef, useMemo } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import isRequiredIf from 'react-proptype-conditional-require';
@@ -15,14 +15,13 @@ const Hyperlink = React.forwardRef(({
   onClick,
   externalLinkAlternativeText,
   externalLinkTitle,
+  rel,
   ...attrs
 }, forwardedRef) => {
-  const ref = useMemo(() => forwardedRef || createRef(), [forwardedRef]);
-
-  const handleLogClick = useHandleLogClick({
+  const [handleLogClick, ref] = useHandleLogClick({
     event: analyticEvents?.onClick,
     onClick,
-    ref,
+    forwardedRef,
   });
 
   let externalLinkIcon;
@@ -30,8 +29,7 @@ const Hyperlink = React.forwardRef(({
   if (target === '_blank') {
     // Add this rel attribute to prevent Reverse Tabnabbing
     Object.assign(attrs, {
-      ...attrs,
-      rel: attrs.rel ? `noopener ${attrs.rel}` : 'noopener',
+      rel: rel ? `noopener ${rel}` : 'noopener',
     });
 
     externalLinkIcon = (
@@ -65,6 +63,7 @@ const Hyperlink = React.forwardRef(({
 
 Hyperlink.defaultProps = {
   target: '_self',
+  rel: undefined,
   onClick: () => {},
   externalLinkAlternativeText: 'Opens in a new window',
   externalLinkTitle: 'Opens in a new window',
@@ -78,6 +77,10 @@ Hyperlink.propTypes = {
   /** specifies where the link should open. The default behavior is `_self`, which means that the URL will be loaded into the same browsing context as the current one. If the target is `_blank` (opening a new window) `rel='noopener'` will be added to the anchor tag to prevent any potential [reverse tabnabbing attack](https://www.owasp.org/index.php/Reverse_Tabnabbing).
    */
   target: PropTypes.string,
+  /** specifies the relationship between the current document and the linked document; the
+   * `noopener` value is automatically added if `target` is "_blank".
+   */
+  rel: PropTypes.string,
   /** specifies the callback function when the link is clicked */
   onClick: PropTypes.func,
   // eslint-disable-next-line max-len
@@ -92,6 +95,7 @@ Hyperlink.propTypes = {
     PropTypes.string,
     props => props.target === '_blank',
   ),
+  /** specifies the analytic events to dispatch for when the user interacts with this component, e.g. `onClick`. */
   analyticEvents: PropTypes.shape({
     onClick: PropTypes.shape({
       name: PropTypes.string,

--- a/src/ParagonProvider/index.jsx
+++ b/src/ParagonProvider/index.jsx
@@ -1,0 +1,37 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+
+export const ParagonContext = React.createContext({});
+
+const ParagonProvider = ({
+  analytics,
+  children,
+}) => {
+  // ``contextValue`` must be memoized such that re-renders of ParagonProvider do
+  // not trigger erroneous updates of the context value.
+  const contextValue = useMemo(
+    () => ({
+      analytics,
+    }),
+    [analytics],
+  );
+
+  return (
+    <ParagonContext.Provider value={contextValue}>
+      {children}
+    </ParagonContext.Provider>
+  );
+};
+
+ParagonProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+  analytics: PropTypes.shape({
+    sendTrackEvent: PropTypes.func,
+  }),
+};
+
+ParagonProvider.defaultProps = {
+  analytics: undefined,
+};
+
+export default ParagonProvider;

--- a/src/hooks/analytics.jsx
+++ b/src/hooks/analytics.jsx
@@ -1,0 +1,57 @@
+import { useContext, useMemo } from 'react';
+
+import { ParagonContext } from '../ParagonProvider';
+
+export const useAnalytics = () => {
+  const { analytics } = useContext(ParagonContext) || {};
+  return analytics;
+};
+
+export const useHandleLogClick = ({
+  event, onClick, ref,
+}) => {
+  const analytics = useAnalytics();
+
+  const trackedRef = useMemo(() => ref?.current, [ref?.current]);
+  const { name, properties, dispatchers } = event || {};
+
+  const sendEventToDispatchers = () => {
+    if (!dispatchers) {
+      return;
+    }
+    dispatchers.filter(dispatcher => typeof dispatcher === 'function').forEach((dispatch) => {
+      dispatch(name, properties);
+    });
+  };
+
+  const handleLogClick = (e) => {
+    if (event) {
+      // handle clicked anchor links that open in same tab by adding a slight delay
+      // to the page redirect to allow enough time for an analytics event to
+      // be dispatched.
+      if (trackedRef?.href && trackedRef?.target !== '_blank') {
+        e.preventDefault();
+
+        analytics.sendTrackEvent(name, properties);
+        sendEventToDispatchers(dispatchers);
+
+        setTimeout(() => {
+          global.location.href = trackedRef.href;
+        }, [300]);
+
+        return;
+      }
+
+      // if ``trackedRef`` is not an anchor link (e.g., a button), dispatch the
+      // analytic event immediately.
+      analytics.sendTrackEvent(name, properties);
+      sendEventToDispatchers(dispatchers);
+    }
+
+    if (onClick) {
+      onClick(e);
+    }
+  };
+
+  return handleLogClick;
+};

--- a/src/hooks/analytics.jsx
+++ b/src/hooks/analytics.jsx
@@ -4,6 +4,8 @@ import {
 
 import { ParagonContext } from '../ParagonProvider';
 
+export const ANALYTICS_TIMEOUT_MS = 300;
+
 /**
  * Returns the ``analytics`` key stored in ParagonProvider's context
  */
@@ -78,8 +80,8 @@ export const useHandleLogClick = ({
         e.preventDefault();
         dispatchAnalyticEvents();
         setTimeout(() => {
-          global.location.href = ref?.current?.href;
-        }, [300]);
+          global.location.href = ref.current.href;
+        }, [ANALYTICS_TIMEOUT_MS]);
         return;
       }
 

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,0 +1,2 @@
+export { default as useWindowSize } from './useWindowSize';
+export { default as useToggle } from './useToggle';

--- a/src/hooks/useWindowSize.jsx
+++ b/src/hooks/useWindowSize.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 
-function useWindowSize() {
+export default function useWindowSize() {
   // Initialize state with undefined width/height so server and client renders match
   // Learn more here: https://joshwcomeau.com/react/the-perils-of-rehydration/
   const [windowSize, setWindowSize] = useState({
@@ -30,5 +30,3 @@ function useWindowSize() {
 
   return windowSize;
 }
-
-export default useWindowSize;

--- a/src/index.js
+++ b/src/index.js
@@ -113,11 +113,20 @@ export { default as TableFooter } from './DataTable/TableFooter';
 export { default as CardView } from './DataTable/CardView';
 export { default as ToggleButton, ToggleButtonGroup } from './ToggleButton';
 export { default as Variant } from './utils/constants';
-export { default as useWindowSize } from './hooks/useWindowSize';
-export { default as useToggle } from './hooks/useToggle';
+
+// Custom hooks
+export {
+  useToggle,
+  useWindowSize,
+} from './hooks';
 
 // Pass through any needed whole third-party library functionality
 // useTable for example is needed to use the DataTable component seamlessly
 // rather than setting a peer dependency in this project, we opt to tightly
 // couple these dependencies by passing through needed functionality.
 export { useTable } from 'react-table';
+
+// ``ParagonProvider`` is a HOC that allows consumers of @edx/paragon to inject dependencies
+// to enable dispatching analytics events from components, i18n, and logging using services
+// from @edx/frontend-platform.
+export { default as ParagonProvider } from './ParagonProvider';

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -1,3 +1,6 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 

--- a/www/src/pages/components/hyperlink.mdx
+++ b/www/src/pages/components/hyperlink.mdx
@@ -5,8 +5,7 @@ status: 'Needs Work'
 designStatus: 'Done'
 devStatus: 'To Do'
 notes: |
-  Improve prop naming. Deprecate content prop.
-  Use React.forwardRef for ref forwarding.
+  Improve prop naming. Deprecate content and destination prop.
 ---
 
 import { graphql } from 'gatsby';

--- a/www/src/pages/components/hyperlink.mdx
+++ b/www/src/pages/components/hyperlink.mdx
@@ -22,7 +22,7 @@ import SingleComponentStatus from '../../components/SingleComponentStatus';
 ##### minimal usage
 
 ```jsx live
-<Hyperlink href="https://en.wikipedia.org/wiki/Hyperlink">edX.org</Hyperlink>
+<Hyperlink destination="https://en.wikipedia.org/wiki/Hyperlink">edX.org</Hyperlink>
 ```
 
 ##### with blank target


### PR DESCRIPTION
See https://github.com/edx/frontend-platform/pull/148 for usage of `Paragon` as a provider component in the frontend-platform example app. Otherwise, read on for the details!

This top-level `Paragon` component, containing an injected analytics service from frontend-platform, is made available to any other Paragon component via React's Context API, without having the consumers of these components do anything special beyond wrapping their entire app in the `Paragon` component, and passing the `dependencies` object that frontend-platform gives frontend devs (see linked PR above).

This PR demonstrates how `Button` would be modified in Paragon to use the injected analytics service from frontend-platform to dispatch an event to Segment to track that a Button was clicked.

A benefit to this approach using the Context API is that consumers of Paragon would only need to wrap their apps in the `Paragon` HOC once and not think about tracking usage again. It also allows tracking to be opt-in.

**Testing instructions**
* Checkout #620 and  https://github.com/edx/frontend-platform/pull/148 locally.
* Use the `module.config.js` approach from frontend-build (see docs) to alias the Paragon dependency in frontend-platform to your local copy (note: you may use the `src` directory in your module.config.js file if you want hot reloading to work on Paragon at the same time as running the frontend-platform example app!)
* Run the frontend-platform example app and click some buttons and/or links.

**Open questions**
1. Is there another viable solution that doesn't require a `Paragon` HOC to do dependency injection (playing devil's advocate on this approach)?
2. What information might be useful to send to Segment as it relates to the design system (e.g., what design system analytics would be valuable for us to know about usage of Paragon components by users across the edX ecosystem?) Would sending through a copy of the component name, its attributes, active URL, etc. make sense (e.g., could see how many clicks we get for brand variant buttons vs. primary, etc.)?
3. Is sending events to Segment the best approach to collect this data? Given the tools we have today, I think so? It's pretty convenient to query Segment events from Snowflake to generate any reports we may need. But can Segment handle significantly more events in our current plan (don't know if we have a quota)?
4. When should we log info about a component? a) when user interacts with it in some way (e.g., clicks); b) when the component mounts to the DOM.
6. Would this same approach work for other dependency injections from frontend-platform such as for logging and i18n?
7. What would it take to get frontend-platform to do preview deploys of it's example app to Netlify like Paragon?