### PR TITLE
fix: form field default icon color

### DIFF
--- a/src/Alert/Alert.scss
+++ b/src/Alert/Alert.scss
@@ -41,6 +41,10 @@
 // added to align content and icon
 .alert-content {
   display: flex;
+
+  div {
+    flex-grow: 1;
+  }
 }
 
 // Provide class for links that match alerts

--- a/src/Form/_Form.scss
+++ b/src/Form/_Form.scss
@@ -115,6 +115,19 @@ $form-control-icon-width: 32px !default;
       padding-right: calc(#{$input-padding-y-sm} - #{2 * $input-border-width});
     }
   }
+
+  .btn-icon {
+    color: $gray-500 !important;
+    &:hover {
+      background-color: $gray-500 !important;
+      color: $white !important;
+    }
+    &:focus {
+      background-color: $white !important;
+      color: $gray-500 !important;
+      box-shadow: inset 0 0 0 2px $gray-500 !important;
+    }
+  }
 }
 
 // Floating Labels


### PR DESCRIPTION
1. set icon button color gray-500 while render in form.

**Results:**

Before
<img width="105" alt="before" src="https://user-images.githubusercontent.com/78487564/123289239-b612e880-d529-11eb-95b1-fbe84ca3fbdf.png">

After
<img width="93" alt="after" src="https://user-images.githubusercontent.com/78487564/123288836-5ae0f600-d529-11eb-91d7-962c454de690.png">

Related ticket:
https://openedx.atlassian.net/browse/VAN-523

2. set alert child content div width 100 %.

**Results:**

Before fix in paragon 
<img width="496" alt="before" src="https://user-images.githubusercontent.com/78487564/123290288-9203d700-d52a-11eb-8a57-fa70babcacc4.png">
Expected result
<img width="503" alt="after" src="https://user-images.githubusercontent.com/78487564/123290336-9cbe6c00-d52a-11eb-9673-c23806e7b6fb.png">

Related ticket:
https://openedx.atlassian.net/browse/VAN-601