### PR TITLE
fix: vertically align breadcrumb spacer with text

### DIFF
--- a/src/Breadcrumb/index.jsx
+++ b/src/Breadcrumb/index.jsx
@@ -12,7 +12,7 @@ const Breadcrumbs = ({
 
   return (
     <nav aria-label="breadcrumb" className="pgn__breadcrumb">
-      <ol className="list-inline d-flex">
+      <ol className="list-inline d-flex align-items-center">
         {links.map(({ url, label }, i) => (
           <React.Fragment key={url}>
             <li className={classNames('list-inline-item')}>


### PR DESCRIPTION
Minor alignment improvement.
![image](https://user-images.githubusercontent.com/1615421/109972219-1228d700-7cc5-11eb-9cb1-84aebcf24642.png)
