### PR TITLE
fix: renames close handler to onClose

### DIFF
--- a/src/Modal/ModalCloseButton.jsx
+++ b/src/Modal/ModalCloseButton.jsx
@@ -4,12 +4,12 @@ import { Button } from '..';
 import ModalContext from './ModalContext';
 
 const ModalCloseButton = React.forwardRef(({ as, children, ...props }, ref) => {
-  const { close } = useContext(ModalContext);
+  const { onClose } = useContext(ModalContext);
   const type = as;
   const componentProps = {
     ...props,
     onClick: () => {
-      close();
+      onClose();
       if (props.onClick) {
         props.onClick();
       }

--- a/src/Modal/ModalCloseButton.test.jsx
+++ b/src/Modal/ModalCloseButton.test.jsx
@@ -7,7 +7,7 @@ describe('<ModalCloseButton />', () => {
   it('calls a modal context close function on click', () => {
     const mockClose = jest.fn();
     const wrapper = mount((
-      <ModalContextProvider close={mockClose} isOpen>
+      <ModalContextProvider onClose={mockClose} isOpen>
         <ModalCloseButton>Close</ModalCloseButton>
       </ModalContextProvider>
     ));
@@ -18,7 +18,7 @@ describe('<ModalCloseButton />', () => {
     const mockClose = jest.fn();
     const mockOnClick = jest.fn();
     const wrapper = mount((
-      <ModalContextProvider close={mockClose} isOpen>
+      <ModalContextProvider onClose={mockClose} isOpen>
         <ModalCloseButton onClick={mockOnClick}>Close</ModalCloseButton>
       </ModalContextProvider>
     ));

--- a/src/Modal/ModalContext.jsx
+++ b/src/Modal/ModalContext.jsx
@@ -4,11 +4,11 @@ import PropTypes from 'prop-types';
 const ModalContext = React.createContext();
 
 const ModalContextProvider = ({
-  close, isOpen, isBlocking, children,
+  onClose, isOpen, isBlocking, children,
 }) => {
   const modalContextValue = useMemo(
-    () => ({ close, isOpen, isBlocking }),
-    [close, isOpen, isBlocking],
+    () => ({ onClose, isOpen, isBlocking }),
+    [onClose, isOpen, isBlocking],
   );
 
   return (
@@ -20,7 +20,7 @@ const ModalContextProvider = ({
 
 ModalContextProvider.propTypes = {
   children: PropTypes.node,
-  close: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
   isBlocking: PropTypes.bool,
   isOpen: PropTypes.bool.isRequired,
 };

--- a/src/Modal/ModalLayer.jsx
+++ b/src/Modal/ModalLayer.jsx
@@ -42,21 +42,21 @@ ModalContentContainer.defaultProps = {
  * component is that if a modal object is visible then it is "enabled"
  */
 const ModalLayer = ({
-  children, close, isOpen, isBlocking,
+  children, onClose, isOpen, isBlocking,
 }) => {
   if (!isOpen) {
     return null;
   }
 
-  const onClickOutside = !isBlocking ? close : null;
+  const onClickOutside = !isBlocking ? onClose : null;
 
   return (
-    <ModalContextProvider close={close} isOpen={isOpen} isBlocking={isBlocking}>
+    <ModalContextProvider onClose={onClose} isOpen={isOpen} isBlocking={isBlocking}>
       <Portal>
         <FocusOn
           scrollLock
           enabled={isOpen}
-          onEscapeKey={close}
+          onEscapeKey={onClose}
           onClickOutside={onClickOutside}
           className="pgn__modal-layer"
         >
@@ -72,7 +72,7 @@ const ModalLayer = ({
 
 ModalLayer.propTypes = {
   children: PropTypes.node.isRequired,
-  close: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
   isOpen: PropTypes.bool.isRequired,
   isBlocking: PropTypes.bool,
 };

--- a/src/Modal/ModalLayer.test.jsx
+++ b/src/Modal/ModalLayer.test.jsx
@@ -34,7 +34,7 @@ describe('<ModalLayer />', () => {
     const isOpen = true;
     const closeFn = jest.fn();
     const wrapper = shallow((
-      <ModalLayer isOpen={isOpen} close={closeFn}>
+      <ModalLayer isOpen={isOpen} onClose={closeFn}>
         <Dialog />
       </ModalLayer>
     ));
@@ -47,7 +47,7 @@ describe('<ModalLayer />', () => {
     it('renders a modal context provider', () => {
       const contextProvider = wrapper.find(ModalContextProvider);
       expect(contextProvider.props().isOpen).toBe(isOpen);
-      expect(contextProvider.props().close).toBe(closeFn);
+      expect(contextProvider.props().onClose).toBe(closeFn);
     });
 
     it('renders a focus-on component with appropriate props', () => {
@@ -61,7 +61,7 @@ describe('<ModalLayer />', () => {
 
   test('when isOpen is false the dialog is not rendered', () => {
     const wrapper = shallow((
-      <ModalLayer isOpen={false} close={jest.fn()}>
+      <ModalLayer isOpen={false} onClose={jest.fn()}>
         <Dialog />
       </ModalLayer>
     ));
@@ -73,7 +73,7 @@ describe('<ModalLayer />', () => {
     it('closes a non-blocking modal layer when clicked', () => {
       const closeFn = jest.fn();
       const wrapper = shallow((
-        <ModalLayer isOpen close={closeFn} isBlocking={false}>
+        <ModalLayer isOpen onClose={closeFn} isBlocking={false}>
           <Dialog />
         </ModalLayer>
       ));
@@ -85,7 +85,7 @@ describe('<ModalLayer />', () => {
     it('does not close a blocking modal layer when clicked', () => {
       const closeFn = jest.fn();
       const wrapper = shallow((
-        <ModalLayer isOpen close={closeFn} isBlocking>
+        <ModalLayer isOpen onClose={closeFn} isBlocking>
           <Dialog />
         </ModalLayer>
       ));

--- a/src/Modal/ModalPopup.jsx
+++ b/src/Modal/ModalPopup.jsx
@@ -6,19 +6,19 @@ import PopperElement from './PopperElement';
 import { ModalContextProvider } from './ModalContext';
 
 const ModalPopup = ({
-  children, close, isOpen, positionRef, isBlocking, withPortal, placement, ...popperProps
+  children, onClose, isOpen, positionRef, isBlocking, withPortal, placement, ...popperProps
 }) => {
   const RootComponent = withPortal ? Portal : React.Fragment;
 
   return (
-    <ModalContextProvider close={close} isOpen={isOpen} isBlocking={isBlocking}>
+    <ModalContextProvider onClose={onClose} isOpen={isOpen} isBlocking={isBlocking}>
       <RootComponent>
         <PopperElement target={positionRef} placement={placement} {...popperProps}>
           <FocusOn
             scrollLock={false}
             enabled={isOpen}
-            onEscapeKey={close}
-            onClickOutside={close}
+            onEscapeKey={onClose}
+            onClickOutside={onClose}
           >
             {isOpen && (
               <>
@@ -34,7 +34,7 @@ const ModalPopup = ({
 
 ModalPopup.propTypes = {
   children: PropTypes.node.isRequired,
-  close: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
   isOpen: PropTypes.bool.isRequired,
   isBlocking: PropTypes.bool,
   withPortal: PropTypes.bool,

--- a/src/Modal/ModalPopup.test.jsx
+++ b/src/Modal/ModalPopup.test.jsx
@@ -37,7 +37,7 @@ describe('<ModalPopup />', () => {
     const isOpen = true;
     const closeFn = jest.fn();
     const wrapper = shallow((
-      <ModalPopup positionRef={mockPositionRef} isOpen={isOpen} close={closeFn}>
+      <ModalPopup positionRef={mockPositionRef} isOpen={isOpen} onClose={closeFn}>
         <Dialog />
       </ModalPopup>
     ));
@@ -50,7 +50,7 @@ describe('<ModalPopup />', () => {
     it('renders a modal context provider', () => {
       const contextProvider = wrapper.find(ModalContextProvider);
       expect(contextProvider.props().isOpen).toBe(isOpen);
-      expect(contextProvider.props().close).toBe(closeFn);
+      expect(contextProvider.props().onClose).toBe(closeFn);
     });
 
     it('renders a focus-on component with appropriate props', () => {
@@ -64,7 +64,7 @@ describe('<ModalPopup />', () => {
 
   it('when isOpen is false the dialog is not rendered', () => {
     const wrapper = shallow((
-      <ModalPopup positionRef={mockPositionRef} isOpen={false} close={jest.fn()}>
+      <ModalPopup positionRef={mockPositionRef} isOpen={false} onClose={jest.fn()}>
         <Dialog />
       </ModalPopup>
     ));
@@ -75,7 +75,7 @@ describe('<ModalPopup />', () => {
   describe('withPortal', () => {
     it('renders no portal by default', () => {
       const wrapper = shallow((
-        <ModalPopup positionRef={mockPositionRef} isOpen close={jest.fn()}>
+        <ModalPopup positionRef={mockPositionRef} isOpen onClose={jest.fn()}>
           <Dialog />
         </ModalPopup>
       ));
@@ -83,7 +83,7 @@ describe('<ModalPopup />', () => {
     });
     it('renders with a portal if withPortal is true', () => {
       const wrapper = shallow((
-        <ModalPopup withPortal positionRef={mockPositionRef} isOpen close={jest.fn()}>
+        <ModalPopup withPortal positionRef={mockPositionRef} isOpen onClose={jest.fn()}>
           <Dialog />
         </ModalPopup>
       ));


### PR DESCRIPTION
This renames the “close” handler in ModalLayer, ModalPopup, and the ModalContext to be “onClose”, which is a more canonical name for a handler.

Technically this is a breaking change, but since we have no known consumers of this component yet, we’re not marking it as so.