### PR TITLE
fix: force container sizes to obey max width

### DIFF
--- a/scss/core/_grid.scss
+++ b/scss/core/_grid.scss
@@ -1,21 +1,21 @@
 @import "~bootstrap/scss/grid";
 
 .container-mw-xs {
-  max-width: $max-width-xs + $grid-gutter-width;
+  max-width: $max-width-xs + $grid-gutter-width !important;
 }
 
 .container-mw-sm {
-  max-width: $max-width-sm + $grid-gutter-width;
+  max-width: $max-width-sm + $grid-gutter-width !important;
 }
 
 .container-mw-md {
-  max-width: $max-width-md + $grid-gutter-width;
+  max-width: $max-width-md + $grid-gutter-width !important;
 }
 
 .container-mw-lg {
-  max-width: $max-width-lg + $grid-gutter-width;
+  max-width: $max-width-lg + $grid-gutter-width !important;
 }
 
 .container-mw-xl {
-  max-width: $max-width-xl + $grid-gutter-width;
+  max-width: $max-width-xl + $grid-gutter-width !important;
 }


### PR DESCRIPTION
The edx.org org theme has a troublesome max-width override set on .container-fluid. Adding these `!important` declarations is the simplest upgrade path for open edx consumers. After open edx consumers no longer rely on the edx.org brand theme to handle max widths, we can remove the offending style declaration and remove these `important` flags.

The problem appearing in the edx.org theme.
![image](https://user-images.githubusercontent.com/1615421/109519748-87a06780-7a79-11eb-9540-5cabb4eb5a36.png)

![image](https://user-images.githubusercontent.com/1615421/109519778-8ec77580-7a79-11eb-8b8c-dd5bab87921d.png)

