### PR TITLE
fix: iconbutton size issue when using Paragon Icons

### DIFF
--- a/src/IconButton/_IconButton.scss
+++ b/src/IconButton/_IconButton.scss
@@ -65,6 +65,11 @@ $btn-icon-accent-color: white !default;
     .btn-icon__icon-container {
         display: inline-flex;
         align-self: center;
+
+        .pgn__icon.btn-icon__icon {
+            height: 1.5rem;
+            width: 1.5rem;
+        }
     }
 
     .btn-icon__icon {


### PR DESCRIPTION
[TNL-8419](https://openedx.atlassian.net/browse/TNL-8419)

Before Change:
<img width="464" alt="Screen Shot 2021-06-21 at 7 16 25 PM" src="https://user-images.githubusercontent.com/4252738/122798844-7a361400-d2da-11eb-9942-08b3847536be.png">

After Change: 
<img width="583" alt="Screen Shot 2021-06-21 at 9 49 32 PM" src="https://user-images.githubusercontent.com/4252738/122798922-92a62e80-d2da-11eb-97dd-7783bf9189f2.png">

