### PR TITLE
[TNL-8132] - fix: update styling for HyperLink component

### DIFF
--- a/src/Hyperlink/index.jsx
+++ b/src/Hyperlink/index.jsx
@@ -25,7 +25,7 @@ function Hyperlink(props) {
 
     externalLinkIcon = (
     // Space between content and icon
-      <span className="d-inline-block">{' '}
+      <span className="d-inline-block align-text-top">{' '}
         <Icon src={Launch} style={{ height: '1em', width: '1em' }} />
       </span>
     );
@@ -33,6 +33,7 @@ function Hyperlink(props) {
 
   return (
     <a
+      style={{ textDecoration: 'underline' }}
       href={destination}
       target={target}
       onClick={onClick}


### PR DESCRIPTION
### [TN-8132](https://openedx.atlassian.net/browse/TNL-8132)

Update HyperLink styling

#### Comment from UX
```We just need to nudge it down a bit so it’s aligned with the baseline of the text. This link is in a paragraph so it will also need the underline.```

#### HyperLink component (before change)
<img width="970" alt="Screen Shot 2021-05-04 at 2 23 01 AM" src="https://user-images.githubusercontent.com/30112155/116936593-8100bd00-ac81-11eb-8f61-459a37f43366.png">


#### HyperLink component (after change)
<img width="1074" alt="Screen Shot 2021-05-05 at 12 00 11 AM" src="https://user-images.githubusercontent.com/30112155/117055683-d649d680-ad34-11eb-8bf3-5a6bff98bed3.png">

**NOTE: HyperLink text here is for testing purpose**
