### PR TITLE
docs: fix scrollbar display

### DIFF
--- a/www/src/components/Header.jsx
+++ b/www/src/components/Header.jsx
@@ -130,7 +130,7 @@ const Header = ({ siteTitle, showMinimizedTitle }) => {
     >
       <div
         className="bg-white sticky-top"
-        style={{ maxHeight: '100vh', overflow: 'scroll' }}
+        style={{ maxHeight: '100vh', overflow: 'auto' }}
       >
         <Navbar
           siteTitle={siteTitle}


### PR DESCRIPTION
Remove scrollbar gaps appearing for macs with particular settings:
![image](https://user-images.githubusercontent.com/1615421/112325202-dd87ba00-8c89-11eb-8e86-88f73b7bb3d1.png)
