### PR TITLE
fix: update default styles to be less different from edx.org brand

### DIFF
--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -37,7 +37,7 @@ $grays: map-merge(
 
 $blue: #23419f !default;
 $red: #C32D3A !default;
-$yellow: #D69600 !default;
+$yellow: #ffd900 !default;
 $green: #178253 !default;
 $teal: #006DAA !default;
 
@@ -56,15 +56,17 @@ $colors: map-merge(
   $colors
 );
 
-$primary: $blue !default;
+$primary: #0A3055 !default;
 $secondary: $gray-700 !default;
-$brand: $primary !default;
+$brand: #9D0054 !default;
 $success: $green !default;
 $info: $teal !default;
 $danger: $red !default;
 $warning: $yellow !default;
-$light: #eee !default;
-$dark: $gray-700 !default;
+$light: #F2ECEC !default;
+$dark: #273F2F !default;
+$accent-a: #00BBF9 !default;
+$accent-b: #FFEE88 !default;
 
 $theme-colors: () !default;
 $theme-colors: map-merge(
@@ -78,7 +80,9 @@ $theme-colors: map-merge(
     "danger":     $danger,
     "light":      $light,
     "dark":       $dark,
-    "gray":  $gray-500,
+    "gray":       $gray-500,
+    "accent-a":   $accent-a,
+    "accent-b":   $accent-b,
   ),
   $theme-colors
 );
@@ -478,9 +482,9 @@ $line-height-sm:              1.5 !default;
 $border-width:                1px !default;
 $border-color:                theme-color("gray", "border") !default;
 
-$border-radius:               .3rem !default;
-$border-radius-lg:            .35rem !default;
-$border-radius-sm:            .2rem !default;
+$border-radius:               0.375rem !default;
+$border-radius-lg:            0.425rem !default;
+$border-radius-sm:            0.25rem !default;
 
 $rounded-pill:                50rem !default;
 
@@ -522,9 +526,9 @@ $font-family-monospace:       SFMono-Regular, Menlo, Monaco, Consolas, "Liberati
 $font-family-base:            $font-family-sans-serif !default;
 // stylelint-enable value-keyword-case
 
-$font-size-base:              1rem !default; // Assumes the browser default, typically `16px`
+$font-size-base:              1.125rem !default; // Assumes the browser default, typically `16px`
 $font-size-lg:                $font-size-base * 1.25 !default;
-$font-size-sm:                $font-size-base * .875 !default;
+$font-size-sm:                0.875rem !default;
 
 $font-weight-lighter:         lighter !default;
 $font-weight-light:           300 !default;
@@ -534,21 +538,21 @@ $font-weight-bold:            700 !default;
 $font-weight-bolder:          bolder !default;
 
 $font-weight-base:            $font-weight-normal !default;
-$line-height-base:            1.5 !default;
+$line-height-base:            1.55555555555555 !default;
 
-$h1-font-size:                $font-size-base * 2.5 !default;
-$h2-font-size:                $font-size-base * 2 !default;
-$h3-font-size:                $font-size-base * 1.75 !default;
-$h4-font-size:                $font-size-base * 1.5 !default;
-$h5-font-size:                $font-size-base * 1.25 !default;
-$h6-font-size:                $font-size-base !default;
+$h1-font-size:                2.5rem !default;
+$h2-font-size:                2rem !default;
+$h3-font-size:                1.375rem !default;
+$h4-font-size:                1.125rem !default;
+$h5-font-size:                .875rem !default;
+$h6-font-size:                .75rem !default;
 
-$h1-mobile-font-size:                $font-size-base * 2 !default;
-$h2-mobile-font-size:                $font-size-base * 1.75 !default;
-$h3-mobile-font-size:                $font-size-base * 1.5 !default;
-$h4-mobile-font-size:                $font-size-base * 1.375 !default;
-$h5-mobile-font-size:                $h5-font-size !default;
-$h6-mobile-font-size:                $h6-font-size !default;
+$h1-mobile-font-size:         2.25rem !default;
+$h2-mobile-font-size:         $h2-font-size !default;
+$h3-mobile-font-size:         $h3-font-size !default;
+$h4-mobile-font-size:         $h4-font-size !default;
+$h5-mobile-font-size:         $h5-font-size !default;
+$h6-mobile-font-size:         $h6-font-size !default;
 
 $headings-margin-bottom:      $spacer / 2 !default;
 $headings-font-family:        null !default;
@@ -620,24 +624,24 @@ $zindex-tooltip:                    1070 !default;
 //
 // Shared variables that are reassigned to `$input-` and `$btn-` specific variables.
 
-$input-btn-padding-y:         .375rem !default;
-$input-btn-padding-x:         .75rem !default;
+$input-btn-padding-y:         0.5625rem !default;
+$input-btn-padding-x:         1rem !default;
 $input-btn-font-family:       null !default;
-$input-btn-font-size:         $font-size-base !default;
-$input-btn-line-height:       $line-height-base !default;
+$input-btn-font-size:         1.125rem !default;
+$input-btn-line-height:       1.33334 !default;
 
-$input-btn-focus-width:       .2rem !default;
-$input-btn-focus-color:       rgba($component-active-bg, .25) !default;
+$input-btn-focus-width:       1px !default;
+$input-btn-focus-color:       $component-active-bg !default;
 $input-btn-focus-box-shadow:  0 0 0 $input-btn-focus-width $input-btn-focus-color !default;
 
-$input-btn-padding-y-sm:      .25rem !default;
-$input-btn-padding-x-sm:      .5rem !default;
-$input-btn-font-size-sm:      $font-size-sm !default;
-$input-btn-line-height-sm:    $line-height-sm !default;
+$input-btn-padding-y-sm:         0.4375rem !default;
+$input-btn-padding-x-sm:         0.75rem !default;
+$input-btn-font-size-sm:         0.875rem !default;
+$input-btn-line-height-sm:       1.42858 !default;
 
-$input-btn-padding-y-lg:      .5rem !default;
-$input-btn-padding-x-lg:      1rem !default;
-$input-btn-font-size-lg:      $font-size-lg !default;
+$input-btn-padding-y-lg:      0.6875rem !default;
+$input-btn-padding-x-lg:      1.25rem !default;
+$input-btn-font-size-lg:      1.325rem !default;
 $input-btn-line-height-lg:    $line-height-lg !default;
 
 $input-btn-border-width:      $border-width !default;

--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -63,7 +63,7 @@ $success: $green !default;
 $info: $teal !default;
 $danger: $red !default;
 $warning: $yellow !default;
-$light: #F2ECEC !default;
+$light: #f5efef !default;
 $dark: #273F2F !default;
 $accent-a: #00BBF9 !default;
 $accent-b: #FFEE88 !default;

--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -388,7 +388,7 @@ $sizes: map-merge(
 // Settings for the `<body>` element.
 
 $body-bg:                   $white !default;
-$body-color:                theme-color("gray", "dark-text") !default;
+$body-color:                $gray-700 !default;
 
 
 // Links
@@ -558,7 +558,7 @@ $headings-margin-bottom:      $spacer / 2 !default;
 $headings-font-family:        null !default;
 $headings-font-weight:        $font-weight-bold !default;
 $headings-line-height:        1.25 !default;
-$headings-color:              null !default;
+$headings-color:              $black !default;
 
 $display1-size:               6rem !default;
 $display2-size:               5.5rem !default;

--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -63,7 +63,7 @@ $success: $green !default;
 $info: $teal !default;
 $danger: $red !default;
 $warning: $yellow !default;
-$light: #f5efef !default;
+$light: #E1DDDB !default;
 $dark: #273F2F !default;
 $accent-a: #00BBF9 !default;
 $accent-b: #FFEE88 !default;

--- a/src/Button/_variables.scss
+++ b/src/Button/_variables.scss
@@ -14,11 +14,11 @@ $btn-padding-x-lg:            $input-btn-padding-x-lg !default;
 $btn-font-size-lg:            $input-btn-font-size-lg !default;
 $btn-line-height-lg:          $input-btn-line-height-lg !default;
 
-$btn-border-width:            2px !default;
+$btn-border-width:            $input-btn-border-width !default;
 
 $btn-font-weight:             $font-weight-normal !default;
 $btn-box-shadow:              inset 0 1px 0 rgba($white, .15), 0 1px 1px rgba($black, .075) !default;
-$btn-focus-width:             3px !default;
+$btn-focus-width:             2px !default;
 $btn-focus-gap:               1px !default;
 $btn-focus-box-shadow:        $input-btn-focus-box-shadow !default;
 $btn-disabled-opacity:        .65 !default;

--- a/src/Form/_variables.scss
+++ b/src/Form/_variables.scss
@@ -28,7 +28,7 @@ $input-border-radius-lg:                $border-radius-lg !default;
 $input-border-radius-sm:                $border-radius-sm !default;
 
 $input-focus-bg:                        $input-bg !default;
-$input-focus-border-color:              lighten($component-active-bg, 25%) !default;
+$input-focus-border-color:              $component-active-bg !default;
 $input-focus-color:                     $input-color !default;
 $input-focus-width:                     $input-btn-focus-width !default;
 $input-focus-box-shadow:                $input-btn-focus-box-shadow !default;

--- a/www/src/components/layout.jsx
+++ b/www/src/components/layout.jsx
@@ -51,7 +51,7 @@ const Layout = ({ children }) => (
       }
     `}
     render={data => (
-      <div className="px-3 d-lg-flex d-block">
+      <div className="d-lg-flex d-block">
 
         <div className="flex-shrink-0">
           <ResponsiveNavigation />

--- a/www/src/components/navigation.jsx
+++ b/www/src/components/navigation.jsx
@@ -2,14 +2,14 @@ import { Link } from 'gatsby';
 import React from 'react';
 import { Nav } from '~paragon-react';
 
-const NavSectionTitle = ({ children }) => <h6 className="mt-4 px-3">{children}</h6>;
+const NavSectionTitle = ({ children }) => <h5 className="mt-4 px-3">{children}</h5>;
 
 const ParNavLink = ({ children, ...props }) => (
   <Link activeClassName="active" className="nav-link" {...props}>{children}</Link>
 );
 
 const Navigation = () => (
-  <Nav variant="pills" defaultActiveKey="/home" className="flex-column align-items-stretch py-3 mr-3">
+  <Nav variant="pills" defaultActiveKey="/home" className="flex-column align-items-stretch py-3 px-3 mr-3">
 
     <NavSectionTitle>Overview</NavSectionTitle>
 


### PR DESCRIPTION
Give edx.org developers higher confidence that what they ship in open edx applications will look similar when the edx.org brand is applied by reducing major differences between paragon default styles and edx brand styles.:
- Match font sizes in the type ramp (though line-heights are slightly different)
- Update colors to utilize the the color system in a similar way to edx.org. Notably: adds a magenta “brand” color.

The differences we'll maintain:
- Font family (system default san-serif vs. edx.org's use of Inter)
- Border radii. (rounded buttons vs. edx.org's square)

![image](https://user-images.githubusercontent.com/1615421/109880900-799f4200-7c45-11eb-871e-936f75e17f9a.png)
![image](https://user-images.githubusercontent.com/1615421/109880958-891e8b00-7c45-11eb-8692-248fc8d11770.png)
