### PR TITLE
feat: new sheet component

### DIFF
--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -584,6 +584,8 @@ $table-th-font-weight:        null !default;
 $zindex-dropdown:                   1000 !default;
 $zindex-sticky:                     1020 !default;
 $zindex-fixed:                      1030 !default;
+$zindex-sheet-backdrop:             1031 !default;
+$zindex-sheet:                      1032 !default;
 $zindex-modal-backdrop:             1040 !default;
 $zindex-modal:                      1050 !default;
 $zindex-popover:                    1060 !default;

--- a/src/Sheet/Sheet.scss
+++ b/src/Sheet/Sheet.scss
@@ -9,11 +9,13 @@
   &.hidden {
     display: none;
   }
+  z-index: $zindex-sheet-backdrop;
 }
 .pgn__sheet-component {
   position: fixed;
   padding: 20px;
   background-color: white;
+  z-index: $zindex-sheet;
   &.pgn__sheet__dark {
     background-color: rgb(0,38,43);
     color: rgb(242,240,239);

--- a/src/Sheet/Sheet.scss
+++ b/src/Sheet/Sheet.scss
@@ -5,7 +5,6 @@
   position: fixed;
   top: 0px;
   left: 0px;
-  font-size: 18px;
   &.hidden {
     display: none;
   }
@@ -13,12 +12,12 @@
 }
 .pgn__sheet-component {
   position: fixed;
-  padding: 20px;
+  padding: 1.25rem;
   background-color: white;
   z-index: $zindex-sheet;
   &.pgn__sheet__dark {
-    background-color: rgb(0,38,43);
-    color: rgb(242,240,239);
+    background-color: $primary-500;
+    color: $light-300;
   }
   &.bottom {
     bottom: 0px;

--- a/src/Sheet/Sheet.scss
+++ b/src/Sheet/Sheet.scss
@@ -1,0 +1,50 @@
+.pgn__sheet-skrim {
+  width: 100%;
+  height: 100%;
+  background-color: rgba(196,196,196,0.5);
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  font-size: 18px;
+  &.hidden {
+    display: none;
+  }
+}
+.pgn__sheet-component {
+  position: fixed;
+  padding: 20px;
+  background-color: white;
+  &.pgn__sheet__dark {
+    background-color: rgb(0,38,43);
+    color: rgb(242,240,239);
+  }
+  &.bottom {
+    bottom: 0px;
+    box-shadow: 0px -4px 10px 0px rgba(0,0,0,0.15);
+    box-shadow: 0px -8px 16px 0px rgba(0,0,0,0.15);
+  }
+  &.top {
+    top: 0px;
+    box-shadow: 0px 4px 10px 0px rgba(0,0,0,0.15);
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.15);
+  }
+  &.left {
+    left: 0px;
+    box-shadow: 4px 0px 10px 0px rgba(0,0,0,0.15);
+    box-shadow: 8px 0px 16px 0px rgba(0,0,0,0.15);
+  }
+  &.right {
+    right: 0px;
+    box-shadow: -4px 0px 10px 0px rgba(0,0,0,0.15);
+    box-shadow: -8px 0px 16px 0px rgba(0,0,0,0.15);
+  }
+
+  &.bottom, &.top {
+    width: 100%;
+    left: 0px;
+  }
+  &.left, &.right {
+    height: 100%;
+    top: 0px;
+  }
+}

--- a/src/Sheet/Sheet.test.jsx
+++ b/src/Sheet/Sheet.test.jsx
@@ -1,12 +1,25 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { mount } from 'enzyme';
 import Sheet, { POSITIONS, VARIANTS } from './index';
 
 /* eslint-disable react/prop-types */
-jest.mock('./SheetContainer', () => (props) => (
-  <sheet-container>{props.children}</sheet-container>
-));
+jest.mock('./SheetContainer', () => (props) => {
+  const { children, ...otherProps } = props;
+  return (
+    <sheet-container {...otherProps}>
+      {children}
+    </sheet-container>
+  );
+});
+
+jest.mock('react-focus-on', () => ({
+  FocusOn: (props) => {
+    const { children, ...otherProps } = props;
+    return (
+      <focus-on {...otherProps}>{children}</focus-on>
+    );
+  },
+}));
 
 const testContent = (<div className="sheet-content">Hi</div>);
 
@@ -35,12 +48,5 @@ describe('<Sheet />', () => {
   it('returns empty render iff show is false', () => {
     expect(renderJSON(<Sheet show={false} />)).toEqual(null);
     expect(renderJSON(<Sheet />)).not.toEqual(null);
-  });
-
-  it('blocks clicks through scrim when blocking===true', () => {
-    const wrapper = mount(<Sheet blocking>{testContent}</Sheet>);
-    const stopPropagation = jest.fn();
-    wrapper.find('.pgn__sheet-skrim').simulate('click', { stopPropagation });
-    expect(stopPropagation).toHaveBeenCalled();
   });
 });

--- a/src/Sheet/Sheet.test.jsx
+++ b/src/Sheet/Sheet.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
+import Sheet, { POSITIONS, VARIANTS } from './index';
+
+/* eslint-disable react/prop-types */
+jest.mock('./SheetContainer', () => (props) => (
+  <sheet-container>{props.children}</sheet-container>
+));
+
+const testContent = (<div className="sheet-content">Hi</div>);
+
+const renderJSON = (jsxContent) => renderer.create(jsxContent).toJSON();
+
+describe('<Sheet />', () => {
+  describe('snapshots', () => {
+    test('default args snapshot: bottom, show, light', () => {
+      const el = renderJSON(<Sheet>{testContent}</Sheet>);
+      expect(el).toMatchSnapshot();
+    });
+
+    test('blocking, left snapshot', () => {
+      expect(
+        renderJSON(<Sheet blocking position={POSITIONS.left} />),
+      ).toMatchSnapshot();
+    });
+
+    test('dark, right snapshot', () => {
+      expect(
+        renderJSON(<Sheet position={POSITIONS.right} variant={VARIANTS.dark} />),
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('returns empty render iff show is false', () => {
+    expect(renderJSON(<Sheet show={false} />)).toEqual(null);
+    expect(renderJSON(<Sheet />)).not.toEqual(null);
+  });
+
+  it('blocks clicks through scrim when blocking===true', () => {
+    const wrapper = mount(<Sheet blocking>{testContent}</Sheet>);
+    const stopPropagation = jest.fn();
+    wrapper.find('.pgn__sheet-skrim').simulate('click', { stopPropagation });
+    expect(stopPropagation).toHaveBeenCalled();
+  });
+});

--- a/src/Sheet/SheetContainer.jsx
+++ b/src/Sheet/SheetContainer.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+
+class SheetContainer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.sheetRootName = 'sheet-root';
+    if (typeof document === 'undefined') {
+      this.rootElement = null;
+    } else if (document.getElementById(this.sheetRootName)) {
+      this.rootElement = document.getElementById(this.sheetRootName);
+    } else {
+      const rootElement = document.createElement('div');
+      rootElement.setAttribute('id', this.sheetRootName);
+      rootElement.setAttribute('class', 'sheet-container');
+      this.rootElement = document.body.appendChild(rootElement);
+    }
+  }
+
+  render() {
+    if (this.rootElement) {
+      return ReactDOM.createPortal(
+        this.props.children,
+        this.rootElement,
+      );
+    }
+    return null;
+  }
+}
+
+SheetContainer.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default SheetContainer;

--- a/src/Sheet/SheetContainer.test.jsx
+++ b/src/Sheet/SheetContainer.test.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import SheetContainer from './SheetContainer';
+
+const childId1 = 'sheet-container-TEST-child1';
+const childId2 = 'sheet-container-TEST-child2';
+const childContent1 = 'SoMe TExt';
+const childContent2 = 'OThER teXT';
+
+const child1 = (<div id={childId1}>{childContent1}</div>);
+const child2 = (<div id={childId2}>{childContent2}</div>);
+
+describe('<SheetContainer />', () => {
+  it('adds itself to the dom if none exist', () => {
+    mount(<SheetContainer>{child1}</SheetContainer>);
+    const rootEl = document.getElementById('sheet-root');
+    expect(rootEl).not.toBeNull();
+    expect(rootEl.classList.contains('sheet-container')).toEqual(true);
+    const childEl = rootEl.querySelector(`#${childId1}`);
+    expect(childEl.innerHTML).toEqual(childContent1);
+  });
+
+  it('only adds itself once, when invoked multiple times', () => {
+    mount(<SheetContainer>{child1}</SheetContainer>);
+    mount(<SheetContainer>{child2}</SheetContainer>);
+    const rootEls = document.querySelectorAll('#sheet-root');
+    expect(rootEls.length).toBeGreaterThan(0);
+    const childEl1 = rootEls[0].querySelector(`#${childId1}`);
+    expect(childEl1.innerHTML).toEqual(childContent1);
+    const childEl2 = rootEls[0].querySelector(`#${childId2}`);
+    expect(childEl2.innerHTML).toEqual(childContent2);
+  });
+});

--- a/src/Sheet/SheetContainer.test.jsx
+++ b/src/Sheet/SheetContainer.test.jsx
@@ -24,7 +24,7 @@ describe('<SheetContainer />', () => {
     mount(<SheetContainer>{child1}</SheetContainer>);
     mount(<SheetContainer>{child2}</SheetContainer>);
     const rootEls = document.querySelectorAll('#sheet-root');
-    expect(rootEls.length).toBeGreaterThan(0);
+    expect(rootEls.length).toEqual(1);
     const childEl1 = rootEls[0].querySelector(`#${childId1}`);
     expect(childEl1.innerHTML).toEqual(childContent1);
     const childEl2 = rootEls[0].querySelector(`#${childId2}`);

--- a/src/Sheet/__snapshots__/Sheet.test.jsx.snap
+++ b/src/Sheet/__snapshots__/Sheet.test.jsx.snap
@@ -4,19 +4,22 @@ exports[`<Sheet /> snapshots blocking, left snapshot 1`] = `
 <sheet-container>
   <div
     className="pgn__sheet-skrim"
-    onClick={[Function]}
     role="presentation"
   />
-  <div
-    aria-atomic="true"
-    aria-live="polite"
-    className="pgn__sheet-component pgn__sheet__light left"
-    role="alert"
+  <focus-on
+    enabled={true}
   >
     <div
-      className="pgn__sheet-content"
-    />
-  </div>
+      aria-atomic="true"
+      aria-live="polite"
+      className="pgn__sheet-component pgn__sheet__light left"
+      role="alert"
+    >
+      <div
+        className="pgn__sheet-content"
+      />
+    </div>
+  </focus-on>
 </sheet-container>
 `;
 
@@ -24,19 +27,22 @@ exports[`<Sheet /> snapshots dark, right snapshot 1`] = `
 <sheet-container>
   <div
     className="pgn__sheet-skrim hidden"
-    onClick={[Function]}
     role="presentation"
   />
-  <div
-    aria-atomic="true"
-    aria-live="polite"
-    className="pgn__sheet-component pgn__sheet__dark right"
-    role="alert"
+  <focus-on
+    enabled={false}
   >
     <div
-      className="pgn__sheet-content"
-    />
-  </div>
+      aria-atomic="true"
+      aria-live="polite"
+      className="pgn__sheet-component pgn__sheet__dark right"
+      role="alert"
+    >
+      <div
+        className="pgn__sheet-content"
+      />
+    </div>
+  </focus-on>
 </sheet-container>
 `;
 
@@ -44,24 +50,27 @@ exports[`<Sheet /> snapshots default args snapshot: bottom, show, light 1`] = `
 <sheet-container>
   <div
     className="pgn__sheet-skrim hidden"
-    onClick={[Function]}
     role="presentation"
   />
-  <div
-    aria-atomic="true"
-    aria-live="polite"
-    className="pgn__sheet-component pgn__sheet__light bottom"
-    role="alert"
+  <focus-on
+    enabled={false}
   >
     <div
-      className="pgn__sheet-content"
+      aria-atomic="true"
+      aria-live="polite"
+      className="pgn__sheet-component pgn__sheet__light bottom"
+      role="alert"
     >
       <div
-        className="sheet-content"
+        className="pgn__sheet-content"
       >
-        Hi
+        <div
+          className="sheet-content"
+        >
+          Hi
+        </div>
       </div>
     </div>
-  </div>
+  </focus-on>
 </sheet-container>
 `;

--- a/src/Sheet/__snapshots__/Sheet.test.jsx.snap
+++ b/src/Sheet/__snapshots__/Sheet.test.jsx.snap
@@ -20,6 +20,26 @@ exports[`<Sheet /> snapshots blocking, left snapshot 1`] = `
 </sheet-container>
 `;
 
+exports[`<Sheet /> snapshots dark, right snapshot 1`] = `
+<sheet-container>
+  <div
+    className="pgn__sheet-skrim hidden"
+    onClick={[Function]}
+    role="presentation"
+  />
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    className="pgn__sheet-component pgn__sheet__dark right"
+    role="alert"
+  >
+    <div
+      className="pgn__sheet-content"
+    />
+  </div>
+</sheet-container>
+`;
+
 exports[`<Sheet /> snapshots default args snapshot: bottom, show, light 1`] = `
 <sheet-container>
   <div

--- a/src/Sheet/__snapshots__/Sheet.test.jsx.snap
+++ b/src/Sheet/__snapshots__/Sheet.test.jsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Sheet /> snapshots blocking, left snapshot 1`] = `
+<sheet-container>
+  <div
+    className="pgn__sheet-skrim"
+    onClick={[Function]}
+    role="presentation"
+  />
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    className="pgn__sheet-component pgn__sheet__light left"
+    role="alert"
+  >
+    <div
+      className="pgn__sheet-content"
+    />
+  </div>
+</sheet-container>
+`;
+
+exports[`<Sheet /> snapshots default args snapshot: bottom, show, light 1`] = `
+<sheet-container>
+  <div
+    className="pgn__sheet-skrim hidden"
+    onClick={[Function]}
+    role="presentation"
+  />
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    className="pgn__sheet-component pgn__sheet__light bottom"
+    role="alert"
+  >
+    <div
+      className="pgn__sheet-content"
+    >
+      <div
+        className="sheet-content"
+      >
+        Hi
+      </div>
+    </div>
+  </div>
+</sheet-container>
+`;

--- a/src/Sheet/index.jsx
+++ b/src/Sheet/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { FocusOn } from 'react-focus-on';
 
 import SheetContainer from './SheetContainer';
 
@@ -19,20 +20,47 @@ export const VARIANTS = {
 class Sheet extends React.Component {
   constructor(props) {
     super(props);
-    this.blockClicks = this.blockClicks.bind(this);
+    this.renderSheet = this.renderSheet.bind(this);
+    this.lockFocusEl = this.lockFocusEl.bind(this);
   }
 
-  blockClicks(event) {
-    event.stopPropagation();
+  lockFocusEl(renderContent) {
+    if (!this.props.blocking) {
+      return renderContent;
+    }
+    return (
+      <FocusOn enabled={this.props.show}>
+        {renderContent}
+      </FocusOn>
+    );
+  }
+
+  renderSheet() {
+    const { children, position, variant } = this.props;
+    return (
+      <div
+        className={classNames(
+          'pgn__sheet-component',
+          `pgn__sheet__${variant}`,
+          position,
+        )}
+        role="alert"
+        {...{
+          'aria-live': 'polite',
+          'aria-atomic': 'true',
+        }}
+      >
+        <div className="pgn__sheet-content">
+          { children }
+        </div>
+      </div>
+    );
   }
 
   render() {
     const {
       blocking,
-      children,
-      position,
       show,
-      variant,
     } = this.props;
     if (!show) {
       return null;
@@ -44,26 +72,9 @@ class Sheet extends React.Component {
             'pgn__sheet-skrim',
             { hidden: !blocking },
           )}
-          onClick={this.blockClicks}
           role="presentation"
         />
-        <div
-          className={classNames(
-            'pgn__sheet-component',
-            `pgn__sheet__${variant}`,
-            position,
-
-          )}
-          role="alert"
-          {...{
-            'aria-live': 'polite',
-            'aria-atomic': 'true',
-          }}
-        >
-          <div className="pgn__sheet-content">
-            { children }
-          </div>
-        </div>
+        {this.lockFocusEl(this.renderSheet())}
       </SheetContainer>
     );
   }

--- a/src/Sheet/index.jsx
+++ b/src/Sheet/index.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import SheetContainer from './SheetContainer';
+
+export const POSITIONS = {
+  left: 'left',
+  right: 'right',
+  top: 'top',
+  bottom: 'bottom',
+};
+
+export const VARIANTS = {
+  light: 'light',
+  dark: 'dark',
+};
+
+class Sheet extends React.Component {
+  constructor(props) {
+    super(props);
+    this.blockClicks = this.blockClicks.bind(this);
+  }
+
+  blockClicks(event) {
+    event.stopPropagation();
+  }
+
+  render() {
+    const {
+      blocking,
+      children,
+      position,
+      show,
+      variant,
+    } = this.props;
+    if (!show) {
+      return null;
+    }
+    return (
+      <SheetContainer>
+        <div
+          className={classNames(
+            'pgn__sheet-skrim',
+            { hidden: !blocking },
+          )}
+          onClick={this.blockClicks}
+          role="presentation"
+        />
+        <div
+          className={classNames(
+            'pgn__sheet-component',
+            `pgn__sheet__${variant}`,
+            position,
+
+          )}
+          role="alert"
+          {...{
+            'aria-live': 'polite',
+            'aria-atomic': 'true',
+          }}
+        >
+          <div className="pgn__sheet-content">
+            { children }
+          </div>
+        </div>
+      </SheetContainer>
+    );
+  }
+}
+
+Sheet.propTypes = {
+  /** specifies whether the sheet provides a click-blocking scrim */
+  blocking: PropTypes.bool,
+  /** an element rendered inside the sheet */
+  children: PropTypes.node,
+  /** a string designating the sheet's position on the window */
+  position: PropTypes.oneOf([
+    POSITIONS.left,
+    POSITIONS.right,
+    POSITIONS.top,
+    POSITIONS.bottom,
+  ]),
+  /** Boolean used to control whether the Sheet shows. */
+  show: PropTypes.bool,
+  /** a string designating which version of the sheet to show (light vs dark) */
+  variant: PropTypes.oneOf([VARIANTS.light, VARIANTS.dark]),
+};
+
+Sheet.defaultProps = {
+  blocking: false,
+  children: undefined,
+  position: POSITIONS.bottom,
+  show: true,
+  variant: VARIANTS.light,
+};
+
+export default Sheet;

--- a/src/Sheet/index.jsx
+++ b/src/Sheet/index.jsx
@@ -21,18 +21,6 @@ class Sheet extends React.Component {
   constructor(props) {
     super(props);
     this.renderSheet = this.renderSheet.bind(this);
-    this.lockFocusEl = this.lockFocusEl.bind(this);
-  }
-
-  lockFocusEl(renderContent) {
-    if (!this.props.blocking) {
-      return renderContent;
-    }
-    return (
-      <FocusOn enabled={this.props.show}>
-        {renderContent}
-      </FocusOn>
-    );
   }
 
   renderSheet() {
@@ -74,7 +62,9 @@ class Sheet extends React.Component {
           )}
           role="presentation"
         />
-        {this.lockFocusEl(this.renderSheet())}
+        <FocusOn enabled={this.props.blocking}>
+          {this.renderSheet()}
+        </FocusOn>
       </SheetContainer>
     );
   }

--- a/src/Sheet/index.jsx
+++ b/src/Sheet/index.jsx
@@ -33,10 +33,8 @@ class Sheet extends React.Component {
           position,
         )}
         role="alert"
-        {...{
-          'aria-live': 'polite',
-          'aria-atomic': 'true',
-        }}
+        aria-live="polite"
+        aria-atomic="true"
       >
         <div className="pgn__sheet-content">
           { children }

--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,7 @@ export {
 } from './Responsive';
 export { default as ResponsiveEmbed } from './ResponsiveEmbed';
 export { default as SearchField } from './SearchField';
+export { default as Sheet } from './Sheet';
 export { default as Spinner } from './Spinner';
 export { default as StatefulButton } from './StatefulButton';
 export { default as StatusAlert } from './StatusAlert';

--- a/src/index.scss
+++ b/src/index.scss
@@ -21,6 +21,7 @@
 @import './Popover/Popover.scss';
 @import './ProgressBar/ProgressBar.scss';
 @import './SearchField/SearchField.scss';
+@import './Sheet/Sheet.scss';
 @import './Spinner/Spinner.scss';
 @import './StatefulButton/StatefulButton.scss';
 @import './Table/Table.scss';
@@ -32,3 +33,4 @@
 @import './IconButton/_IconButton.scss';
 @import './Toast/Toast.scss';
 @import './Toast/_ToastContainer.scss';
+

--- a/www/src/components/navigation.jsx
+++ b/www/src/components/navigation.jsx
@@ -54,6 +54,7 @@ const menu = [
       { title: 'ProgressBar', url: '/components/progress-bar' },
       { title: 'Responsive', url: '/components/responsive' },
       { title: 'SearchField', url: '/components/searchfield' },
+      { title: 'Sheet', url: '/components/sheet' },
       { title: 'Spinner', url: '/components/spinner' },
       { title: 'StatefulButton', url: '/components/statefulbutton' },
       { title: 'Table', url: '/components/table' },

--- a/www/src/pages/components/sheet.mdx
+++ b/www/src/pages/components/sheet.mdx
@@ -1,0 +1,85 @@
+---
+title: 'Sheet'
+type: 'component'
+status: 'New'
+designStatus: 'In Progress'
+devStatus: 'In Progress'
+notes: |
+  Window-level edge-anchored content container with elevation shadow, with option to block content.
+---
+
+import { StaticQuery, graphql } from 'gatsby';
+import PropsTable from '../../components/PropsTable';
+import get from 'lodash/get';
+import SingleComponentStatus from '../../components/SingleComponentStatus';
+
+# Sheet
+
+<SingleComponentStatus
+  frontmatter={
+    get(props, 'pageContext.frontmatter') ? props.pageContext.frontmatter : null
+  }
+/>
+
+##### Basic Usage
+
+```jsx live
+
+() => {
+  const [blocking, setBlocking] = useState(false);
+  const [dark, setDark] = useState(false);
+  const [position, setPosition] = useState('bottom');
+  const [show, setShow] = useState(false);
+
+  const positions = ['left', 'right', 'top', 'bottom'];
+
+  return (
+    <>
+      <DropdownButton
+        id="position-dropdown-btn"
+        onSelect={setPosition}
+        title="Sheet Position"
+      >
+        {positions.map(position => (
+          <Dropdown.Item eventKey={position}>{position}</Dropdown.Item>
+        ))}
+      </DropdownButton>
+      <Button onClick={() => setShow(!show)}>
+        {show ? "Hide" : "Show"} the Sheet.
+      </Button>
+      <Button onClick={() => setBlocking(!blocking)}>
+        {blocking ? "Disable": "Enable"} blocking content
+      </Button>
+      <Button onClick={() => setDark(!dark)}>
+        Set {dark ? "Light": "Dark"} mode
+      </Button>
+
+      <Sheet
+        position={position}
+        show={show}
+        blocking={blocking}
+        variant={dark ? 'dark' : 'light'}
+      >
+        This is a Sheet component <br />
+        <Button onClick={() => setShow(false)}>Hide Me!</Button>
+      </Sheet>
+    </>
+  )
+}
+```
+
+##### Props
+
+<StaticQuery
+  query={graphql`
+    query {
+      componentMetadata(displayName: { eq: "Sheet" }) {
+        ...ComponentDocGenData
+      }
+    }
+  `}
+  render={({ componentMetadata }) => {
+    if (componentMetadata === null) return null;
+    return <PropsTable propMetaData={componentMetadata.props} />;
+  }}
+/>


### PR DESCRIPTION
Implements a basic "Sheet" component, which serves as a basic UI container element bound to and spanning one edge of the window.
Supports light/dark theming, as well as content-blocking.

https://www.figma.com/file/eGmDp94FlqEr4iSqy1Uc1K/Paragon-2021?node-id=7520%3A16719