### PR TITLE
feat: add Checkbox, Switch, and CheckboxSet

### DIFF
--- a/src/Form/FormCheckbox.jsx
+++ b/src/Form/FormCheckbox.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { useCheckboxSetContext } from './FormCheckboxSetContext';
+import { FormGroupContextProvider, useFormGroupContext } from './FormGroupContext';
+import FormLabel from './FormLabel';
+import FormControlFeedback from './FormControlFeedback';
+
+const CheckboxControl = React.forwardRef(
+  ({ isIndeterminate, ...props }, ref) => {
+    const defaultRef = React.useRef();
+    const resolvedRef = ref || defaultRef;
+    const { getControlProps } = useFormGroupContext();
+    const checkboxProps = getControlProps(props);
+
+    React.useEffect(() => {
+      resolvedRef.current.indeterminate = isIndeterminate;
+    }, [resolvedRef, isIndeterminate]);
+
+    return (
+      <input type="checkbox" {...checkboxProps} ref={resolvedRef} {...props} />
+    );
+  },
+);
+
+CheckboxControl.propTypes = {
+  isIndeterminate: PropTypes.bool,
+};
+
+CheckboxControl.defaultProps = {
+  isIndeterminate: false,
+};
+
+const FormCheckbox = React.forwardRef(({
+  children,
+  className,
+  controlClassName,
+  labelClassName,
+  description,
+  isInvalid,
+  isValid,
+  ...props
+}, ref) => {
+  const { getCheckboxControlProps } = useCheckboxSetContext();
+  const checkboxInputProps = getCheckboxControlProps(props);
+  return (
+    <FormGroupContextProvider
+      controlId={checkboxInputProps.id}
+      isInvalid={isInvalid}
+      isValid={isValid}
+    >
+      <div
+        className={classNames('pgn__form-checkbox', className, {
+          'pgn__form-checkbox-valid': isValid,
+          'pgn__form-checkbox-invalid': isInvalid,
+          'pgn__form-checkbox-disabled': checkboxInputProps.disabled,
+        })}
+      >
+        <CheckboxControl {...checkboxInputProps} ref={ref} />
+        <div className={classNames('pgn__form-checkbox-display', controlClassName)}>
+          <FormLabel className={classNames('pgn__form-checkbox-label', labelClassName)}>
+            <span className={classNames('pgn__form-checkbox-control', controlClassName)} />
+            {children}
+          </FormLabel>
+          {description && (
+            <FormControlFeedback hasIcon={false}>
+              {description}
+            </FormControlFeedback>
+          )}
+        </div>
+      </div>
+    </FormGroupContextProvider>
+  );
+});
+
+FormCheckbox.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  controlClassName: PropTypes.string,
+  labelClassName: PropTypes.string,
+  description: PropTypes.node,
+  isInvalid: PropTypes.bool,
+  isValid: PropTypes.bool,
+};
+
+FormCheckbox.defaultProps = {
+  className: undefined,
+  controlClassName: undefined,
+  labelClassName: undefined,
+  description: undefined,
+  isInvalid: false,
+  isValid: false,
+};
+
+export default FormCheckbox;

