### PR TITLE
fix: make useIsVisible hook more resilient

### DIFF
--- a/src/Modal/tests/ModalDialog.test.jsx
+++ b/src/Modal/tests/ModalDialog.test.jsx
@@ -12,10 +12,6 @@ jest.mock('../ModalLayer', () => (props) => {
   );
 });
 
-// Mock this hook since it uses Intersection Observer which is unavailable
-// in the context of a test.
-jest.mock('../../hooks/useIsVisible', () => () => [false, () => {}]);
-
 describe('ModalDialog', () => {
   const onClose = jest.fn();
   const wrapper = mount((

--- a/src/hooks/useIsVisible.jsx
+++ b/src/hooks/useIsVisible.jsx
@@ -18,6 +18,10 @@ const useIsVisible = (defaultIsVisible = true) => {
         };
       }
     } catch (e) {
+      const isReferenceError = e instanceof ReferenceError;
+      if (!isReferenceError) {
+        throw e;
+      }
       // Do nothing if an intersection observer can't be created.
     }
     return () => {};

--- a/src/hooks/useIsVisible.jsx
+++ b/src/hooks/useIsVisible.jsx
@@ -5,16 +5,20 @@ const useIsVisible = (defaultIsVisible = true) => {
   const [isVisible, setIsVisible] = useState(defaultIsVisible);
 
   useEffect(() => {
-    if (sentinelRef.current) {
-      const observer = new IntersectionObserver((entries) => {
-        entries.forEach(({ isIntersecting }) => {
-          setIsVisible(isIntersecting);
-        });
-      }, {});
-      observer.observe(sentinelRef.current);
-      return () => {
-        observer.disconnect();
-      };
+    try {
+      if (sentinelRef.current) {
+        const observer = new IntersectionObserver((entries) => {
+          entries.forEach(({ isIntersecting }) => {
+            setIsVisible(isIntersecting);
+          });
+        }, {});
+        observer.observe(sentinelRef.current);
+        return () => {
+          observer.disconnect();
+        };
+      }
+    } catch (e) {
+      // Do nothing if an intersection observer can't be created.
     }
     return () => {};
   }, [sentinelRef.current]);


### PR DESCRIPTION
Put usage of `IntersectionObserver` in a try catch so it does not need to be mocked in tests.