### PR TITLE
refactor: update statefullbutton icons

### DIFF
--- a/scss/core/_utilities.scss
+++ b/scss/core/_utilities.scss
@@ -39,6 +39,6 @@ $color-levels: 100, 200, 300, 400, 500, 600, 700, 800, 900;
 }
 
 .icon-spin {
-  animation: 0.75s linear infinite spinner-border-ltr;
-  -webkit-animation: 0.75s linear infinite spinner-border-ltr;
+  animation: spinner-border 0.75s linear infinite;
+  -webkit-animation: spinner-border 0.75s linear infinite;
 }

--- a/scss/core/_utilities.scss
+++ b/scss/core/_utilities.scss
@@ -37,3 +37,8 @@ $color-levels: 100, 200, 300, 400, 500, 600, 700, 800, 900;
 .mw-xl {
   max-width: $max-width-xl !important;
 }
+
+.icon-spin {
+  animation: 0.75s linear infinite spinner-border-ltr;
+  -webkit-animation: 0.75s linear infinite spinner-border-ltr;
+}

--- a/src/StatefulButton/README.md
+++ b/src/StatefulButton/README.md
@@ -17,9 +17,10 @@ notes: ''
 () => {
   const props = {
     labels: {
-      default: 'Saved',
+      default: 'Save',
       pending: 'Saving',
       complete: 'Saved',
+      error: 'Error'
     },
     variant: 'primary',
     className: 'mr-2',
@@ -27,14 +28,15 @@ notes: ''
   return (
     <div>
       <StatefulButton {...props} />
-      <StatefulButton state="pending" {...props} />
+      <StatefulButton state="pending" {...props} classNames='icon-spin' />
       <StatefulButton state="complete" {...props} />
+      <StatefulButton state="error" {...props} />
     </div>
   );
 };
 ```
 
-### custom icons and disable during state
+### custom icons and disable states
 
 ```jsx live
 () => {
@@ -43,11 +45,13 @@ notes: ''
       default: 'Download',
       pending: 'Downloading',
       complete: 'Downloaded',
+      error: 'Retry'
     },
     icons: {
       default: <Icon className="fa fa-download" />,
       pending: <Icon className="fa fa-spinner fa-spin" />,
       complete: <Icon className="fa fa-check" />,
+      error: <Icon className="fa fa-retweet" />,
     },
     disabledStates: ['pending'],
     variant: 'primary',
@@ -58,12 +62,13 @@ notes: ''
       <StatefulButton state="default" {...downloadButtonProps} />
       <StatefulButton state="pending" {...downloadButtonProps} />
       <StatefulButton state="complete" {...downloadButtonProps} />
+      <StatefulButton state="error" {...downloadButtonProps} />
     </React.Fragment>
   );
 };
 ```
 
-### custom states
+### custom states with paragon icons
 
 ```jsx live
 () => {
@@ -73,8 +78,8 @@ notes: ''
       edited: 'Save Changes',
     },
     icons: {
-      unedited: <Icon className="fa fa-save" />,
-      edited: <Icon className="fa fa-save" />,
+      unedited: <Icon src={Add} />,
+      edited: <Icon src={Add} />,
     },
     disabledStates: ['unedited'],
     variant: 'primary',

--- a/src/StatefulButton/__snapshots__/StatefulButtontest.test.jsx.snap
+++ b/src/StatefulButton/__snapshots__/StatefulButtontest.test.jsx.snap
@@ -40,10 +40,24 @@ exports[`StatefulButton renders basic usage 1`] = `
           className="pgn__stateful-btn-icon"
         >
           <span
-            aria-hidden={true}
-            className="icon fa fa-spinner fa-spin"
-            id="Icon1"
-          />
+            className="pgn__icon icon-spin"
+          >
+            <svg
+              aria-hidden={true}
+              fill="none"
+              focusable={false}
+              height={24}
+              role="img"
+              viewBox="0 0 24 24"
+              width={24}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M22 12A10 10 0 116.122 3.91l1.176 1.618A8 8 0 1020 12h2z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
         </span>
         <span>
           Saving
@@ -69,10 +83,24 @@ exports[`StatefulButton renders basic usage 1`] = `
           className="pgn__stateful-btn-icon"
         >
           <span
-            aria-hidden={true}
-            className="icon fa fa-check-circle"
-            id="Icon2"
-          />
+            className="pgn__icon"
+          >
+            <svg
+              aria-hidden={true}
+              fill="none"
+              focusable={false}
+              height={24}
+              role="img"
+              viewBox="0 0 24 24"
+              width={24}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm4.59-12.42L10 14.17l-2.59-2.58L6 13l4 4 8-8-1.41-1.42z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
         </span>
         <span>
           Saved
