### PR TITLE
refactor: hyperlink updated to underline link text conditionally

### DIFF
--- a/src/Hyperlink/Hyperlink.test.jsx
+++ b/src/Hyperlink/Hyperlink.test.jsx
@@ -68,3 +68,10 @@ describe('event handlers are triggered correctly', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('show underlined hyperlink text', () => {
+  it('it checks if hyperlink is underlined', () => {
+    const wrapper = mount(<Hyperlink {...props} isUnderline />).find('a');
+    expect(wrapper.prop('style')).toEqual({ textDecoration: 'underline' });
+  });
+});

--- a/src/Hyperlink/README.md
+++ b/src/Hyperlink/README.md
@@ -53,3 +53,8 @@ notes: |
   />
 </Hyperlink>
 ```
+### underlined 
+
+```jsx live
+<Hyperlink href="https://en.wikipedia.org/wiki/Hyperlink" isUnderline>edX.org</Hyperlink>
+```

--- a/src/Hyperlink/index.jsx
+++ b/src/Hyperlink/index.jsx
@@ -14,6 +14,7 @@ function Hyperlink(props) {
     onClick,
     externalLinkAlternativeText,
     externalLinkTitle,
+    isUnderline,
     ...other
   } = props;
 
@@ -33,12 +34,14 @@ function Hyperlink(props) {
 
   return (
     <a
-      style={{ textDecoration: 'underline' }}
+      style={{ textDecoration: isUnderline ? 'underline' : '' }}
       href={destination}
       target={target}
       onClick={onClick}
       {...other}
-    >{children}{externalLinkIcon}
+    >
+      {children}
+      {externalLinkIcon}
     </a>
   );
 }
@@ -48,6 +51,7 @@ Hyperlink.defaultProps = {
   onClick: () => {},
   externalLinkAlternativeText: 'Opens in a new window',
   externalLinkTitle: 'Opens in a new window',
+  isUnderline: false,
 };
 
 Hyperlink.propTypes = {
@@ -71,6 +75,7 @@ Hyperlink.propTypes = {
     PropTypes.string,
     props => props.target === '_blank',
   ),
+  isUnderline: PropTypes.bool,
 };
 
 export default withDeprecatedProps(Hyperlink, 'Hyperlink', {


### PR DESCRIPTION
- hyperlink component updated to support new link designs it will support underlined text by passing prop isUnderline and will render simple text by default.
- test case added according to the new prop 
- hyperlink documentation updated

the motivation behind this change is https://www.figma.com/file/SeNpRff5HxzdpCgoD5pmlQ/Apps-and-resources-landing-page?node-id=4306%3A0


<img width="1552" alt="Screenshot 2021-06-09 at 2 56 18 PM" src="https://user-images.githubusercontent.com/67791278/121342999-abf2c680-c93b-11eb-8da6-8ea5f2784ec2.png">
