### PR TITLE
fix: update line height for micro text class

### DIFF
--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -591,7 +591,7 @@ $small-font-size:             87.5% !default;
 $x-small-font-size:             75% !default;
 
 $micro-font-size:        0.688rem;
-$micro-line-height:      136% !default;
+$micro-line-height:      0.938rem;
 
 $text-muted:                  theme-color("gray", "light-text") !default;
 


### PR DESCRIPTION
After update from design team, the line height for `.micro` class needs to be updated. 

#### changes
Made line height for micro text to be 15px
|Before|After|
|----|-----|
<img width="500" alt="Screenshot 2021-06-16 at 11 55 59 AM" src="https://user-images.githubusercontent.com/40633976/122172110-e14a6780-ce99-11eb-9cc8-1fa32869db46.png">|<img width="500" alt="Screenshot 2021-06-16 at 11 55 51 AM" src="https://user-images.githubusercontent.com/40633976/122172101-de4f7700-ce99-11eb-8094-4e7c7a75a724.png">

