### PR TITLE
fix: top shadow fix for showing above page content

### DIFF
--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -143,6 +143,7 @@
     margin-left: -$modal-inner-padding;
     margin-right: -$modal-inner-padding;
     opacity: .5;
+    z-index: 2;
   }
   &::after{
     content:"";


### PR DESCRIPTION
-In reference to the [ticket](https://openedx.atlassian.net/browse/TNL-8405) the shadow issue was fixed in [this](https://github.com/edx/paragon/pull/757) [PR](https://github.com/edx/paragon/pull/757) upon integration with course authoring MFE, it turns out that the top shadow still hides under the page content if some other component is passed as children, hence to fix that a positive z-index of 2 is passed in top shadow which seems to fix the issue in course authoring use cases.