### PR TITLE
[PAR-443] fix: update HyperLink component

### DIFF
--- a/src/Hyperlink/Hyperlink.test.jsx
+++ b/src/Hyperlink/Hyperlink.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import classNames from 'classnames';
 
 import Hyperlink from './index';
 
@@ -41,12 +40,12 @@ describe('correct rendering', () => {
     expect(wrapper.find('span')).toHaveLength(2);
 
     const icon = wrapper.find('span').at(1);
+    const iconImage = icon.find('svg').at(0);
 
-    expect(icon.prop('aria-hidden')).toEqual(false);
-    expect(icon.prop('className'))
-      .toEqual(classNames('fa', 'fa-external-link'));
-    expect(icon.prop('aria-label')).toEqual(externalLinkAlternativeText);
-    expect(icon.prop('title')).toEqual(externalLinkTitle);
+    expect(icon.prop('className')).toEqual('pgn__icon');
+    expect(iconImage.prop('role')).toEqual('img');
+    expect(iconImage.prop('width')).toEqual(24);
+    expect(iconImage.prop('height')).toEqual(24);
   });
 });
 

--- a/src/Hyperlink/index.jsx
+++ b/src/Hyperlink/index.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import isRequiredIf from 'react-proptype-conditional-require';
+import Icon from '../Icon';
+import { Launch } from '../../icons';
 
 import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
 
@@ -23,14 +24,9 @@ function Hyperlink(props) {
     other.rel = other.rel ? `noopener ${other.rel}` : 'noopener';
 
     externalLinkIcon = (
-      // Space between content and icon
-      <span>{' '}
-        <span
-          className={classNames('fa', 'fa-external-link')}
-          aria-hidden={false}
-          aria-label={externalLinkAlternativeText}
-          title={externalLinkTitle}
-        />
+    // Space between content and icon
+      <span className="d-inline-block">{' '}
+        <Icon src={Launch} />
       </span>
     );
   }


### PR DESCRIPTION
### [PAR-443](https://openedx.atlassian.net/browse/PAR-443)

Update HyperLink component to use Paragon icon `Launch` instead of loading icon from `font-awesome` library.

#### HyperLink component (after change)
<img width="1004" alt="Screen Shot 2021-04-29 at 5 37 21 AM" src="https://user-images.githubusercontent.com/30112155/116489062-6ad3b500-a8ad-11eb-8d82-f5ad411ccdb3.png">
