### PR TITLE
fix: google translate issue with text nodes

### DIFF
--- a/src/StatefulButton/__snapshots__/StatefulButtontest.test.jsx.snap
+++ b/src/StatefulButton/__snapshots__/StatefulButtontest.test.jsx.snap
@@ -13,7 +13,9 @@ exports[`StatefulButton renders basic usage 1`] = `
     <span
       className="d-flex align-items-center justify-content-center"
     >
-      Saved
+      <span>
+        Saved
+      </span>
     </span>
   </button>
   <button
@@ -36,7 +38,9 @@ exports[`StatefulButton renders basic usage 1`] = `
           id="Icon1"
         />
       </span>
-      Saving
+      <span>
+        Saving
+      </span>
     </span>
   </button>
   <button
@@ -59,7 +63,9 @@ exports[`StatefulButton renders basic usage 1`] = `
           id="Icon2"
         />
       </span>
-      Saved
+      <span>
+        Saved
+      </span>
     </span>
   </button>
 </div>
@@ -87,7 +93,9 @@ Array [
           id="Icon3"
         />
       </span>
-      Download
+      <span>
+        Download
+      </span>
     </span>
   </button>,
   <button
@@ -110,7 +118,9 @@ Array [
           id="Icon4"
         />
       </span>
-      Downloading
+      <span>
+        Downloading
+      </span>
     </span>
   </button>,
   <button
@@ -133,7 +143,9 @@ Array [
           id="Icon5"
         />
       </span>
-      Downloaded
+      <span>
+        Downloaded
+      </span>
     </span>
   </button>,
 ]
@@ -161,7 +173,9 @@ Array [
           id="Icon6"
         />
       </span>
-      Save (no changes)
+      <span>
+        Save (no changes)
+      </span>
     </span>
   </button>,
   <button
@@ -184,7 +198,9 @@ Array [
           id="Icon7"
         />
       </span>
-      Save Changes
+      <span>
+        Save Changes
+      </span>
     </span>
   </button>,
 ]

--- a/src/StatefulButton/index.jsx
+++ b/src/StatefulButton/index.jsx
@@ -92,7 +92,7 @@ function StatefulButton({
     >
       <span className="d-flex align-items-center justify-content-center">
         {icon ? <span className="pgn__stateful-btn-icon">{icon}</span> : null}
-        {labels[state] !== undefined ? labels[state] : labels.default}
+        <span>{labels[state] !== undefined ? labels[state] : labels.default}</span>
       </span>
     </Button>
   );


### PR DESCRIPTION
Fixes `Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.`

For more details see https://github.com/facebook/react/issues/11538#issuecomment-390386520