### PR TITLE
fix: enforce text alternative rules for svg icon

### DIFF
--- a/src/Button/__snapshots__/Button.test.jsx.snap
+++ b/src/Button/__snapshots__/Button.test.jsx.snap
@@ -15,6 +15,7 @@ exports[`<Button /> correct rendering renders with props iconAfter 1`] = `
     >
       <svg
         aria-hidden={true}
+        aria-label=""
         fill="none"
         focusable={false}
         height={24}
@@ -47,6 +48,7 @@ exports[`<Button /> correct rendering renders with props iconBefore 1`] = `
     >
       <svg
         aria-hidden={true}
+        aria-label=""
         fill="none"
         focusable={false}
         height={24}
@@ -80,6 +82,7 @@ exports[`<Button /> correct rendering renders with props iconBefore and iconAfte
     >
       <svg
         aria-hidden={true}
+        aria-label=""
         fill="none"
         focusable={false}
         height={24}
@@ -100,6 +103,7 @@ exports[`<Button /> correct rendering renders with props iconBefore and iconAfte
     >
       <svg
         aria-hidden={true}
+        aria-label=""
         fill="none"
         focusable={false}
         height={24}

--- a/src/Icon/index.jsx
+++ b/src/Icon/index.jsx
@@ -5,6 +5,13 @@ import classNames from 'classnames';
 import newId from '../utils/newId';
 import withDeprecatedProps, { DEPR_TYPES } from '../withDeprecatedProps';
 
+/**
+ * An svg with an "img" role must satisfy the following a11y requirements
+ * - It needs a text alternative in the form of aria-label, aria-labelledby, or screen-reader only text.
+ * - If no label is desired, aria-label will be set to an empty string and aria-hidden to "true".
+ * - focusable is set to false on the svg in all cases as a workaround for an ie11 bug
+ */
+
 function Icon({
   src: Component,
   id,
@@ -15,19 +22,32 @@ function Icon({
   ...attrs
 }) {
   if (Component) {
-    const mergedSvgProps = { ...svgAttrs, role: 'img' };
     // If no aria label is specified, hide this icon from screenreaders
-    if (!svgAttrs['aria-label']) {
+    const hasAriaLabel = svgAttrs['aria-label'] || svgAttrs['aria-labelledby'];
+
+    const mergedSvgProps = { ...svgAttrs };
+
+    if (!hasAriaLabel) {
+      mergedSvgProps['aria-label'] = '';
       mergedSvgProps['aria-hidden'] = true;
-      mergedSvgProps.focusable = false;
     }
+
     return (
       <span
         className={classNames('pgn__icon', className)}
         id={id}
         {...attrs}
       >
-        <Component {...mergedSvgProps} />
+        <Component
+          role="img"
+          focusable={false}
+          {...mergedSvgProps}
+        />
+        {screenReaderText && (
+          <span className="sr-only">
+            {screenReaderText}
+          </span>
+        )}
       </span>
     );
   }

--- a/src/StatefulButton/__snapshots__/StatefulButtontest.test.jsx.snap
+++ b/src/StatefulButton/__snapshots__/StatefulButtontest.test.jsx.snap
@@ -44,6 +44,7 @@ exports[`StatefulButton renders basic usage 1`] = `
           >
             <svg
               aria-hidden={true}
+              aria-label=""
               fill="none"
               focusable={false}
               height={24}
@@ -87,6 +88,7 @@ exports[`StatefulButton renders basic usage 1`] = `
           >
             <svg
               aria-hidden={true}
+              aria-label=""
               fill="none"
               focusable={false}
               height={24}


### PR DESCRIPTION
https://openedx.atlassian.net/browse/PAR-432

An svg with an "img" role must satisfy the following a11y requirements
 * It needs a text alternative in the form of aria-label, aria-labelledby, or screen-reader only text.
 * If no label is desired, aria-label will be set to an empty string and aria-hidden to "true".
 * focusable is set to false on the svg in all cases as a workaround for an ie11 bug