### PR TITLE
Fix/modal shadow

### DIFF
--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -129,24 +129,60 @@
   flex-grow: 1;
   padding: $modal-inner-padding $modal-inner-padding $modal-inner-padding / 2;
   overflow: auto;
-  box-shadow: inset 0 10px 10px -10px rgba(black, .5), inset 0 -10px 10px -10px rgba(black, .5);
-  transition: box-shadow 150ms ease;
+  position: relative;
+
+  &::before{
+    content:"";
+    background-color: transparent;
+    background-image: linear-gradient(#605c5c, #b8bebe, transparent 50%);
+    display: block;
+    height: 20px;
+    position: sticky;
+    top: -$modal-inner-padding;
+    margin-top: -$modal-inner-padding;
+    margin-left: -$modal-inner-padding;
+    margin-right: -$modal-inner-padding;
+    opacity: .5;
+  }
+  &::after{
+    content:"";
+    background-color: transparent;
+    background-image: linear-gradient(360deg, #605c5c, #b8bebe, transparent 50%);
+    display: block;
+    height: 20px;
+    position: sticky;
+    bottom: -$modal-inner-padding / 2;
+    margin-bottom: -$modal-inner-padding;
+    margin-left: -$modal-inner-padding;
+    margin-right: -$modal-inner-padding;
+    opacity: .5;
+  }
 
   &.pgn__modal-body-scroll-bottom {
-    box-shadow: inset 0 10px 10px -10px rgba(black, .5), inset 0 -10px 10px -10px rgba(black, 0);
+    &::before{
+      opacity: .5;
+    }
+    &::after{
+      opacity: 0;
+    }
   }
 
   &.pgn__modal-body-scroll-top {
-    box-shadow: inset 0 10px 10px -10px rgba(black, 0), inset 0 -10px 10px -10px rgba(black, .5);
+    &::before{
+      opacity: 0;
+    }
+    &::after{
+      opacity: .5;
+    }
   }
 
   &.pgn__modal-body-scroll-top.pgn__modal-body-scroll-bottom {
-    box-shadow: inset 0 10px 10px -10px rgba(black, 0), inset 0 -10px 10px -10px rgba(black, 0);
-  }
-
-  .pgn__modal-body-content {
-    z-index: -1;
-    position: relative;
+    &::before{
+      opacity: 0;
+    }
+    &::after{
+      opacity: 0;
+    }
   }
 
   .pgn__modal-body-content > *:last-child {
@@ -185,6 +221,10 @@
 
   .pgn__modal-body {
     padding: $modal-inner-padding / 2 $modal-inner-padding;
+
+    &::before{
+      top: -$modal-inner-padding / 2
+    }
   }
 }
 

--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -144,6 +144,11 @@
     box-shadow: inset 0 10px 10px -10px rgba(black, 0), inset 0 -10px 10px -10px rgba(black, 0);
   }
 
+  .pgn__modal-body-content {
+    z-index: -1;
+    position: relative;
+  }
+
   .pgn__modal-body-content > *:last-child {
     margin-bottom: 0;
   }

--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -143,6 +143,7 @@
     margin-left: -$modal-inner-padding;
     margin-right: -$modal-inner-padding;
     opacity: .5;
+    z-index: 2;
   }
   &::after{
     content:"";


### PR DESCRIPTION
-In reference to the [ticket](https://openedx.atlassian.net/browse/TNL-8405)  the shadow issue was fixed in [this](https://github.com/edx/paragon/pull/757) PR upon integration with course authoring MFE, it turns out that the top shadow still hides under the page content if some other component is passed as children, hence to fix that a positive z-index of 2 is passed in top shadow which seems to fix the issue in course authoring use cases. 