### PR TITLE
fix: reintroduce list group and media css

### DIFF
--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -658,3 +658,29 @@ $user-selects: all, auto, none !default;
 
 $print-page-size:                   a3 !default;
 $print-body-min-width:              map-get($grid-breakpoints, "lg") !default;
+
+
+// List group
+
+$list-group-color:                  null !default;
+$list-group-bg:                     $white !default;
+$list-group-border-color:           rgba($black, .125) !default;
+$list-group-border-width:           $border-width !default;
+$list-group-border-radius:          $border-radius !default;
+
+$list-group-item-padding-y:         .75rem !default;
+$list-group-item-padding-x:         1.25rem !default;
+
+$list-group-hover-bg:               $gray-100 !default;
+$list-group-active-color:           $component-active-color !default;
+$list-group-active-bg:              $component-active-bg !default;
+$list-group-active-border-color:    $list-group-active-bg !default;
+
+$list-group-disabled-color:         $gray-600 !default;
+$list-group-disabled-bg:            $list-group-bg !default;
+
+$list-group-action-color:           $gray-700 !default;
+$list-group-action-hover-color:     $list-group-action-color !default;
+
+$list-group-action-active-color:    $body-color !default;
+$list-group-action-active-bg:       $gray-200 !default;

--- a/scss/core/core.scss
+++ b/scss/core/core.scss
@@ -7,6 +7,8 @@
 @import "grid";
 @import "~bootstrap/scss/transitions";
 @import "utilities";
+@import "~bootstrap/scss/media";
+@import "~bootstrap/scss/list-group";
 @import "~bootstrap/scss/print";
 
 // Paragon components


### PR DESCRIPTION
These were incorrectly removed when collocating css and javascript components: https://github.com/edx/paragon/pull/606