### PR TITLE
Make TableControlBar more flexible

### DIFF
--- a/src/DataTable/SmartStatus.jsx
+++ b/src/DataTable/SmartStatus.jsx
@@ -1,14 +1,20 @@
 import React, { useContext } from 'react';
-import SelectionStatus from './SelectionStatus';
-import RowStatus from './RowStatus';
-import FilterStatus from './FilterStatus';
 import DataTableContext from './DataTableContext';
+import FilterStatusDefault from './FilterStatus';
+import RowStatusDefault from './RowStatus';
+import SelectionStatusDefault from './SelectionStatus';
 
 const SMART_STATUS_CLASS = 'pgn__smart-status';
 
 const SmartStatus = () => {
-  const { state, selectedFlatRows } = useContext(DataTableContext);
+  const {
+    state, selectedFlatRows, SelectionStatusComponent, FilterStatusComponent, RowStatusComponent,
+  } = useContext(DataTableContext);
   const numSelectedRows = selectedFlatRows?.length;
+  const SelectionStatus = SelectionStatusComponent || SelectionStatusDefault;
+  const FilterStatus = FilterStatusComponent || FilterStatusDefault;
+  const RowStatus = RowStatusComponent || RowStatusDefault;
+
   if (selectedFlatRows && numSelectedRows > 0) {
     return (
       <SelectionStatus

--- a/src/DataTable/TableControlBar.jsx
+++ b/src/DataTable/TableControlBar.jsx
@@ -16,14 +16,14 @@ const TableControlBar = ({
     <div className={classNames('pgn__data-table-status-bar', className)}>
       {/* Using setFilter as a proxy for isFilterable */}
       {setFilter && (
-      <div className="pgn__data-table-actions">
-        <div className="pgn__data-table-actions-left">
-          <DropdownFilters />
+        <div className="pgn__data-table-actions">
+          <div className="pgn__data-table-actions-left">
+            <DropdownFilters />
+          </div>
+          <div className="pgn__data-table-actions-right">
+            <ActionDisplay />
+          </div>
         </div>
-        <div className="pgn__data-table-actions-right">
-          <ActionDisplay />
-        </div>
-      </div>
       )}
       <div className="pgn__data-table-status">
         <div className="pgn__data-table-status-left">

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -73,8 +73,7 @@ function DataTable({
     if (fetchData) {
       fetchData(instance.state);
     }
-    // Stringifying the data gives a quick way of checking deep equality
-  }, [fetchData, JSON.stringify(instance.state)]);
+  }, [fetchData, instance.state]);
 
   const enhancedInstance = {
     ...instance,
@@ -120,6 +119,9 @@ DataTable.defaultProps = {
   tableActions: [],
   numBreakoutFilters: 1,
   manualSelectColumn: undefined,
+  SelectionStatusComponent: SelectionStatus,
+  FilterStatusComponent: FilterStatus,
+  RowStatusComponent: RowStatus,
 };
 
 DataTable.propTypes = {
@@ -216,6 +218,12 @@ DataTable.propTypes = {
   numBreakoutFilters: PropTypes.oneOf([1, 2, 3, 4]),
   /** Component to be displayed when the table is empty */
   EmptyTableComponent: PropTypes.func,
+  /** Component to be displayed for row status, ie, 10 of 20 rows. Displayed by default in the TableControlBar */
+  RowStatusComponent: PropTypes.func,
+  /** Component to be displayed for selection status. Displayed when there are selected rows and no active filters */
+  SelectionStatusComponent: PropTypes.func,
+  /** Component to be displayed for filter status. Displayed when there are active filters. */
+  FilterStatusComponent: PropTypes.func,
   /** If children are not provided a table with control bar and footer will be rendered */
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
 };

--- a/src/DataTable/tests/SmartStatus.test.jsx
+++ b/src/DataTable/tests/SmartStatus.test.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import SmartStatus from '../SmartStatus';
-import SelectionState from '../SelectionStatus';
 import DataTableContext from '../DataTableContext';
+import FilterStatus from '../FilterStatus';
+import RowStatus from '../RowStatus';
+import SelectionStatus from '../SelectionStatus';
 
 const filters = [{ id: 'name' }, { id: 'age' }];
 const filterNames = ['name', 'age'];
@@ -16,6 +18,9 @@ const instance = {
   setAllFilters: () => {},
   toggleAllRowsSelected: () => {},
   itemCount,
+  SelectionStatusComponent: SelectionStatus,
+  FilterStatusComponent: FilterStatus,
+  RowStatusComponent: RowStatus,
 };
 
 // eslint-disable-next-line react/prop-types
@@ -27,7 +32,7 @@ describe('<SmartStatus />', () => {
     const wrapper = mount(
       <SmartStatusWrapper value={{ ...instance, state: {}, selectedFlatRows: Array(5) }} />,
     );
-    expect(wrapper.find(SelectionState)).toHaveLength(1);
+    expect(wrapper.find(SelectionStatus)).toHaveLength(1);
   });
   it('Shows the filter state with selection turned off', () => {
     const wrapper = mount(<SmartStatusWrapper value={{ ...instance, state: { filters } }} />);
@@ -54,5 +59,31 @@ describe('<SmartStatus />', () => {
     );
     const status = wrapper.find(SmartStatus);
     expect(status.text()).toContain(`Showing ${instance.page.length} of ${itemCount}`);
+  });
+  it('shows an alternate selection status', () => {
+    const altStatusText = 'horses R cool';
+    const AltStatus = () => <div>{altStatusText}</div>;
+    const wrapper = mount(<SmartStatusWrapper
+      value={{
+        ...instance, SelectionStatusComponent: AltStatus, state: {}, selectedFlatRows: Array(5),
+      }}
+    />);
+    expect(wrapper.text()).toContain(altStatusText);
+  });
+  it('shows an alternate row status', () => {
+    const altStatusText = 'horses R cool';
+    const AltStatus = () => <div>{altStatusText}</div>;
+    const wrapper = mount(<SmartStatusWrapper
+      value={{ ...instance, RowStatusComponent: AltStatus }}
+    />);
+    expect(wrapper.text()).toContain(altStatusText);
+  });
+  it('shows an alternate filter status', () => {
+    const altStatusText = 'horses R cool';
+    const AltStatus = () => <div>{altStatusText}</div>;
+    const wrapper = mount(<SmartStatusWrapper
+      value={{ ...instance, FilterStatusComponent: AltStatus, state: { filters } }}
+    />);
+    expect(wrapper.text()).toContain(altStatusText);
   });
 });


### PR DESCRIPTION
I've got a couple of tables where I need the selection state to be controlled from outside the table context, and therefore, I need the display of the selection state to also be controlled from outside of the table context. This allows me to do so, with some defensive programming added in to cover different ways someone might want to use the control bar.