### PR TITLE
feat: enable manual selection for DataTable

### DIFF
--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -31,6 +31,7 @@ function DataTable({
   bulkActions, tableActions, numBreakoutFilters,
   initialTableOptions,
   EmptyTableComponent,
+  manualSelectColumn,
   children,
   ...props
 }) {
@@ -60,7 +61,9 @@ function DataTable({
   });
   // adds selection column and action columns as necessary
   tableArgs.push(hooks => {
-    hooks.visibleColumns.push(visibleColumns => getVisibleColumns(isSelectable, visibleColumns, additionalColumns));
+    hooks.visibleColumns.push(
+      visibleColumns => getVisibleColumns(isSelectable, visibleColumns, additionalColumns, manualSelectColumn),
+    );
   });
 
   // Use the state and functions returned from useTable to build your UI
@@ -116,6 +119,7 @@ DataTable.defaultProps = {
   bulkActions: [],
   tableActions: [],
   numBreakoutFilters: 1,
+  manualSelectColumn: undefined,
 };
 
 DataTable.propTypes = {
@@ -130,6 +134,13 @@ DataTable.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   /** table rows can be selected */
   isSelectable: PropTypes.bool,
+  /** Alternate column for selecting rows. See react table useSort docs for more information */
+  manualSelectColumn: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    Header: PropTypes.func.isRequired,
+    Cell: PropTypes.func.isRequired,
+    disableSortBy: PropTypes.bool.isRequired,
+  }),
   /** Table columns can be sorted */
   isSortable: PropTypes.bool,
   /** Indicates that sorting will be done via backend API. A fetchData function must be provided */

--- a/src/DataTable/utils/getVisibleColumns.jsx
+++ b/src/DataTable/utils/getVisibleColumns.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import IndeterminateCheckbox from '../IndeterminateCheckBox';
 
-const sortColumn = {
+export const selectColumn = {
   id: 'selection',
   // The header can use the table's getToggleAllRowsSelectedProps method
   // to render a checkbox
@@ -25,10 +25,10 @@ const sortColumn = {
   disableSortBy: true,
 };
 
-const getVisibleColumns = (isSelectable, visibleColumns, additionalColumns = []) => {
+const getVisibleColumns = (isSelectable, visibleColumns, additionalColumns = [], manualSelectColumn = selectColumn) => {
   let columns = [];
   if (isSelectable) {
-    columns.push(sortColumn);
+    columns.push(manualSelectColumn);
   }
   columns = columns.concat(visibleColumns);
   if (additionalColumns.length > 0) {

--- a/src/DataTable/utils/tests/getVisibleColumns.test.js
+++ b/src/DataTable/utils/tests/getVisibleColumns.test.js
@@ -1,0 +1,31 @@
+/* eslint-disable object-curly-newline */
+
+import getVisibleColumns, { selectColumn } from '../getVisibleColumns';
+
+describe('getVisibleColums', () => {
+  const visibleColumns = [{ id: 'foo' }];
+  it('adds the sort column', () => {
+    expect(getVisibleColumns(true, [], [])).toEqual([selectColumn]);
+  });
+  it('returns the visible columns', () => {
+    expect(getVisibleColumns(false, visibleColumns)).toEqual(visibleColumns);
+  });
+  it('adds the sort column before visible columns', () => {
+    expect(getVisibleColumns(true, visibleColumns))
+      .toEqual([selectColumn, ...visibleColumns]);
+  });
+  it('uses a manual sort column if given one', () => {
+    const manualSort = { id: 'manual' };
+    expect(getVisibleColumns(true, visibleColumns, [], manualSort)).toEqual([manualSort, ...visibleColumns]);
+  });
+  it('adds additional columns after the visible columns', () => {
+    const additionalColumns = [{ id: 'bar' }, { id: 'baz' }];
+    expect(getVisibleColumns(false, visibleColumns, additionalColumns))
+      .toEqual([...visibleColumns, ...additionalColumns]);
+  });
+  it('puts columns in the correct order', () => {
+    const additionalColumns = [{ id: 'bar' }, { id: 'baz' }];
+    expect(getVisibleColumns(true, visibleColumns, additionalColumns))
+      .toEqual([selectColumn, ...visibleColumns, ...additionalColumns]);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ export { default as Collapsible } from './Collapsible';
 export { default as Dropdown, DropdownButton, SplitButton } from './Dropdown';
 export { default as Fade } from './Fade';
 export { default as Fieldset } from './Fieldset';
+export { default as IndeterminateCheckbox } from './DataTable/IndeterminateCheckBox';
 export {
   default as Form,
   CheckboxControl,


### PR DESCRIPTION
This allows for the selection column to be manually added, which is necessary when storing selections in a context outside the DataTable context.