### PR TITLE
fix: make floating label react to size prop

### DIFF
--- a/src/Form/FormControl.jsx
+++ b/src/Form/FormControl.jsx
@@ -19,11 +19,12 @@ const FormControl = React.forwardRef(({
   ...props
 }, ref) => {
   const {
-    size,
     isInvalid,
     isValid,
     getControlProps,
+    ...formGroupContext
   } = useFormGroupContext();
+  const size = props.size || formGroupContext.size;
 
   const [hasValue, checkInputEventValue] = useHasValue({
     defaultValue: props.defaultValue,

--- a/src/Form/FormControlDecoratorGroup.jsx
+++ b/src/Form/FormControlDecoratorGroup.jsx
@@ -17,7 +17,8 @@ const FormControlDecoratorGroup = ({
   className,
   ...props
 }) => {
-  const { size } = useFormGroupContext(props);
+  const formGroupContext = useFormGroupContext(props);
+  const size = props.size || formGroupContext.size;
   return (
     <div
       className={classNames(

--- a/src/Form/form-control.mdx
+++ b/src/Form/form-control.mdx
@@ -159,3 +159,42 @@ or [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element
   );
 }
 ```
+
+### Sizes
+
+```jsx live
+() => {
+  const [value, setValue] = useState('');
+  return (
+    <>
+      <Form.Group size="sm">
+        <Form.Control
+          leadingElement={<Icon src={FavoriteBorder} />}
+          trailingElement={<Icon src={Verified} />}
+          floatingLabel="What kind of cats?"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+      </Form.Group>
+      <Form.Group>
+        <Form.Control
+          leadingElement={<Icon src={FavoriteBorder} />}
+          trailingElement={<Icon src={Verified} />}
+          floatingLabel="What kind of cats?"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+      </Form.Group>
+      <Form.Group size="lg">
+        <Form.Control
+          leadingElement={<Icon src={FavoriteBorder} />}
+          trailingElement={<Icon src={Verified} />}
+          floatingLabel="What kind of cats?"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+      </Form.Group>
+    </>
+  );
+}
+```


### PR DESCRIPTION
Fixes a problem where setting the size prop on a form control with a floating label wouldn't affect the label's size.
![image](https://user-images.githubusercontent.com/1615421/118678129-bef5f900-b7ca-11eb-862a-94cb05d7c6a4.png)
