### PR TITLE
fix: added min height to stepper header

### DIFF
--- a/src/Stepper/Stepper.scss
+++ b/src/Stepper/Stepper.scss
@@ -13,6 +13,7 @@
   justify-content: center;
   background: $white;
   padding: .75rem 1rem;
+  min-height: 5.13rem;
 }
 
 .pgn__stepper-header-step {


### PR DESCRIPTION
### https://openedx.atlassian.net/browse/TNL-8406

Added min-height to stepper header so it does not change its height in case of error. and updated the example with an error message.

### Before  : 
![2 - stepper resize](https://user-images.githubusercontent.com/26253150/122884823-f3c01780-d357-11eb-9903-800ea6d6ce35.gif)


### After:
![Webp net-gifmaker](https://user-images.githubusercontent.com/26253150/122899068-e9f0e100-d364-11eb-930e-4ddb409e0512.gif)
