### PR TITLE
fix: remove border from dark modal footers

### DIFF
--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -51,6 +51,11 @@
   margin: 0;
   max-height: none;
   max-width: none;
+
+  .pgn__modal-footer {
+    border-top: solid 1px $light;
+    padding-top: $modal-footer-padding-y;
+  }
 }
 
 // Made specific due to a selector in Modal.scss
@@ -190,10 +195,6 @@
 
   .pgn__modal-header {
     border-bottom: solid 1px $light;
-  }
-  .pgn__modal-footer {
-    border-top: solid 1px $light;
-    padding-top: $modal-footer-padding-y;
   }
 }
 


### PR DESCRIPTION
Restricts the border on the modal footer to just the fullscreen modal. It was erroneously applied to the marketing modal before. Fix:

![image](https://user-images.githubusercontent.com/1615421/122268309-e8797180-cea9-11eb-894e-15482d5fd532.png)
