### PR TITLE
fix: fixed modal box shadow above page content

### DIFF
--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -129,24 +129,60 @@
   flex-grow: 1;
   padding: $modal-inner-padding $modal-inner-padding $modal-inner-padding / 2;
   overflow: auto;
-  box-shadow: inset 0 10px 10px -10px rgba(black, .5), inset 0 -10px 10px -10px rgba(black, .5);
-  transition: box-shadow 150ms ease;
+  position: relative;
+
+  &::before{
+    content:"";
+    background-color: transparent;
+    background-image: linear-gradient(#605c5c, #b8bebe, transparent 50%);
+    display: block;
+    height: 20px;
+    position: sticky;
+    top: -$modal-inner-padding;
+    margin-top: -$modal-inner-padding;
+    margin-left: -$modal-inner-padding;
+    margin-right: -$modal-inner-padding;
+    opacity: .5;
+  }
+  &::after{
+    content:"";
+    background-color: transparent;
+    background-image: linear-gradient(360deg, #605c5c, #b8bebe, transparent 50%);
+    display: block;
+    height: 20px;
+    position: sticky;
+    bottom: -$modal-inner-padding / 2;
+    margin-bottom: -$modal-inner-padding;
+    margin-left: -$modal-inner-padding;
+    margin-right: -$modal-inner-padding;
+    opacity: .5;
+  }
 
   &.pgn__modal-body-scroll-bottom {
-    box-shadow: inset 0 10px 10px -10px rgba(black, .5), inset 0 -10px 10px -10px rgba(black, 0);
+    &::before{
+      opacity: .5;
+    }
+    &::after{
+      opacity: 0;
+    }
   }
 
   &.pgn__modal-body-scroll-top {
-    box-shadow: inset 0 10px 10px -10px rgba(black, 0), inset 0 -10px 10px -10px rgba(black, .5);
+    &::before{
+      opacity: 0;
+    }
+    &::after{
+      opacity: .5;
+    }
   }
 
   &.pgn__modal-body-scroll-top.pgn__modal-body-scroll-bottom {
-    box-shadow: inset 0 10px 10px -10px rgba(black, 0), inset 0 -10px 10px -10px rgba(black, 0);
-  }
-
-  .pgn__modal-body-content {
-    z-index: -1;
-    position: relative;
+    &::before{
+      opacity: 0;
+    }
+    &::after{
+      opacity: 0;
+    }
   }
 
   .pgn__modal-body-content > *:last-child {
@@ -185,6 +221,10 @@
 
   .pgn__modal-body {
     padding: $modal-inner-padding / 2 $modal-inner-padding;
+
+    &::before{
+      top: -$modal-inner-padding / 2
+    }
   }
 }
 

--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -144,6 +144,11 @@
     box-shadow: inset 0 10px 10px -10px rgba(black, 0), inset 0 -10px 10px -10px rgba(black, 0);
   }
 
+  .pgn__modal-body-content {
+    z-index: -1;
+    position: relative;
+  }
+
   .pgn__modal-body-content > *:last-child {
     margin-bottom: 0;
   }


### PR DESCRIPTION
Ticket: https://openedx.atlassian.net/browse/TNL-8405

Issue: The issue was in the modal component in which the box-shadow was appearing under the child component.  The issue is fixed now by removing box-shadow and adding before and after pseudo-element in the modal body class with the linear gradient.
<img width="1552" alt="Screenshot 2021-06-22 at 8 48 32 PM" src="https://user-images.githubusercontent.com/67791278/122958316-2c81e000-d39c-11eb-9575-eff9f98b14c2.png">

<img width="1552" alt="Screenshot 2021-06-22 at 8 47 57 PM" src="https://user-images.githubusercontent.com/67791278/122958173-0f4d1180-d39c-11eb-8725-70fc6874b85c.png">