--- a/src/Form/FormCheckbox.jsx
+++ b/src/Form/FormCheckbox.jsx
@@ -41,7 +41,14 @@ const FormCheckbox = React.forwardRef(({
   isValid,
   ...props
 }, ref) => {
-  const { getCheckboxControlProps } = useCheckboxSetContext();
+  const { getCheckboxControlProps, hasCheckboxSetProvider } = useCheckboxSetContext();
+  const { hasFormGroupProvider, useSetIsControlGroupEffect, getControlProps } = useFormGroupContext();
+  useSetIsControlGroupEffect(true);
+  const shouldActAsGroup = hasFormGroupProvider && !hasCheckboxSetProvider;
+  const groupProps = shouldActAsGroup ? {
+    ...getControlProps({}),
+    role: 'group',
+  } : {};
   const checkboxInputProps = getCheckboxControlProps(props);
   return (
     <FormGroupContextProvider
@@ -55,6 +62,7 @@ const FormCheckbox = React.forwardRef(({
           'pgn__form-checkbox-invalid': isInvalid,
           'pgn__form-checkbox-disabled': checkboxInputProps.disabled,
         })}
+        {...groupProps}
       >
         <CheckboxControl {...checkboxInputProps} ref={ref} />
         <div className={classNames('pgn__form-checkbox-display', controlClassName)}>

--- a/src/Form/FormCheckboxSet.jsx
+++ b/src/Form/FormCheckboxSet.jsx
@@ -17,13 +17,13 @@ const FormCheckboxSet = ({
 }) => {
   const { getControlProps, useSetIsControlGroupEffect } = useFormGroupContext();
   useSetIsControlGroupEffect(true);
-  const controlProps = getControlProps(props);
   const className = classNames(
     'pgn__form-control-set',
     'pgn__form-checkbox-set',
     props.className,
     { 'pgn__form-checkbox-set-inline': isInline },
   );
+  const controlProps = getControlProps({ ...props, className });
   return (
     <FormCheckboxSetContextProvider
       name={name}

--- a/src/Form/FormCheckboxSet.jsx
+++ b/src/Form/FormCheckboxSet.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { useFormGroupContext } from './FormGroupContext';
+import { FormCheckboxSetContextProvider } from './FormCheckboxSetContext';
+
+const FormCheckboxSet = ({
+  children,
+  name,
+  value,
+  defaultValue,
+  isInline,
+  onChange,
+  onFocus,
+  onBlur,
+  ...props
+}) => {
+  const { getControlProps, useSetIsControlGroupEffect } = useFormGroupContext();
+  useSetIsControlGroupEffect(true);
+  const controlProps = getControlProps(props);
+  const className = classNames(
+    'pgn__form-control-set',
+    'pgn__form-checkbox-set',
+    props.className,
+    { 'pgn__form-checkbox-set-inline': isInline },
+  );
+  return (
+    <FormCheckboxSetContextProvider
+      name={name}
+      value={value}
+      defaultValue={defaultValue}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      onChange={onChange}
+    >
+      <div
+        role="group"
+        className={className}
+        {...controlProps}
+      >
+        {children}
+      </div>
+    </FormCheckboxSetContextProvider>
+  );
+};
+
+FormCheckboxSet.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.arrayOf(PropTypes.string),
+  defaultValue: PropTypes.arrayOf(PropTypes.string),
+  isInline: PropTypes.bool,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+};
+
+FormCheckboxSet.defaultProps = {
+  className: undefined,
+  value: undefined,
+  defaultValue: undefined,
+  isInline: false,
+  onChange: undefined,
+  onFocus: undefined,
+  onBlur: undefined,
+};
+
+export default FormCheckboxSet;

--- a/src/Form/FormCheckboxSetContext.jsx
+++ b/src/Form/FormCheckboxSetContext.jsx
@@ -6,6 +6,7 @@ const identityFn = props => props;
 
 const FormCheckboxSetContext = React.createContext({
   getCheckboxControlProps: identityFn,
+  hasCheckboxSetProvider: false,
 });
 
 const useCheckboxSetContext = () => useContext(FormCheckboxSetContext);
@@ -40,6 +41,7 @@ const FormCheckboxSetContextProvider = ({
     onBlur,
     onFocus,
     onChange,
+    hasCheckboxSetProvider: true,
   };
   return (
     <FormCheckboxSetContext.Provider value={contextValue}>

--- a/src/Form/FormCheckboxSetContext.jsx
+++ b/src/Form/FormCheckboxSetContext.jsx
@@ -1,0 +1,73 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { callAllHandlers } from './fieldUtils';
+
+const identityFn = props => props;
+
+const FormCheckboxSetContext = React.createContext({
+  getCheckboxControlProps: identityFn,
+});
+
+const useCheckboxSetContext = () => useContext(FormCheckboxSetContext);
+
+const FormCheckboxSetContextProvider = ({
+  children,
+  name,
+  onBlur,
+  onFocus,
+  onChange,
+  value,
+  defaultValue,
+}) => {
+  const isControlled = !defaultValue && Array.isArray(value);
+  const getCheckboxControlProps = (checkboxProps) => ({
+    ...checkboxProps,
+    name,
+    /* istanbul ignore next */
+    onBlur: checkboxProps.onBlur ? callAllHandlers(onBlur, checkboxProps.onBlur) : onBlur,
+    /* istanbul ignore next */
+    onFocus: checkboxProps.onFocus ? callAllHandlers(onFocus, checkboxProps.onFocus) : onFocus,
+    /* istanbul ignore next */
+    onChange: checkboxProps.onChange ? callAllHandlers(onChange, checkboxProps.onChange) : onChange,
+    checked: isControlled ? value.includes(checkboxProps.value) : undefined,
+    defaultChecked: isControlled ? undefined : (defaultValue && defaultValue.includes(checkboxProps.value)),
+  });
+  const contextValue = {
+    name,
+    value,
+    defaultValue,
+    getCheckboxControlProps,
+    onBlur,
+    onFocus,
+    onChange,
+  };
+  return (
+    <FormCheckboxSetContext.Provider value={contextValue}>
+      {children}
+    </FormCheckboxSetContext.Provider>
+  );
+};
+
+FormCheckboxSetContextProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+  name: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
+  onFocus: PropTypes.func,
+  onChange: PropTypes.func,
+  value: PropTypes.arrayOf(PropTypes.string),
+  defaultValue: PropTypes.arrayOf(PropTypes.string),
+};
+
+FormCheckboxSetContextProvider.defaultProps = {
+  onBlur: undefined,
+  onFocus: undefined,
+  onChange: undefined,
+  value: undefined,
+  defaultValue: undefined,
+};
+
+export default FormCheckboxSetContext;
+export {
+  useCheckboxSetContext,
+  FormCheckboxSetContextProvider,
+};

--- a/src/Form/FormCheckboxSetContext.jsx
+++ b/src/Form/FormCheckboxSetContext.jsx
@@ -52,7 +52,7 @@ const FormCheckboxSetContextProvider = ({
 
 FormCheckboxSetContextProvider.propTypes = {
   children: PropTypes.node.isRequired,
-  name: PropTypes.string.isRequired,
+  name: PropTypes.string,
   onBlur: PropTypes.func,
   onFocus: PropTypes.func,
   onChange: PropTypes.func,
@@ -62,6 +62,7 @@ FormCheckboxSetContextProvider.propTypes = {
 
 FormCheckboxSetContextProvider.defaultProps = {
   onBlur: undefined,
+  name: undefined,
   onFocus: undefined,
   onChange: undefined,
   value: undefined,

--- a/src/Form/FormGroupContext.jsx
+++ b/src/Form/FormGroupContext.jsx
@@ -15,6 +15,7 @@ const FormGroupContext = React.createContext({
   useSetIsControlGroupEffect: noop,
   getLabelProps: identityFn,
   getDescriptorProps: identityFn,
+  hasFormGroupProvider: false,
 });
 
 const useFormGroupContext = () => React.useContext(FormGroupContext);
@@ -84,6 +85,7 @@ const FormGroupContextProvider = ({
     isInvalid,
     isValid,
     size,
+    hasFormGroupProvider: true,
   };
 
   return (

--- a/src/Form/FormSwitch.jsx
+++ b/src/Form/FormSwitch.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import FormCheckbox from './FormCheckbox';
+
+const FormSwitch = React.forwardRef(({
+  children,
+  className,
+  ...props
+}, ref) => (
+
+  <FormCheckbox
+    className={classNames('pgn__form-switch', className)}
+    {...props}
+    role="switch"
+    ref={ref}
+  >
+    {children}
+  </FormCheckbox>
+));
+
+FormSwitch.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+};
+
+FormSwitch.defaultProps = {
+  className: undefined,
+};
+
+export default FormSwitch;

--- a/src/Form/FormSwitchSet.jsx
+++ b/src/Form/FormSwitchSet.jsx
@@ -1,0 +1,6 @@
+import FormCheckboxSet from './FormCheckboxSet';
+
+// SwitchSet is an alias for CheckboxSet since under the hood
+// Checkbox and Switch are the same.
+
+export default FormCheckboxSet;

--- a/src/Form/FormSwitchSet.jsx
+++ b/src/Form/FormSwitchSet.jsx
@@ -1,6 +1,0 @@
-import FormCheckboxSet from './FormCheckboxSet';
-
-// SwitchSet is an alias for CheckboxSet since under the hood
-// Checkbox and Switch are the same.
-
-export default FormCheckboxSet;

--- a/src/Form/_Form.scss
+++ b/src/Form/_Form.scss
@@ -4,6 +4,7 @@
 @import "~bootstrap/scss/custom-forms";
 @import "mixins";
 @import "FormRadio";
+@import "FormCheckbox";
 @import "FormText";
 
 $form-control-icon-width: 32px !default;

--- a/src/Form/_FormCheckbox.scss
+++ b/src/Form/_FormCheckbox.scss
@@ -1,4 +1,4 @@
-.pgn__form-radio {
+.pgn__form-checkbox {
   font-size: $font-size-base;
   line-height: $line-height-base;
   display: block;
@@ -15,18 +15,18 @@
     position: absolute;
   }
 
-  .pgn__form-radio-label {
+  .pgn__form-checkbox-label {
     display: block;
     display: flex;
     align-items: center;
     margin-bottom: 0;
   }
-  input:disabled ~ .pgn__form-radio-display {
+  input:disabled ~ .pgn__form-checkbox-display {
     opacity: .3;
   }
 }
 
-.pgn__form-radio-display {
+.pgn__form-checkbox-display {
   .pgn__form-text {
     margin-top: -4px;
     padding-left: calc(#{$custom-control-indicator-size} + #{$custom-control-gutter});
@@ -34,7 +34,7 @@
 }
 
 
-.pgn__form-radio-control {
+.pgn__form-checkbox-control {
   height: $custom-control-indicator-size;
   width: $custom-control-indicator-size;
   flex-shrink: 0;
@@ -45,7 +45,7 @@
   background-color: rgba(0,0,0,0.01);
   transition: background-color, box-shadow 150ms ease;
 
-  input:not(:disabled) + .pgn__form-radio-display:hover & {
+  input:not(:disabled) + .pgn__form-checkbox-display:hover & {
     cursor: pointer;
     background: rgba(0,0,0,.1);
     box-shadow: 0 0 0 8px rgba(0,0,0,.1);
@@ -58,7 +58,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    border-radius: $custom-radio-indicator-border-radius;
+    border-radius: $custom-checkbox-indicator-border-radius;
   }
   &:before {
     height: 20px;
@@ -66,40 +66,45 @@
     border: $custom-control-indicator-border-color solid $custom-control-indicator-border-width;
     transition: box-shadow 150ms ease;
 
-    input:checked + .pgn__form-radio-display & {
+    input:checked + .pgn__form-checkbox-display & {
       border-color: $custom-control-indicator-active-border-color;
     }
-    .pgn__form-radio-invalid input + .pgn__form-radio-display & {
+    .pgn__form-checkbox-invalid input + .pgn__form-checkbox-display & {
       border-color: $form-feedback-invalid-color;
     }
-    .pgn__form-radio-valid input + .pgn__form-radio-display & {
+    .pgn__form-checkbox-valid input + .pgn__form-checkbox-display & {
       border-color: $form-feedback-valid-color;
     }
-    input:focus + .pgn__form-radio-display & {
+    input:focus + .pgn__form-checkbox-display & {
       box-shadow: 0 0 0 1px $component-active-bg;
-      .pgn__form-radio-invalid & {
+      .pgn__form-checkbox-invalid & {
         box-shadow: 0 0 0 1px $form-feedback-invalid-color;
       }
-      .pgn__form-radio-valid & {
+      .pgn__form-checkbox-valid & {
         box-shadow: 0 0 0 1px $form-feedback-valid-color;
       }
     }
   }
   &:after {
-    height: 14px;
-    width: 14px;
-    background-image: escape-svg($custom-radio-indicator-icon-checked);
+    height: 24px;
+    width: 24px;
+    background-image: escape-svg($custom-checkbox-indicator-icon-checked);
     opacity: 0;
     transform: translate(-50%, -50%) scale(0);
     transition: opacity 150ms ease, transform 150ms ease;
-    input:checked + .pgn__form-radio-display & {
+    input:checked + .pgn__form-checkbox-display & {
+      transform: translate(-50%, -50%) scale(1);
+      opacity: 1;
+    }
+    input:indeterminate + .pgn__form-checkbox-display & {
+      background-image: escape-svg($custom-checkbox-indicator-icon-indeterminate);
       transform: translate(-50%, -50%) scale(1);
       opacity: 1;
     }
   }
 }
 
-.pgn__form-radio-set {
+.pgn__form-checkbox-set {
   display: flex;
   align-items: flex-start;
   flex-direction: column;
@@ -108,7 +113,7 @@
   }
 }
 
-.pgn__form-radio-set-inline {
+.pgn__form-checkbox-set-inline {
   flex-direction: row;
   flex-wrap: 1;
   align-items: flex-start;

--- a/src/Form/_FormCheckbox.scss
+++ b/src/Form/_FormCheckbox.scss
@@ -30,6 +30,10 @@
   .pgn__form-text {
     margin-top: -4px;
     padding-left: calc(#{$custom-control-indicator-size} + #{$custom-control-gutter});
+
+    .pgn__form-switch & {
+      padding-left: calc(#{$custom-switch-width} + #{$custom-control-gutter});
+    }
   }
 }
 
@@ -45,6 +49,11 @@
   background-color: rgba(0,0,0,0.01);
   transition: background-color, box-shadow 150ms ease;
 
+  .pgn__form-switch & {
+    width: $custom-switch-width;
+    border-radius: $custom-switch-indicator-border-radius;
+  }
+
   input:not(:disabled) + .pgn__form-checkbox-display:hover & {
     cursor: pointer;
     background: rgba(0,0,0,.1);
@@ -59,15 +68,26 @@
     left: 50%;
     transform: translate(-50%, -50%);
     border-radius: $custom-checkbox-indicator-border-radius;
+
+    .pgn__form-switch & {
+      border-radius: $custom-switch-indicator-border-radius;
+    }
   }
   &:before {
     height: 20px;
     width: 20px;
     border: $custom-control-indicator-border-color solid $custom-control-indicator-border-width;
-    transition: box-shadow 150ms ease;
+    transition: box-shadow 150ms ease, background-color 150ms ease;
+
+    .pgn__form-switch & {
+      width: $custom-switch-width;
+    }
 
     input:checked + .pgn__form-checkbox-display & {
       border-color: $custom-control-indicator-active-border-color;
+      .pgn__form-switch & {
+        background: $component-active-bg;
+      }
     }
     .pgn__form-checkbox-invalid input + .pgn__form-checkbox-display & {
       border-color: $form-feedback-invalid-color;
@@ -91,10 +111,24 @@
     background-image: escape-svg($custom-checkbox-indicator-icon-checked);
     opacity: 0;
     transform: translate(-50%, -50%) scale(0);
-    transition: opacity 150ms ease, transform 150ms ease;
+    transition: opacity 150ms ease, transform 150ms ease, background-color 150ms ease;
+
+    .pgn__form-switch & {
+      height: 14px;
+      width: 14px;
+      background: $component-active-bg;
+      transform: translate(-50%, -50%) scale(1) translateX(-7px);
+      opacity: 1;
+    }
+
     input:checked + .pgn__form-checkbox-display & {
       transform: translate(-50%, -50%) scale(1);
       opacity: 1;
+
+      .pgn__form-switch & {
+        background: $component-active-color;
+        transform: translate(-50%, -50%) scale(1) translateX(7px);
+      }
     }
     input:indeterminate + .pgn__form-checkbox-display & {
       background-image: escape-svg($custom-checkbox-indicator-icon-indeterminate);

--- a/src/Form/_variables.scss
+++ b/src/Form/_variables.scss
@@ -73,7 +73,7 @@ $custom-control-cursor:                 null !default;
 $custom-control-indicator-size:         1.25rem !default;
 $custom-control-indicator-bg:           $input-bg !default;
 
-$custom-control-indicator-bg-size:      50% 50% !default;
+$custom-control-indicator-bg-size:      100% !default;
 $custom-control-indicator-box-shadow:   $input-box-shadow !default;
 $custom-control-indicator-border-color: $gray-700 !default;
 $custom-control-indicator-border-width: 2px !default;
@@ -83,7 +83,7 @@ $custom-control-label-color:            null !default;
 $custom-control-indicator-disabled-bg:          $input-disabled-bg !default;
 $custom-control-label-disabled-color:           theme-color("gray", "light-text") !default;
 
-$custom-control-indicator-checked-color:        white !default;
+$custom-control-indicator-checked-color:        $component-active-bg !default;
 $custom-control-indicator-checked-bg:           $component-active-bg !default;
 $custom-control-indicator-checked-disabled-bg:  rgba(theme-color("primary"), .5) !default;
 $custom-control-indicator-checked-box-shadow:   none !default;
@@ -96,13 +96,14 @@ $custom-control-indicator-active-color:         $component-active-color !default
 $custom-control-indicator-active-bg:            $component-active-bg !default;
 $custom-control-indicator-active-box-shadow:    none !default;
 $custom-control-indicator-active-border-color:  $custom-control-indicator-active-bg !default;
+// <svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M19 5V19H5V5H19ZM21 3H3V21H21V3Z' fill='black'/></svg>
 
-$custom-checkbox-indicator-border-radius:       $border-radius !default;
-$custom-checkbox-indicator-icon-checked:        str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='#{$custom-control-indicator-checked-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3e%3c/svg%3e"), "#", "%23") !default;
+$custom-checkbox-indicator-border-radius:       0 !default;
+$custom-checkbox-indicator-icon-checked:        str-replace(url("data:image/svg+xml,<svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M21 3H3V21H21V3ZM10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z' fill='#{$custom-control-indicator-checked-color}'/></svg>"), "#", "%23") !default;
 
 $custom-checkbox-indicator-indeterminate-bg:           $component-active-bg !default;
 $custom-checkbox-indicator-indeterminate-color:        $custom-control-indicator-checked-color !default;
-$custom-checkbox-indicator-icon-indeterminate:         str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3e%3cpath stroke='#{$custom-checkbox-indicator-indeterminate-color}' d='M0 2h4'/%3e%3c/svg%3e"), "#", "%23") !default;
+$custom-checkbox-indicator-icon-indeterminate:         str-replace(url("data:image/svg+xml,<svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M21 3H3V21H21V3ZM17 13H7V11H17V13Z' fill='#{$custom-checkbox-indicator-indeterminate-color}'/></svg>"), "#", "%23") !default;
 $custom-checkbox-indicator-indeterminate-box-shadow:   none !default;
 $custom-checkbox-indicator-indeterminate-border-color: $custom-checkbox-indicator-indeterminate-bg !default;
 

--- a/src/Form/form-checkbox.mdx
+++ b/src/Form/form-checkbox.mdx
@@ -1,0 +1,228 @@
+---
+title: 'Form.Checkbox'
+type: 'component'
+components:
+- FormCheckbox
+categories:
+- Forms
+status: 'Stable'
+designStatus: 'Done'
+devStatus: 'Done'
+notes: |
+
+---
+
+A simple c  heckbox for use with `Form.CheckboxSet`.
+
+Note: extra props added to this component are passed as attributes to the
+underlying `input` node. See MDN for documentation on available
+[input attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attributes).
+
+
+### Controlled Standalone Usage
+
+```jsx live
+() => {
+  const [isChecked, setChecked] = useState(false);
+  const handleChange = e => setChecked(e.target.checked);
+  return (
+    <Form.Checkbox
+      checked={isChecked}
+      onChange={handleChange}
+    >
+      I want pizza.
+    </Form.Checkbox>
+  );
+}
+```
+
+### Controlled Group Usage
+
+```jsx live
+() => {
+
+  const [colorValues, { add, remove }] = useCheckboxSetValues(['green']);
+
+  const handleChange = e => {
+    if (e.target.checked) {
+      add(e.target.value);
+    } else {
+      remove(e.target.value);
+    }
+  }
+  return (
+    <Form.Group>
+      <Form.Label>Which Color?</Form.Label>
+      <Form.CheckboxSet
+        name="colors"
+        onChange={handleChange}
+        value={colorValues}
+      >
+        <Form.Checkbox value="red">Red</Form.Checkbox>
+        <Form.Checkbox value="green">Green</Form.Checkbox>
+        <Form.Checkbox value="blue">Blue</Form.Checkbox>
+        <Form.Checkbox value="cyan" disabled>Cyan</Form.Checkbox>
+      </Form.CheckboxSet>
+    </Form.Group>
+  );
+}
+```
+
+### Uncontrolled Usage
+
+```jsx live
+<Form.Group>
+  <Form.Label>Which Color?</Form.Label>
+  <Form.CheckboxSet
+    name="color-two"
+    onChange={(e) => console.log(e.target.value)}
+    defaultValue={['green']}
+  >
+    <Form.Checkbox value="red">Red</Form.Checkbox>
+    <Form.Checkbox value="green">Green</Form.Checkbox>
+    <Form.Checkbox value="blue">Blue</Form.Checkbox>
+    <Form.Checkbox value="cyan" disabled>Cyan</Form.Checkbox>
+  </Form.CheckboxSet>
+</Form.Group>
+```
+
+### Indeterminate Usage
+
+```jsx live
+() => {
+  const allCheeseOptions = ['swiss', 'cheddar', 'pepperjack'];
+  const [checkedCheeses, { add, remove, set, clear }] = useCheckboxSetValues(['swiss']);
+
+  const handleChange = e => {
+    if (e.target.checked) {
+      add(e.target.value);
+    } else {
+      remove(e.target.value);
+    }
+  }
+
+  const handleCheckAllChange = e => {
+    if (e.target.checked) {
+      set(allCheeseOptions);
+    } else {
+      clear();
+    }
+  };
+
+  const allChecked = allCheeseOptions.every(value => checkedCheeses.includes(value));
+  const someChecked = allCheeseOptions.some(value => checkedCheeses.includes(value));
+  const isIndeterminate = someChecked && !allChecked;
+
+  return (
+    <>
+      <Form.Checkbox
+        checked={allChecked}
+        isIndeterminate={isIndeterminate}
+        onChange={handleCheckAllChange}
+      >
+        All the cheese
+      </Form.Checkbox>
+      <div className="pl-4 my-2">
+        <Form.Checkbox
+          checked={checkedCheeses.includes('swiss')}
+          onChange={handleChange}
+          value="swiss"
+        >
+          Swiss
+        </Form.Checkbox>
+        <Form.Checkbox
+          checked={checkedCheeses.includes('cheddar')}
+          onChange={handleChange}
+          value="cheddar"
+        >
+          Cheddar
+        </Form.Checkbox>
+        <Form.Checkbox
+          checked={checkedCheeses.includes('pepperjack')}
+          onChange={handleChange}
+          value="pepperjack"
+        >
+          Pepperjack
+        </Form.Checkbox>
+      </div>
+    </>
+  );
+}
+```
+
+### Inline layout
+
+```jsx live
+<Form.Group>
+  <Form.Label>Which Color?</Form.Label>
+  <Form.CheckboxSet
+    name="color-three"
+    onChange={(e) => console.log(e.target.value)}
+    defaultValue={['green']}
+    isInline
+  >
+    <Form.Checkbox value="red">Red</Form.Checkbox>
+    <Form.Checkbox value="green">Green</Form.Checkbox>
+    <Form.Checkbox value="blue">Blue</Form.Checkbox>
+    <Form.Checkbox value="cyan" disabled>Cyan</Form.Checkbox>
+  </Form.CheckboxSet>
+</Form.Group>
+```
+
+### Validation
+
+#### Group Level Validation
+
+```jsx live
+<Form.Group isInvalid>
+  <Form.Label>Which Color?</Form.Label>
+  <Form.CheckboxSet
+    name="color-five"
+    onChange={(e) => console.log(e.target.value)}
+  >
+    <Form.Checkbox value="red">Red</Form.Checkbox>
+    <Form.Checkbox value="green">Green</Form.Checkbox>
+    <Form.Checkbox value="blue">Blue</Form.Checkbox>
+    <Form.Checkbox value="cyan" disabled>Cyan</Form.Checkbox>
+  </Form.CheckboxSet>
+  <Form.Control.Feedback>
+    Please choose an option.
+  </Form.Control.Feedback>
+</Form.Group>
+```
+
+#### Individual option validation
+
+```jsx live
+<Form.Group>
+  <Form.Label>Which Color?</Form.Label>
+  <Form.CheckboxSet name="color-four">
+    <Form.Checkbox
+      value="red"
+      description="Red's cool"
+    >
+      Red
+    </Form.Checkbox>
+    <Form.Checkbox
+      value="green"
+      description="Excellent choice"
+      isValid
+    >
+      Green
+    </Form.Checkbox>
+    <Form.Checkbox
+      value="blue"
+      description="Poor choice"
+      isInvalid
+    >
+      Blue
+    </Form.Checkbox>
+    <Form.Checkbox
+      value="cyan"
+      disabled
+    >
+      Cyan
+    </Form.Checkbox>
+  </Form.CheckboxSet>
+</Form.Group>
+```

--- a/src/Form/form-checkbox.mdx
+++ b/src/Form/form-checkbox.mdx
@@ -5,7 +5,7 @@ components:
 - FormCheckbox
 categories:
 - Forms
-status: 'Stable'
+status: 'New'
 designStatus: 'Done'
 devStatus: 'Done'
 notes: |

--- a/src/Form/form-checkbox.mdx
+++ b/src/Form/form-checkbox.mdx
@@ -12,7 +12,7 @@ notes: |
 
 ---
 
-A simple c  heckbox for use with `Form.CheckboxSet`.
+A simple checkbox for use with `Form.CheckboxSet`.
 
 Note: extra props added to this component are passed as attributes to the
 underlying `input` node. See MDN for documentation on available

--- a/src/Form/form-checkbox.mdx
+++ b/src/Form/form-checkbox.mdx
@@ -26,17 +26,18 @@ underlying `input` node. See MDN for documentation on available
   const [isChecked, setChecked] = useState(false);
   const handleChange = e => setChecked(e.target.checked);
   return (
-    <Form.Checkbox
-      checked={isChecked}
-      onChange={handleChange}
-    >
+    <Form.Checkbox checked={isChecked} onChange={handleChange}>
       I want pizza.
     </Form.Checkbox>
   );
 }
 ```
 
-### Controlled Group Usage
+### Controlled Group Usage with useCheckboxSetValues
+
+`useCheckboxSetValues(initialValues[])` returns an array: `[state, dispatchers]`.
+
+`dispatchers` includes `add(value)` `remove(value)` `set(values[])` and `clear()`
 
 ```jsx live
 () => {
@@ -67,6 +68,8 @@ underlying `input` node. See MDN for documentation on available
   );
 }
 ```
+
+
 
 ### Uncontrolled Usage
 

--- a/src/Form/form-checkbox.mdx
+++ b/src/Form/form-checkbox.mdx
@@ -97,19 +97,11 @@ underlying `input` node. See MDN for documentation on available
   const [checkedCheeses, { add, remove, set, clear }] = useCheckboxSetValues(['swiss']);
 
   const handleChange = e => {
-    if (e.target.checked) {
-      add(e.target.value);
-    } else {
-      remove(e.target.value);
-    }
-  }
+    e.target.checked ? add(e.target.value) : remove(e.target.value);
+  };
 
   const handleCheckAllChange = e => {
-    if (e.target.checked) {
-      set(allCheeseOptions);
-    } else {
-      clear();
-    }
+    e.target.checked ? set(allCheeseOptions) : clear();
   };
 
   const allChecked = allCheeseOptions.every(value => checkedCheeses.includes(value));
@@ -125,29 +117,15 @@ underlying `input` node. See MDN for documentation on available
       >
         All the cheese
       </Form.Checkbox>
-      <div className="pl-4 my-2">
-        <Form.Checkbox
-          checked={checkedCheeses.includes('swiss')}
-          onChange={handleChange}
-          value="swiss"
-        >
-          Swiss
-        </Form.Checkbox>
-        <Form.Checkbox
-          checked={checkedCheeses.includes('cheddar')}
-          onChange={handleChange}
-          value="cheddar"
-        >
-          Cheddar
-        </Form.Checkbox>
-        <Form.Checkbox
-          checked={checkedCheeses.includes('pepperjack')}
-          onChange={handleChange}
-          value="pepperjack"
-        >
-          Pepperjack
-        </Form.Checkbox>
-      </div>
+      <Form.CheckboxSet
+        className="p-2"
+        value={checkedCheeses}
+        onChange={handleChange}
+      >
+        <Form.Checkbox value="swiss">Swiss</Form.Checkbox>
+        <Form.Checkbox value="cheddar">Cheddar</Form.Checkbox>
+        <Form.Checkbox value="pepperjack">Pepperjack</Form.Checkbox>
+      </Form.CheckboxSet>
     </>
   );
 }

--- a/src/Form/form-radio.mdx
+++ b/src/Form/form-radio.mdx
@@ -5,7 +5,7 @@ components:
 - FormRadio
 categories:
 - Forms
-status: 'Stable'
+status: 'New'
 designStatus: 'Done'
 devStatus: 'Done'
 notes: |

--- a/src/Form/form-switch.mdx
+++ b/src/Form/form-switch.mdx
@@ -1,0 +1,212 @@
+---
+title: 'Form.Switch'
+type: 'component'
+components:
+- FormSwitch
+- FormCheckbox
+categories:
+- Forms
+status: 'New'
+designStatus: 'Done'
+devStatus: 'Done'
+notes: |
+
+---
+
+A switch control for use with `Form.CheckboxSet`. This component has identical
+props to `Form.Checkbox` and is interoperable with `Form.CheckboxSet` and
+`useCheckboxSetValues`.
+
+Note: extra props added to this component are passed as attributes to the
+underlying `input` node. See MDN for documentation on available
+[input attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attributes).
+
+
+### Controlled Standalone Usage
+
+```jsx live
+() => {
+  const [isChecked, setChecked] = useState(false);
+  const handleChange = e => setChecked(e.target.checked);
+  return (
+    <Form.Switch checked={isChecked} onChange={handleChange}>
+      I want pizza.
+    </Form.Switch>
+  );
+}
+```
+
+### Controlled Group Usage with useCheckboxSetValues
+
+`useCheckboxSetValues(initialValues[])` returns an array: `[state, dispatchers]`.
+
+`dispatchers` includes `add(value)` `remove(value)` `set(values[])` and `clear()`
+
+```jsx live
+() => {
+
+  const [colorValues, { add, remove }] = useCheckboxSetValues(['green']);
+
+  const handleChange = e => {
+    if (e.target.checked) {
+      add(e.target.value);
+    } else {
+      remove(e.target.value);
+    }
+  }
+  return (
+    <Form.Group>
+      <Form.Label>Which Color?</Form.Label>
+      <Form.CheckboxSet
+        name="colors"
+        onChange={handleChange}
+        value={colorValues}
+      >
+        <Form.Switch value="red">Red</Form.Switch>
+        <Form.Switch value="green">Green</Form.Switch>
+        <Form.Switch value="blue">Blue</Form.Switch>
+        <Form.Switch value="cyan" disabled>Cyan</Form.Switch>
+      </Form.CheckboxSet>
+    </Form.Group>
+  );
+}
+```
+
+
+
+### Uncontrolled Usage
+
+```jsx live
+<Form.Group>
+  <Form.Label>Which Color?</Form.Label>
+  <Form.CheckboxSet
+    name="color-two"
+    onChange={(e) => console.log(e.target.value)}
+    defaultValue={['green']}
+  >
+    <Form.Switch value="red">Red</Form.Switch>
+    <Form.Switch value="green">Green</Form.Switch>
+    <Form.Switch value="blue">Blue</Form.Switch>
+    <Form.Switch value="cyan" disabled>Cyan</Form.Switch>
+  </Form.CheckboxSet>
+</Form.Group>
+```
+
+### Indeterminate Usage
+
+```jsx live
+() => {
+  const allCheeseOptions = ['swiss', 'cheddar', 'pepperjack'];
+  const [checkedCheeses, { add, remove, set, clear }] = useCheckboxSetValues(['swiss']);
+
+  const handleChange = e => {
+    e.target.checked ? add(e.target.value) : remove(e.target.value);
+  };
+
+  const handleCheckAllChange = e => {
+    e.target.checked ? set(allCheeseOptions) : clear();
+  };
+
+  const allChecked = allCheeseOptions.every(value => checkedCheeses.includes(value));
+  const someChecked = allCheeseOptions.some(value => checkedCheeses.includes(value));
+  const isIndeterminate = someChecked && !allChecked;
+
+  return (
+    <>
+      <Form.Switch
+        checked={allChecked}
+        isIndeterminate={isIndeterminate}
+        onChange={handleCheckAllChange}
+      >
+        All the cheese
+      </Form.Switch>
+      <Form.CheckboxSet
+        className="p-2"
+        value={checkedCheeses}
+        onChange={handleChange}
+      >
+        <Form.Switch value="swiss">Swiss</Form.Switch>
+        <Form.Switch value="cheddar">Cheddar</Form.Switch>
+        <Form.Switch value="pepperjack">Pepperjack</Form.Switch>
+      </Form.CheckboxSet>
+    </>
+  );
+}
+```
+
+### Inline layout
+
+```jsx live
+<Form.Group>
+  <Form.Label>Which Color?</Form.Label>
+  <Form.CheckboxSet
+    name="color-three"
+    onChange={(e) => console.log(e.target.value)}
+    defaultValue={['green']}
+    isInline
+  >
+    <Form.Switch value="red">Red</Form.Switch>
+    <Form.Switch value="green">Green</Form.Switch>
+    <Form.Switch value="blue">Blue</Form.Switch>
+    <Form.Switch value="cyan" disabled>Cyan</Form.Switch>
+  </Form.CheckboxSet>
+</Form.Group>
+```
+
+### Validation
+
+#### Group Level Validation
+
+```jsx live
+<Form.Group isInvalid>
+  <Form.Label>Which Color?</Form.Label>
+  <Form.CheckboxSet
+    name="color-five"
+    onChange={(e) => console.log(e.target.value)}
+  >
+    <Form.Switch value="red">Red</Form.Switch>
+    <Form.Switch value="green">Green</Form.Switch>
+    <Form.Switch value="blue">Blue</Form.Switch>
+    <Form.Switch value="cyan" disabled>Cyan</Form.Switch>
+  </Form.CheckboxSet>
+  <Form.Control.Feedback>
+    Please choose an option.
+  </Form.Control.Feedback>
+</Form.Group>
+```
+
+#### Individual option validation
+
+```jsx live
+<Form.Group>
+  <Form.Label>Which Color?</Form.Label>
+  <Form.CheckboxSet name="color-four">
+    <Form.Switch
+      value="red"
+      description="Red's cool"
+    >
+      Red
+    </Form.Switch>
+    <Form.Switch
+      value="green"
+      description="Excellent choice"
+      isValid
+    >
+      Green
+    </Form.Switch>
+    <Form.Switch
+      value="blue"
+      description="Poor choice"
+      isInvalid
+    >
+      Blue
+    </Form.Switch>
+    <Form.Switch
+      value="cyan"
+      disabled
+    >
+      Cyan
+    </Form.Switch>
+  </Form.CheckboxSet>
+</Form.Group>
+```

--- a/src/Form/index.jsx
+++ b/src/Form/index.jsx
@@ -8,10 +8,16 @@ import FormControlDecoratorGroup from './FormControlDecoratorGroup';
 import FormRadio from './FormRadio';
 import FormRadioSet from './FormRadioSet';
 import FormRadioSetContext from './FormRadioSetContext';
+import FormCheckbox from './FormCheckbox';
+import FormCheckboxSet from './FormCheckboxSet';
+import FormCheckboxSetContext from './FormCheckboxSetContext';
+import useCheckboxSetValues from './useCheckboxSetValues';
 
 Form.Control = FormControl;
 Form.Radio = FormRadio;
 Form.RadioSet = FormRadioSet;
+Form.Checkbox = FormCheckbox;
+Form.CheckboxSet = FormCheckboxSet;
 Form.Label = FormLabel;
 Form.Group = FormGroup;
 Form.Text = FormText;
@@ -23,10 +29,14 @@ export {
   FormRadio,
   FormRadioSet,
   FormRadioSetContext,
+  FormCheckbox,
+  FormCheckboxSet,
+  FormCheckboxSetContext,
   FormGroup,
   FormControlDecoratorGroup,
   FormControlFeedback,
   FormText,
+  useCheckboxSetValues,
 };
 
 export { default as FormCheck } from 'react-bootstrap/FormCheck';

--- a/src/Form/index.jsx
+++ b/src/Form/index.jsx
@@ -9,6 +9,7 @@ import FormRadio from './FormRadio';
 import FormRadioSet from './FormRadioSet';
 import FormRadioSetContext from './FormRadioSetContext';
 import FormCheckbox from './FormCheckbox';
+import FormSwitch from './FormSwitch';
 import FormCheckboxSet from './FormCheckboxSet';
 import FormCheckboxSetContext from './FormCheckboxSetContext';
 import useCheckboxSetValues from './useCheckboxSetValues';
@@ -17,6 +18,7 @@ Form.Control = FormControl;
 Form.Radio = FormRadio;
 Form.RadioSet = FormRadioSet;
 Form.Checkbox = FormCheckbox;
+Form.Switch = FormSwitch;
 Form.CheckboxSet = FormCheckboxSet;
 Form.Label = FormLabel;
 Form.Group = FormGroup;
@@ -30,6 +32,7 @@ export {
   FormRadioSet,
   FormRadioSetContext,
   FormCheckbox,
+  FormSwitch,
   FormCheckboxSet,
   FormCheckboxSetContext,
   FormGroup,

--- a/src/Form/tests/FormCheckbox.test.jsx
+++ b/src/Form/tests/FormCheckbox.test.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import FormCheckbox from '../FormCheckbox';
+import FormGroup from '../FormGroup';
+import FormLabel from '../FormLabel';
 
 describe('FormCheckbox', () => {
   const handleChange = jest.fn();
@@ -67,5 +69,36 @@ describe('FormCheckbox', () => {
         type: 'blur',
       }),
     );
+  });
+});
+
+describe('FormCheckbox with FormGroup', () => {
+  const handleChange = jest.fn();
+  const handleFocus = jest.fn();
+  const handleBlur = jest.fn();
+  const wrapper = mount((
+    <FormGroup controlId="group-id">
+      <FormLabel>Group Label</FormLabel>
+      <FormCheckbox
+        value="green"
+        name="color"
+        onChange={handleChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        description="Describe green"
+      >
+        Green
+      </FormCheckbox>
+    </FormGroup>
+  ));
+
+  it('renders an a group with a label', () => {
+    expect(wrapper.exists('#group-id')).toBe(true);
+    const groupNode = wrapper.find('#group-id').first();
+    const labelledById = groupNode.props()['aria-labelledby'];
+    expect(labelledById).toBeTruthy();
+    expect(wrapper.exists(`#${labelledById}`)).toBe(true);
+    const labelNode = wrapper.find(`#${labelledById}`).first();
+    expect(labelNode.text()).toBe('Group Label');
   });
 });

--- a/src/Form/tests/FormCheckbox.test.jsx
+++ b/src/Form/tests/FormCheckbox.test.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import FormCheckbox from '../FormCheckbox';
+
+describe('FormCheckbox', () => {
+  const handleChange = jest.fn();
+  const handleFocus = jest.fn();
+  const handleBlur = jest.fn();
+  const wrapper = mount((
+    <FormCheckbox
+      value="green"
+      name="color"
+      onChange={handleChange}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      description="Describe green"
+    >
+      Green
+    </FormCheckbox>
+  ));
+  const inputNode = wrapper.find('input[value="green"]').first();
+
+  it('renders an input with a name and value', () => {
+    wrapper.exists('input[value="green"]');
+    expect(inputNode.props().name).toBe('color');
+  });
+
+  it('has an associated label', () => {
+    const inputNodeId = inputNode.props().id;
+    wrapper.exists({ htmlFor: inputNodeId });
+    const labelNode = wrapper.find({ htmlFor: inputNodeId }).hostNodes().first();
+    expect(labelNode.text()).toBe('Green');
+  });
+
+  it('has an associated description', () => {
+    const describerIds = inputNode.props()['aria-describedby'];
+    const describerNode = wrapper.find({ id: describerIds }).hostNodes().first();
+    wrapper.exists({ id: describerIds });
+    expect(describerNode.text()).toBe('Describe green');
+  });
+
+  it('calls the change handler', () => {
+    inputNode.simulate('change');
+    expect(handleChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({ value: 'green' }),
+        type: 'change',
+      }),
+    );
+  });
+
+  it('calls the focus handler', () => {
+    inputNode.simulate('focus');
+    expect(handleFocus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({ value: 'green' }),
+        type: 'focus',
+      }),
+    );
+  });
+
+  it('calls the blur handler', () => {
+    inputNode.simulate('blur');
+    expect(handleBlur).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({ value: 'green' }),
+        type: 'blur',
+      }),
+    );
+  });
+});

--- a/src/Form/tests/FormCheckboxSet.test.jsx
+++ b/src/Form/tests/FormCheckboxSet.test.jsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import FormGroup from '../FormGroup';
+import FormCheckboxSet from '../FormCheckboxSet';
+import FormCheckbox from '../FormCheckbox';
+import FormLabel from '../FormLabel';
+
+describe('FormCheckboxSet', () => {
+  describe('associate element ids and attributes', () => {
+    const handleChange = jest.fn();
+    const value = ['green'];
+    const wrapper = mount((
+      <FormGroup controlId="my-field">
+        <FormLabel>Which color?</FormLabel>
+        <FormCheckboxSet
+          name="colors"
+          onChange={handleChange}
+          value={value}
+        >
+          <FormCheckbox value="red">Red</FormCheckbox>
+          <FormCheckbox value="green">Green</FormCheckbox>
+          <FormCheckbox value="blue" description="Blue description">Blue</FormCheckbox>
+          <FormCheckbox value="cyan" disabled>Cyan</FormCheckbox>
+        </FormCheckboxSet>
+      </FormGroup>
+    ));
+
+    it('has a group div with the proper id', () => {
+      expect(wrapper.exists('div[role="group"]')).toBe(true);
+      const groupNode = wrapper.find('div[role="group"]').first();
+      expect(groupNode.props().id).toEqual('my-field');
+    });
+
+    it('has an element labelling the group', () => {
+      expect(wrapper.exists('FormLabel')).toBe(true);
+      const labelNode = wrapper.find('FormLabel').first().childAt(0);
+      const labelNodeId = labelNode.props().id;
+      expect(labelNode.props().id).toBeTruthy();
+      const groupNode = wrapper.find('div[role="group"]').first();
+      expect(groupNode.props()['aria-labelledby']).toContain(labelNodeId);
+    });
+
+    it('has a description for a checkbox value', () => {
+      expect(wrapper.exists({ children: 'Blue description' })).toBe(true);
+      const checkboxNode = wrapper.find('input[value="blue"]').first();
+      const describerIds = checkboxNode.props()['aria-describedby'];
+      expect(describerIds).toBeTruthy();
+      expect(wrapper.exists(`#${describerIds}`)).toBe(true);
+      const descriptionNode = wrapper.find(`#${describerIds}`).first();
+      const descriptionNodeContent = descriptionNode.props().children;
+      expect(descriptionNodeContent).toBe('Blue description');
+    });
+  });
+
+  describe('controlled behavior', () => {
+    const setValue = jest.fn();
+    const wrapper = mount((
+      <FormCheckboxSet
+        value={['red']}
+        name="colors"
+        onChange={(e) => {
+          setValue(e.target.value);
+        }}
+      >
+        <FormCheckbox value="red">red</FormCheckbox>
+        <FormCheckbox value="green">green</FormCheckbox>
+        <FormCheckbox value="blue">blue</FormCheckbox>
+      </FormCheckboxSet>
+    ));
+
+    it('checks the right checkbox button', () => {
+      const checkboxNode = wrapper.find('input[value="red"]').first();
+      expect(checkboxNode.props().checked).toBe(true);
+    });
+
+    it('calls the change handlers with the right value', () => {
+      const checkboxNode = wrapper.find('input[value="green"]').first();
+      const eventData = { target: { value: 'green' } };
+      checkboxNode.simulate('change', eventData);
+      expect(setValue).toHaveBeenCalledWith('green');
+    });
+  });
+
+  describe('event handlers', () => {
+    const onChange = jest.fn();
+    const onBlur = jest.fn();
+    const onFocus = jest.fn();
+    const wrapper = mount((
+      <FormCheckboxSet
+        value={['red']}
+        name="colors"
+        onBlur={onBlur}
+        onFocus={onFocus}
+        onChange={onChange}
+      >
+        <FormCheckbox value="red">red</FormCheckbox>
+        <FormCheckbox value="green">green</FormCheckbox>
+        <FormCheckbox value="blue">blue</FormCheckbox>
+      </FormCheckboxSet>
+    ));
+
+    const checkboxNode = wrapper.find('input[value="green"]').first();
+
+    it('calls the change handlers with the right value', () => {
+      checkboxNode.simulate('change');
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: expect.objectContaining({ value: 'green' }),
+          type: 'change',
+        }),
+      );
+    });
+    it('calls the focus handler', () => {
+      checkboxNode.simulate('focus');
+      expect(onFocus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: expect.objectContaining({ value: 'green' }),
+          type: 'focus',
+        }),
+      );
+    });
+    it('calls the blur handler', () => {
+      checkboxNode.simulate('blur');
+      expect(onBlur).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: expect.objectContaining({ value: 'green' }),
+          type: 'blur',
+        }),
+      );
+    });
+  });
+
+  describe('uncontrolled behavior', () => {
+    const wrapper = mount((
+      <FormCheckboxSet
+        defaultValue={['red']}
+        name="colors"
+        id="my-field"
+        label="Which color?"
+      >
+        <FormCheckbox value="red">red</FormCheckbox>
+        <FormCheckbox value="green">green</FormCheckbox>
+        <FormCheckbox value="blue">blue</FormCheckbox>
+      </FormCheckboxSet>
+    ));
+
+    it('checks the right checkbox button', () => {
+      const checkboxNode = wrapper.find('input[value="red"]').first();
+      expect(checkboxNode.props().defaultChecked).toBe(true);
+    });
+  });
+
+  it('renders checkbox control without a context', () => {
+    const wrapper = mount((
+      <>
+        <FormCheckbox name="trees">Evergreen</FormCheckbox>
+      </>
+    ));
+
+    expect(wrapper.exists('input[type="checkbox"]')).toBe(true);
+    const checkboxNode = wrapper.find('input[type="checkbox"]').first();
+    expect(checkboxNode.props().name).toBe('trees');
+  });
+});

--- a/src/Form/tests/FormCheckboxSet.test.jsx
+++ b/src/Form/tests/FormCheckboxSet.test.jsx
@@ -149,16 +149,4 @@ describe('FormCheckboxSet', () => {
       expect(checkboxNode.props().defaultChecked).toBe(true);
     });
   });
-
-  it('renders checkbox control without a context', () => {
-    const wrapper = mount((
-      <>
-        <FormCheckbox name="trees">Evergreen</FormCheckbox>
-      </>
-    ));
-
-    expect(wrapper.exists('input[type="checkbox"]')).toBe(true);
-    const checkboxNode = wrapper.find('input[type="checkbox"]').first();
-    expect(checkboxNode.props().name).toBe('trees');
-  });
 });

--- a/src/Form/tests/FormSwitch.test.jsx
+++ b/src/Form/tests/FormSwitch.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import FormSwitch from '../FormSwitch';
+
+// A minimal test here since Switch depends on Checkbox
+
+describe('FormSwitch', () => {
+  const wrapper = mount((
+    <FormSwitch name="color value="green" description="Describe green">
+      Green
+    </FormSwitch>
+  ));
+  const inputNode = wrapper.find('input[value="green"]').first();
+
+  it('renders an input with a name and value and role=switch', () => {
+    wrapper.exists('input[value="green"]');
+    expect(inputNode.props().name).toBe('color');
+    expect(inputNode.props().role).toBe('switch');
+  });
+});

--- a/src/Form/tests/FormSwitch.test.jsx
+++ b/src/Form/tests/FormSwitch.test.jsx
@@ -6,7 +6,7 @@ import FormSwitch from '../FormSwitch';
 
 describe('FormSwitch', () => {
   const wrapper = mount((
-    <FormSwitch name="color value="green" description="Describe green">
+    <FormSwitch name="color" value="green" description="Describe green">
       Green
     </FormSwitch>
   ));

--- a/src/Form/tests/useCheckboxSetValues.test.jsx
+++ b/src/Form/tests/useCheckboxSetValues.test.jsx
@@ -1,0 +1,65 @@
+/* eslint-disable react/button-has-type */
+import React from 'react';
+import { mount } from 'enzyme';
+import useCheckboxSetValues from '../useCheckboxSetValues';
+
+const Example = () => {
+  const [values, {
+    add, remove, set, clear,
+  }] = useCheckboxSetValues(['cheddar']);
+  return (
+    <>
+      <span id="values">{values.join(' ')}</span>
+      <button id="add" onClick={() => add('provolone')}>Add</button>
+      <button id="remove" onClick={() => remove('provolone')}>Add</button>
+      <button id="set" onClick={() => set(['cheddar', 'swiss', 'provolone'])}>Add</button>
+      <button id="clear" onClick={() => clear()}>Add</button>
+    </>
+  );
+};
+
+describe('useCheckboxSetValues', () => {
+  const wrapper = mount(<Example />);
+
+  const getValues = () => {
+    const valueStr = wrapper.find('#values').first().text();
+    if (valueStr === '') {
+      return [];
+    }
+    return valueStr.split(' ');
+  };
+
+  const addButton = wrapper.find('#add').first();
+  const removeButton = wrapper.find('#remove').first();
+  const setButton = wrapper.find('#set').first();
+  const clearButton = wrapper.find('#clear').first();
+
+  it('has a default value', () => {
+    const values = getValues();
+    expect(values).toEqual(['cheddar']);
+  });
+
+  it('can append a value', () => {
+    addButton.simulate('click');
+    const values = getValues();
+    expect(values).toEqual(['cheddar', 'provolone']);
+  });
+
+  it('can remove a value', () => {
+    removeButton.simulate('click');
+    const values = getValues();
+    expect(values).toEqual(['cheddar']);
+  });
+
+  it('can replace all values', () => {
+    setButton.simulate('click');
+    const values = getValues();
+    expect(values).toEqual(['cheddar', 'swiss', 'provolone']);
+  });
+
+  it('can clear all values', () => {
+    clearButton.simulate('click');
+    const values = getValues();
+    expect(values).toEqual([]);
+  });
+});

--- a/src/Form/useCheckboxSetValues.jsx
+++ b/src/Form/useCheckboxSetValues.jsx
@@ -9,12 +9,12 @@ const checkboxValuesReducer = (state, action) => {
     case 'set':
       return [...action.value];
     case 'clear':
-      return [];
     default:
-      throw new Error('An unknown update to checkbox set values was attemped');
+      return [];
   }
 };
 
+// istanbul ignore else
 const useCheckboxSetValues = (initialState = []) => {
   const [state, dispatch] = useReducer(checkboxValuesReducer, initialState);
 

--- a/src/Form/useCheckboxSetValues.jsx
+++ b/src/Form/useCheckboxSetValues.jsx
@@ -14,7 +14,6 @@ const checkboxValuesReducer = (state, action) => {
   }
 };
 
-// istanbul ignore else
 const useCheckboxSetValues = (initialState = []) => {
   const [state, dispatch] = useReducer(checkboxValuesReducer, initialState);
 

--- a/src/Form/useCheckboxSetValues.jsx
+++ b/src/Form/useCheckboxSetValues.jsx
@@ -1,0 +1,30 @@
+import { useReducer } from 'react';
+
+const checkboxValuesReducer = (state, action) => {
+  switch (action.type) {
+    case 'add':
+      return [...state, action.value];
+    case 'remove':
+      return state.filter(value => value !== action.value);
+    case 'set':
+      return [...action.value];
+    case 'clear':
+      return [];
+    default:
+      throw new Error('An unknown update to checkbox set values was attemped');
+  }
+};
+
+const useCheckboxSetValues = (initialState = []) => {
+  const [state, dispatch] = useReducer(checkboxValuesReducer, initialState);
+
+  const dispatchers = {
+    add: (value) => dispatch({ type: 'add', value }),
+    remove: (value) => dispatch({ type: 'remove', value }),
+    set: (value) => dispatch({ type: 'set', value }),
+    clear: () => dispatch({ type: 'clear' }),
+  };
+  return [state, dispatchers];
+};
+
+export default useCheckboxSetValues;

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ export {
   FormRadioSetContext,
   FormGroup,
   FormLabel,
+  useCheckboxSetValues,
   FormText,
   InputGroup,
 } from './Form';

--- a/www/src/components/Header.jsx
+++ b/www/src/components/Header.jsx
@@ -97,8 +97,8 @@ const Navbar = ({
 Navbar.propTypes = {
   siteTitle: PropTypes.string.isRequired,
   onMenuClick: PropTypes.func.isRequired,
-  menuIsOpen: PropTypes.string,
-  showMinimizedTitle: PropTypes.string,
+  menuIsOpen: PropTypes.bool,
+  showMinimizedTitle: PropTypes.bool,
 };
 Navbar.defaultProps = {
   menuIsOpen: false,


### PR DESCRIPTION
Add `Checkbox`, `Switch`, `CheckboxSet` and `useCheckboxSetValues` to facilitate check-style options.

Individual usage:
```
() => {
  const [isChecked, setChecked] = useState(false);
  const handleChange = e => setChecked(e.target.checked);
  return (
    <Form.Checkbox checked={isChecked} onChange={handleChange}>
      I want pizza.
    </Form.Checkbox>
  );
}
```

Set usage
```
() => {

  const [colorValues, { add, remove }] = useCheckboxSetValues(['green']);

  const handleChange = e => {
    if (e.target.checked) {
      add(e.target.value);
    } else {
      remove(e.target.value);
    }
  }
  return (
    <Form.Group>
      <Form.Label>Which Color?</Form.Label>
      <Form.CheckboxSet
        name="colors"
        onChange={handleChange}
        value={colorValues}
      >
        <Form.Checkbox value="red">Red</Form.Checkbox>
        <Form.Checkbox value="green">Green</Form.Checkbox>
        <Form.Checkbox value="blue">Blue</Form.Checkbox>
        <Form.Checkbox value="cyan" disabled>Cyan</Form.Checkbox>
      </Form.CheckboxSet>
    </Form.Group>
  );
}
```