### PR TITLE
[BD-35] PAR-289 feat: change styles according to new toast component design

### DIFF
--- a/src/Toast/_Toast.scss
+++ b/src/Toast/_Toast.scss
@@ -6,7 +6,7 @@
   box-shadow: $toast-box-shadow;
   margin: 0;
   min-width: $toast-max-width;
-  padding: 1.25rem;
+  padding: 1rem;
   position: relative;
   border-radius: $toast-border-radius;
   z-index: 2;

--- a/src/Toast/_variables.scss
+++ b/src/Toast/_variables.scss
@@ -9,8 +9,8 @@ $toast-color:                       null !default;
 $toast-background-color:            $gray-700 !default;
 $toast-border-width:                1px !default;
 $toast-border-color:                rgba(0, 0, 0, .1) !default;
-$toast-border-radius:               .1875rem !default;
-$toast-box-shadow:                  .125rem .125rem .25rem 0 rgba($black, .25) !default;
+$toast-border-radius:               .25rem !default;
+$toast-box-shadow:                  0 1.25rem 2.5rem rgba($black, .15), 0 .5rem 3rem rgba($black, .15) !default;
 
 $toast-header-color:                $white !default;
 $toast-header-background-color:     $gray-700 !default;


### PR DESCRIPTION
@abutterworth 
Ticket on Jira: https://openedx.atlassian.net/browse/PAR-289
Update toast component according to the new design: https://www.figma.com/file/eGmDp94FlqEr4iSqy1Uc1K/Paragon-2021?node-id=7583%3A878
![toast-old](https://user-images.githubusercontent.com/36944773/109672633-35c41400-7b43-11eb-97e4-f01cd7c6848f.jpg)
![toast-new](https://user-images.githubusercontent.com/36944773/109672646-378dd780-7b43-11eb-9906-653156dcf149.jpg)
