### PR TITLE
fix: resolve console error during testing with react-testing-renderer

### DIFF
--- a/src/DataTable/IndeterminateCheckBox.jsx
+++ b/src/DataTable/IndeterminateCheckBox.jsx
@@ -7,7 +7,10 @@ const IndeterminateCheckbox = React.forwardRef(
     const resolvedRef = ref || defaultRef;
 
     React.useEffect(() => {
-      resolvedRef.current.indeterminate = indeterminate;
+      // this if(resolvedRef.current) prevents console errors in testing
+      if (resolvedRef.current) {
+        resolvedRef.current.indeterminate = indeterminate;
+      }
     }, [resolvedRef, indeterminate]);
 
     return (

--- a/src/Form/FormCheckbox.jsx
+++ b/src/Form/FormCheckbox.jsx
@@ -15,9 +15,11 @@ const CheckboxControl = React.forwardRef(
       ...props,
       className: classNames('pgn__form-checkbox-input', props.className),
     });
-
     React.useEffect(() => {
-      resolvedRef.current.indeterminate = isIndeterminate;
+      // this if(resolvedRef.current) prevents console errors in testing
+      if (resolvedRef.current) {
+        resolvedRef.current.indeterminate = isIndeterminate;
+      }
     }, [resolvedRef, isIndeterminate]);
 
     return (

--- a/src/Form/FormSwitch.jsx
+++ b/src/Form/FormSwitch.jsx
@@ -18,7 +18,10 @@ const SwitchControl = React.forwardRef(
     });
 
     React.useEffect(() => {
-      resolvedRef.current.indeterminate = isIndeterminate;
+      // this if(resolvedRef.current) prevents console errors in testing
+      if (resolvedRef.current) {
+        resolvedRef.current.indeterminate = isIndeterminate;
+      }
     }, [resolvedRef, isIndeterminate]);
 
     return (


### PR DESCRIPTION
react-testing-renderer does not handle refs in the same way as the browser does, causing a large console error. This change resolves that error.