### PR TITLE
feat: add disclaimer text class

### DIFF
--- a/scss/core/_utilities.scss
+++ b/scss/core/_utilities.scss
@@ -18,6 +18,12 @@ $color-levels: 100, 200, 300, 400, 500, 600, 700, 800, 900;
   font-size: $x-small-font-size;
 }
 
+.micro {
+  font-size: $micro-font-size;
+  font-weight: normal;
+  line-height: $micro-line-height;
+}
+
 .mw-xs {
   max-width: $max-width-xs !important;
 }

--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -590,6 +590,9 @@ $lead-font-weight:            null !default;
 $small-font-size:             87.5% !default;
 $x-small-font-size:             75% !default;
 
+$micro-font-size:        0.688rem;
+$micro-line-height:      136% !default;
+
 $text-muted:                  theme-color("gray", "light-text") !default;
 
 $blockquote-small-color:      theme-color("gray", "light-text") !default;

--- a/src/StatefulButton/index.jsx
+++ b/src/StatefulButton/index.jsx
@@ -95,7 +95,7 @@ function StatefulButton({
       {...attributes}
     >
       <span className="d-flex align-items-center justify-content-center">
-        {icon && <span className="pgn__stateful-btn-icon">{icon}</span>}
+        {icon && <span className={classNames({ 'pgn__stateful-btn-icon': label })}>{icon}</span>}
         <span
           className={classNames(
             { 'sr-only': !label },

--- a/www/src/pages/foundations/typography.jsx
+++ b/www/src/pages/foundations/typography.jsx
@@ -138,6 +138,16 @@ export default function TypographyPage() {
                 <code>.x-small</code>
               </td>
             </tr>
+            <tr>
+              <td colSpan="2">
+                <MeasuredItem {...measuredTypeProps}>
+                  <p className="micro m-0">Micro Body</p>
+                </MeasuredItem>
+              </td>
+              <td>
+                <code>.micro</code>
+              </td>
+            </tr>
           </tbody>
           <tbody>
             <tr>


### PR DESCRIPTION
#### Changes
- Added a new class for disclaimer text
<img width="495" alt="Screenshot 2021-06-11 at 5 44 33 PM" src="https://user-images.githubusercontent.com/40633976/121689143-b5b42f80-cadd-11eb-95ae-adef947d65af.png">

- Fixed the stateful button spinner alignment in cases when no text is provided to the button:

|Before|After|
------|-------
<img width="408" alt="Screenshot 2021-06-10 at 12 52 34 PM" src="https://user-images.githubusercontent.com/40633976/121689047-9917f780-cadd-11eb-8675-894987cc3228.png">|<img width="495" alt="Screenshot 2021-06-11 at 5 45 15 PM" src="https://user-images.githubusercontent.com/40633976/121689066-9cab7e80-cadd-11eb-8c61-83e462fc9735.png">


#### Tickets:

https://openedx.atlassian.net/browse/VAN-546
https://openedx.atlassian.net/browse/VAN-593