### PR TITLE
fix: sheet css theming and example updates

### DIFF
--- a/src/Sheet/Sheet.scss
+++ b/src/Sheet/Sheet.scss
@@ -16,7 +16,7 @@
   background-color: white;
   z-index: $zindex-sheet;
   &.pgn__sheet__dark {
-    background-color: $primary-500;
+    background-color: $dark-500;
     color: $light-300;
   }
   &.bottom {

--- a/www/src/pages/components/sheet.mdx
+++ b/www/src/pages/components/sheet.mdx
@@ -43,13 +43,13 @@ import SingleComponentStatus from '../../components/SingleComponentStatus';
         {positions.map(position => (
           <Dropdown.Item eventKey={position}>{position}</Dropdown.Item>
         ))}
-      </DropdownButton>
+      </DropdownButton><br />
       <Button onClick={() => setShow(!show)}>
         {show ? "Hide" : "Show"} the Sheet.
-      </Button>
+      </Button>{' '}
       <Button onClick={() => setBlocking(!blocking)}>
         {blocking ? "Disable": "Enable"} blocking content
-      </Button>
+      </Button>{' '}
       <Button onClick={() => setDark(!dark)}>
         Set {dark ? "Light": "Dark"} mode
       </Button>
@@ -61,7 +61,12 @@ import SingleComponentStatus from '../../components/SingleComponentStatus';
         variant={dark ? 'dark' : 'light'}
       >
         This is a Sheet component <br />
-        <Button onClick={() => setShow(false)}>Hide Me!</Button>
+        <Button
+          onClick={() => setShow(false)}
+          variant={dark ? 'inverse-primary' : 'primary'}
+        >
+          Hide Me!
+        </Button>
       </Sheet>
     </>
   )


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/5533134/107539486-01d47f00-6b93-11eb-8c8d-6411772ff93f.png)
![image](https://user-images.githubusercontent.com/5533134/107539515-0b5de700-6b93-11eb-8ded-a8a973dece40.png)

Update background css variable for sheet component dark mode to work better in unbranded environment. 

Minor stylistic updates to example page to make more readable.