### PR TITLE
[AA-304]  change modal close icon from font awesome to paragon close icon

### DIFF
--- a/src/Modal/index.jsx
+++ b/src/Modal/index.jsx
@@ -10,6 +10,7 @@ import { Button } from '..';
 import Icon from '../Icon';
 import newId from '../utils/newId';
 import Variant from '../utils/constants';
+import { Close } from '../../icons';
 
 class Modal extends React.Component {
   constructor(props) {
@@ -220,7 +221,7 @@ class Modal extends React.Component {
                       className="p-1"
                       onClick={this.close}
                     >
-                      <Icon className="fa fa-times" screenReaderText={closeText} />
+                      <Icon src={Close} screenReaderText={closeText} />
                     </Button.Deprecated>
                   )}
                 </div>


### PR DESCRIPTION
Changing the icon based on these mocks
https://www.figma.com/file/B6AF4htYRdesPBNR08Fzvp/Celebratory-Milestones?node-id=312%3A23
and this slack thread
https://edx-internal.slack.com/archives/G019J2RMNEA/p1612878880015500

fyi @abutterworth @ekangedx 

(Changing the x icon)
before:
<img width="538" alt="Screen Shot 2021-02-11 at 5 50 07 PM" src="https://user-images.githubusercontent.com/5958221/107711322-6ed03d80-6c95-11eb-9bf8-e18027afd078.png">

after:
<img width="480" alt="Screen Shot 2021-02-11 at 6 10 13 PM" src="https://user-images.githubusercontent.com/5958221/107711324-6f68d400-6c95-11eb-8c81-2ec9b98c094a.png">
