### PR TITLE
fix: prevent exceeding call stack size with 5000+ pages

### DIFF
--- a/src/Pagination/constants.js
+++ b/src/Pagination/constants.js
@@ -1,0 +1,2 @@
+/* eslint-disable import/prefer-default-export */
+export const ELLIPSIS = '...';

--- a/src/Pagination/getPaginationRange.js
+++ b/src/Pagination/getPaginationRange.js
@@ -1,0 +1,33 @@
+import { ELLIPSIS } from './constants';
+
+const getPaginationRange = ({
+  currentIndex,
+  count,
+  length,
+  requireFirstAndLastPages = true,
+}) => {
+  const boundedLength = Math.min(count, length);
+  const unboundedStartIndex = currentIndex - Math.ceil(boundedLength / 2);
+  const zeroBoundedStartIndex = Math.max(0, unboundedStartIndex);
+  // Bind maximum value of zeroBoundedStartIndex to avoid running past the count of pages
+  const boundedStartIndex = Math.min(zeroBoundedStartIndex, count - boundedLength);
+
+  const range = Array.from({ length: boundedLength }, (el, i) => boundedStartIndex + i);
+
+  const isFirstPageInRange = range[0] === 0;
+  const isLastPageInRange = range[range.length - 1] === count - 1;
+
+  if (requireFirstAndLastPages && !isFirstPageInRange) {
+    range[0] = 0;
+    range[1] = ELLIPSIS;
+  }
+
+  if (requireFirstAndLastPages && !isLastPageInRange) {
+    range[range.length - 1] = count - 1;
+    range[range.length - 2] = ELLIPSIS;
+  }
+
+  return range;
+};
+
+export default getPaginationRange;

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -28,7 +28,7 @@ class Pagination extends React.Component {
   }
 
   // TODO: Move to getDerivedStateFromProps
-  // eslint-disable-next-line react/no-deprecated
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (
       nextProps.currentPage !== this.props.currentPage

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -303,16 +303,10 @@ class Pagination extends React.Component {
     );
   }
 
-  /*
-   * Uses recursion to generate an array of the buttons to display (i.e., page/ellipsis
-   * buttons) given the currently selected page, the max number of buttons to display, and
-   * the total number of pages.
-   */
   renderPageButtons() {
     const { currentPage } = this.state;
     const { pageCount, maxPagesDisplayed } = this.props;
 
-    // const chunks = getPaginationChunks(currentPage, pageCount, { maxPagesDisplayed });
     const pages = getPaginationRange({
       currentIndex: currentPage,
       count: pageCount,
@@ -320,28 +314,12 @@ class Pagination extends React.Component {
       requireFirstAndLastPages: true,
     });
 
-    return (
-      <>
-        {/* {chunks.start && (
-          <>
-            {this.renderPageButton(1)}
-            {this.renderEllipsisButton()}
-          </>
-        )} */}
-        {pages.map((pageIndex) => {
-          if (pageIndex === ELLIPSIS) {
-            return this.renderEllipsisButton();
-          }
-          return this.renderPageButton(pageIndex + 1);
-        })}
-        {/* {chunks.end && (
-          <>
-            {this.renderEllipsisButton()}
-            {this.renderPageButton(pageCount)}
-          </>
-        )} */}
-      </>
-    );
+    return pages.map((pageIndex) => {
+      if (pageIndex === ELLIPSIS) {
+        return this.renderEllipsisButton();
+      }
+      return this.renderPageButton(pageIndex + 1);
+    });
   }
 
   render() {

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -52,7 +52,6 @@ const getPaginationChunks = (
   return chunks;
 };
 
-
 class Pagination extends React.Component {
   constructor(props) {
     super(props);

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -9,48 +9,8 @@ import { ExtraSmall, LargerThanExtraSmall } from '../Responsive';
 import getTextFromElement from '../utils/getTextFromElement';
 import Icon from '../Icon';
 import newId from '../utils/newId';
-
-const getPaginationRange = (currentIndex, count, length) => {
-  const boundedLength = Math.min(count, length);
-  const unboundedStartIndex = currentIndex - Math.floor(boundedLength / 2);
-  let startIndex = Math.max(0, unboundedStartIndex);
-  startIndex = Math.min(startIndex, count - boundedLength);
-
-  return Array.from(
-    {
-      length: boundedLength,
-    },
-    (el, i) => startIndex + i,
-  );
-};
-
-const getPaginationChunks = (
-  currentIndex,
-  count,
-  { maxPagesDisplayed = 7 } = {},
-) => {
-  const lastIndex = count - 1;
-  const centerChunk = getPaginationRange(currentIndex, count, maxPagesDisplayed - 2);
-
-  if (centerChunk[0] === 1) {
-    centerChunk.unshift(0);
-  }
-
-  if (centerChunk[centerChunk.length - 1] === lastIndex - 1) {
-    centerChunk.push(lastIndex);
-  }
-
-  const needsStartChunk = centerChunk[0] !== 0;
-  const needsEndChunk = centerChunk[centerChunk.length - 1] !== lastIndex;
-
-  const chunks = {
-    start: needsStartChunk ? [0] : undefined,
-    center: centerChunk,
-    end: needsEndChunk ? [lastIndex] : undefined,
-  };
-
-  return chunks;
-};
+import { ELLIPSIS } from './constants';
+import getPaginationRange from './getPaginationRange';
 
 class Pagination extends React.Component {
   constructor(props) {
@@ -69,7 +29,7 @@ class Pagination extends React.Component {
 
   // TODO: Move to getDerivedStateFromProps
   // eslint-disable-next-line react/no-deprecated
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (
       nextProps.currentPage !== this.props.currentPage
       || nextProps.currentPage !== this.state.currentPage
@@ -352,23 +312,34 @@ class Pagination extends React.Component {
     const { currentPage } = this.state;
     const { pageCount, maxPagesDisplayed } = this.props;
 
-    const chunks = getPaginationChunks(currentPage, pageCount, { maxPagesDisplayed });
+    // const chunks = getPaginationChunks(currentPage, pageCount, { maxPagesDisplayed });
+    const pages = getPaginationRange({
+      currentIndex: currentPage,
+      count: pageCount,
+      length: maxPagesDisplayed,
+      requireFirstAndLastPages: true,
+    });
 
     return (
       <>
-        {chunks.start && (
+        {/* {chunks.start && (
           <>
             {this.renderPageButton(1)}
             {this.renderEllipsisButton()}
           </>
-        )}
-        {chunks.center.map((index) => this.renderPageButton(index + 1))}
-        {chunks.end && (
+        )} */}
+        {pages.map((pageIndex) => {
+          if (pageIndex === ELLIPSIS) {
+            return this.renderEllipsisButton();
+          }
+          return this.renderPageButton(pageIndex + 1);
+        })}
+        {/* {chunks.end && (
           <>
             {this.renderEllipsisButton()}
             {this.renderPageButton(pageCount)}
           </>
-        )}
+        )} */}
       </>
     );
   }


### PR DESCRIPTION
Refactor how Pagination determines what page ranges to display. No longer uses recursion that was causing a `RangeError: Maximum call stack size exceeded` error. Fixes part of https://openedx.atlassian.net/browse/PAR-346