### PR TITLE
fix: update tab styling to match design system

### DIFF
--- a/src/Nav/Nav.scss
+++ b/src/Nav/Nav.scss
@@ -1,2 +1,159 @@
 @import "variables";
-@import "~bootstrap/scss/nav";
+
+// Base class
+//
+// Kickstart any navigation component with a set of style resets. Works with
+// `<nav>`s, `<ul>`s or `<ol>`s.
+
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  padding-left: 0;
+  margin-bottom: 0;
+  list-style: none;
+}
+
+.nav-link {
+  display: block;
+  padding: $nav-link-padding-y $nav-link-padding-x;
+  text-decoration: if($link-decoration == none, null, none);
+  color: $nav-link-color;
+  font-weight: $nav-link-font-weight;
+
+  @include hover-focus() {
+    text-decoration: none;
+    color: $nav-link-color;
+  }
+
+  // Disabled state lightens text
+  &.disabled {
+    color: $nav-link-disabled-color;
+    pointer-events: none;
+    cursor: default;
+  }
+}
+
+//
+// Tabs
+//
+
+.nav-tabs {
+  border-bottom: $nav-tabs-border-width solid $nav-tabs-border-color;
+
+  .nav-link {
+    margin-bottom: -$nav-tabs-border-width;
+    border-top: $nav-tabs-border-width solid transparent;
+    border-bottom: $nav-tabs-border-width solid transparent;
+    border-left: none;
+    border-right: none;
+
+    @include border-top-radius($nav-tabs-border-radius);
+
+    @include hover-focus() {
+      border-color: $nav-tabs-link-hover-border-color;
+      background-color: $nav-tabs-link-hover-bg;
+    }
+
+    &.disabled {
+      color: $nav-link-disabled-color;
+      background-color: transparent;
+      border-color: transparent;
+    }
+  }
+
+  .nav-link.active,
+  .nav-item.show .nav-link {
+    color: $nav-tabs-link-active-color;
+    background-color: $nav-tabs-link-active-bg;
+    border-color: $nav-tabs-link-active-border-color;
+  }
+
+  .dropdown-menu {
+    // Make dropdown border overlap tab border
+    margin-top: -$nav-tabs-border-width;
+    // Remove the top rounded corners here since there is a hard edge above the menu
+    @include border-top-radius(0);
+  }
+}
+
+
+//
+// Pills
+//
+
+.nav-pills {
+  .nav-link {
+    @include border-radius($nav-pills-border-radius);
+  }
+
+  .nav-link.active,
+  .show > .nav-link {
+    color: $nav-pills-link-active-color;
+    background-color: $nav-pills-link-active-bg;
+  }
+}
+
+//
+// Button Group
+//
+
+.nav-button-group {
+  .nav-link {
+    border: solid 1px $nav-tabs-border-color;
+    &:first-child {
+      @include border-left-radius($nav-pills-border-radius);
+    }
+    &:last-child {
+      @include border-right-radius($nav-pills-border-radius);
+    }
+    &:hover {
+      background: $nav-tabs-link-hover-bg;
+    }
+    & + .nav-link {
+      margin-left: -1px;
+    }
+  }
+
+  .nav-link.active,
+  .show > .nav-link {
+    color: $nav-pills-link-active-color;
+    background-color: $nav-pills-link-active-bg;
+    border-color: transparent;
+  }
+}
+
+
+//
+// Justified variants
+//
+
+.nav-fill {
+  > .nav-link,
+  .nav-item {
+    flex: 1 1 auto;
+    text-align: center;
+  }
+}
+
+.nav-justified {
+  > .nav-link,
+  .nav-item {
+    flex-basis: 0;
+    flex-grow: 1;
+    text-align: center;
+  }
+}
+
+
+// Tabbable tabs
+//
+// Hide tabbable panes to start, show them when `.active`
+
+.tab-content {
+  > .tab-pane {
+    display: none;
+  }
+  > .active {
+    display: block;
+  }
+}

--- a/src/Nav/_variables.scss
+++ b/src/Nav/_variables.scss
@@ -3,15 +3,18 @@
 
 $nav-link-padding-y:                .5rem !default;
 $nav-link-padding-x:                1rem !default;
-$nav-link-disabled-color:           theme-color("gray", "light-text") !default;
+$nav-link-color:                    $gray-700 !default;
+$nav-link-disabled-color:           $gray-300 !default;
+$nav-link-font-weight:              500 !default;
 
-$nav-tabs-border-color:             theme-color("gray", "border") !default;
-$nav-tabs-border-width:             $border-width !default;
-$nav-tabs-border-radius:            $border-radius !default;
-$nav-tabs-link-hover-border-color:  theme-color("gray", "border") theme-color("gray", "border") $nav-tabs-border-color !default;
-$nav-tabs-link-active-color:        theme-color("gray", "text") !default;
+$nav-tabs-border-color:             $light-400 !default;
+$nav-tabs-border-width:             2px !default;
+$nav-tabs-border-radius:            0 !default;
+$nav-tabs-link-hover-border-color:  transparent transparent $nav-tabs-border-color !default;
+$nav-tabs-link-hover-bg:            $light-400 !default;
+$nav-tabs-link-active-color:        $primary-500 !default;
 $nav-tabs-link-active-bg:           $body-bg !default;
-$nav-tabs-link-active-border-color: theme-color("gray", "active-border") theme-color("gray", "active-border") $nav-tabs-link-active-bg !default;
+$nav-tabs-link-active-border-color: transparent transparent $primary-500 !default;
 
 $nav-pills-border-radius:           $border-radius !default;
 $nav-pills-link-active-color:       $component-active-color !default;

--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -59,9 +59,51 @@ notes: |
 }
 ```
 
+### Button Group Usage
+
+```jsx live
+<Tabs
+  defaultActiveKey="profile"
+  id="uncontrolled-pills-tab-example"
+  variant="button-group"
+>
+  <Tab eventKey="home" title="Home">
+    Hello I am the first panel.
+  </Tab>
+  <Tab eventKey="profile" title="Profile">
+    Hello I am the second panel.
+  </Tab>
+  <Tab eventKey="contact" title="Contact" disabled>
+    Hello I am third first panel.
+  </Tab>
+</Tabs>
+```
+
+### Pills Usage
+
+```jsx live
+<Tabs
+  defaultActiveKey="profile"
+  id="uncontrolled-pills-tab-example"
+  variant="pills"
+>
+  <Tab eventKey="home" title="Home">
+    Hello I am the first panel.
+  </Tab>
+  <Tab eventKey="profile" title="Profile">
+    Hello I am the second panel.
+  </Tab>
+  <Tab eventKey="contact" title="Contact" disabled>
+    Hello I am third first panel.
+  </Tab>
+</Tabs>
+```
+
 ***
 
 ## Tabs.Deprecated
+
+<br/>
 
 ### Basic Usage
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1615421/118700982-36368780-b7e1-11eb-86da-4bc2e9d29d3d.png)

Pulls in bootstrap nav sass into Paragon with some minor customizations. Adds a `button-group` variant for tabs