### PR TITLE
style: text and padding fix for stepper component

### DIFF
--- a/src/Stepper/Stepper.scss
+++ b/src/Stepper/Stepper.scss
@@ -1,6 +1,6 @@
 .pgn__stepper-header-step-list {
   list-style: none;
-  padding: .75rem 0;
+  padding: .25rem 0;
   display: flex;
   align-items: center;
   margin: 0;
@@ -12,6 +12,7 @@
   display: flex;
   justify-content: center;
   background: $white;
+  padding: .75rem 1rem;
 }
 
 .pgn__stepper-header-step {

--- a/src/Stepper/StepperHeader.jsx
+++ b/src/Stepper/StepperHeader.jsx
@@ -41,7 +41,7 @@ StepList.defaultProps = {
   steps: [],
 };
 
-const PageCount = ({ activeStepIndex, totalSteps }) => `${activeStepIndex + 1} of ${totalSteps}`;
+const PageCount = ({ activeStepIndex, totalSteps }) => `Step ${activeStepIndex + 1} of ${totalSteps}`;
 
 const StepperHeader = ({ className, PageCountComponent }) => {
   const { steps, activeKey } = useContext(StepperContext);


### PR DESCRIPTION
- Fixed stepper padding issue with figma. 
- Fixed text in stepper according to figma as **Step 1 of 2** instead of **1 of 2** 

general note: created this PR against PAR-441 and we can close TNL-8134 as well after that.

FYI : @awaisdar001 

<img width="1552" alt="Screenshot 2021-05-18 at 7 48 42 PM" src="https://user-images.githubusercontent.com/67791278/118673178-3bf89100-b812-11eb-8fa0-1ace2b07885d.png">