@@ -105,7 +133,7 @@ Array [
           <span
             aria-hidden={true}
             className="fa fa-download"
-            id="Icon3"
+            id="Icon1"
           />
         </span>
         <span>
@@ -134,7 +162,7 @@ Array [
           <span
             aria-hidden={true}
             className="fa fa-spinner fa-spin"
-            id="Icon4"
+            id="Icon2"
           />
         </span>
         <span>
@@ -163,7 +191,7 @@ Array [
           <span
             aria-hidden={true}
             className="fa fa-check"
-            id="Icon5"
+            id="Icon3"
           />
         </span>
         <span>
@@ -197,7 +225,7 @@ Array [
           <span
             aria-hidden={true}
             className="fa fa-save"
-            id="Icon6"
+            id="Icon4"
           />
         </span>
         <span>
@@ -226,7 +254,7 @@ Array [
           <span
             aria-hidden={true}
             className="fa fa-save"
-            id="Icon7"
+            id="Icon5"
           />
         </span>
         <span>

--- a/src/StatefulButton/index.jsx
+++ b/src/StatefulButton/index.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Icon from '../Icon';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Button } from '..';
+import { Cancel, CheckCircleOutline, SpinnerSimple } from '../../icons';
+import Icon from '../Icon';
 
 const propTypes = {
   className: PropTypes.string,
@@ -47,9 +48,9 @@ const defaultProps = {
   state: 'default',
   icons: {
     default: undefined,
-    pending: <Icon className="icon fa fa-spinner fa-spin" />,
-    complete: <Icon className="icon fa fa-check-circle" />,
-    error: <Icon className="icon fa fa-times-circle" />,
+    pending: <Icon src={SpinnerSimple} className={classNames('icon-spin')} />,
+    complete: <Icon src={CheckCircleOutline} />,
+    error: <Icon src={Cancel} />,
   },
   disabledStates: ['pending', 'complete'],
   onClick: undefined,
@@ -86,13 +87,17 @@ function StatefulButton({
           return;
         }
 
-        if (onClick) { onClick(e); }
+        if (onClick) {
+          onClick(e);
+        }
       }}
       {...attributes}
     >
       <span className="d-flex align-items-center justify-content-center">
         {icon ? <span className="pgn__stateful-btn-icon">{icon}</span> : null}
-        <span>{labels[state] !== undefined ? labels[state] : labels.default}</span>
+        <span>
+          {labels[state] !== undefined ? labels[state] : labels.default}
+        </span>
       </span>
     </Button>
   );

--- a/src/StatefulButton/index.jsx
+++ b/src/StatefulButton/index.jsx
@@ -67,7 +67,7 @@ function StatefulButton({
 }) {
   const isDisabled = disabledStates.indexOf(state) !== -1;
   const icon = icons[state] !== undefined ? icons[state] : icons.default;
-  const label = labels[state] !== undefined ? labels[state] : labels.default
+  const label = labels[state] !== undefined ? labels[state] : labels.default;
 
   return (
     <Button

--- a/src/StatefulButton/index.jsx
+++ b/src/StatefulButton/index.jsx
@@ -1,6 +1,6 @@
-import classNames from 'classnames';
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { Button } from '..';
 import { Cancel, CheckCircleOutline, SpinnerSimple } from '../../icons';
 import Icon from '../Icon';
@@ -67,6 +67,7 @@ function StatefulButton({
 }) {
   const isDisabled = disabledStates.indexOf(state) !== -1;
   const icon = icons[state] !== undefined ? icons[state] : icons.default;
+  const label = labels[state] !== undefined ? labels[state] : labels.default
 
   return (
     <Button
@@ -94,10 +95,8 @@ function StatefulButton({
       {...attributes}
     >
       <span className="d-flex align-items-center justify-content-center">
-        {icon ? <span className="pgn__stateful-btn-icon">{icon}</span> : null}
-        <span>
-          {labels[state] !== undefined ? labels[state] : labels.default}
-        </span>
+        {icon && <span className="pgn__stateful-btn-icon">{icon}</span>}
+        <span>{label}</span>
       </span>
     </Button>
   );


### PR DESCRIPTION
Update `statefullbutton` component. 

This PR changes a couple of things. 
1. Use icons from Pargon rather than fontawsome
2. Adds the ability to spin the pending icon. 


[TNL-8320](https://openedx.atlassian.net/browse/TNL-8320)