### PR TITLE
feat: add breakpoints to width utility class

### DIFF
--- a/scss/core/_utilities.scss
+++ b/scss/core/_utilities.scss
@@ -48,3 +48,14 @@ $color-levels: 100, 200, 300, 400, 500, 600, 700, 800, 900;
   animation: spinner-border 0.75s linear infinite;
   -webkit-animation: spinner-border 0.75s linear infinite;
 }
+
+// Define breakpoints for `.w-*` class (e.g. `.w-md-100`)
+@each $breakpoint-name, $breakpoint-value in $grid-breakpoints {
+  @each $size-name, $size-value in $sizes {
+    @media(min-width: $breakpoint-value) {
+      .w-#{$breakpoint-name}-#{$size-name} {
+        width: $size-value !important;
+      }
+    }
+  }
+}

--- a/www/src/pages/foundations/css-utilities.mdx
+++ b/www/src/pages/foundations/css-utilities.mdx
@@ -14,7 +14,33 @@ import CSSUtilitiesTable from '../../components/CSSUtilitiesTable';
 ### Utility Classes
 
 <CSSUtilitiesTable
-  selectors={getCssSelectors(props.data.utilities.nodes)}
+  selectors={getCssSelectors(props.data.utilities.nodes).concat([
+    { selector: 'w-xs-25', declarations: ['@media(min-width: 0px) { width: 25% !important; }']},
+    { selector: 'w-xs-50', declarations: ['@media(min-width: 0px) { width: 50% !important; }']},
+    { selector: 'w-xs-75', declarations: ['@media(min-width: 0px) { width: 75% !important; }']},
+    { selector: 'w-xs-100', declarations: ['@media(min-width: 0px) { width: 100% !important; }']},
+    { selector: 'w-xs-auto', declarations: ['@media(min-width: 0px) { width: auto !important; }']},
+    { selector: 'w-sm-25', declarations: ['@media(min-width: 576px) { width: 25% !important; }']},
+    { selector: 'w-sm-50', declarations: ['@media(min-width: 576px) { width: 50% !important; }']},
+    { selector: 'w-sm-75', declarations: ['@media(min-width: 576px) { width: 75% !important; }']},
+    { selector: 'w-sm-100', declarations: ['@media(min-width: 576px) { width: 100% !important; }']},
+    { selector: 'w-sm-auto', declarations: ['@media(min-width: 576px) { width: auto !important; }']},
+    { selector: 'w-md-25', declarations: ['@media(min-width: 768px) { width: 25% !important; }']},
+    { selector: 'w-md-50', declarations: ['@media(min-width: 768px) { width: 50% !important; }']},
+    { selector: 'w-md-75', declarations: ['@media(min-width: 768px) { width: 75% !important; }']},
+    { selector: 'w-md-100', declarations: ['@media(min-width: 768px) { width: 100% !important; }']},
+    { selector: 'w-md-auto', declarations: ['@media(min-width: 768px) { width: auto !important; }']},
+    { selector: 'w-lg-25', declarations: ['@media(min-width: 992px) { width: 25% !important; }']},
+    { selector: 'w-lg-50', declarations: ['@media(min-width: 992px) { width: 50% !important; }']},
+    { selector: 'w-lg-75', declarations: ['@media(min-width: 992px) { width: 75% !important; }']},
+    { selector: 'w-lg-100', declarations: ['@media(min-width: 992px) { width: 100% !important; }']},
+    { selector: 'w-lg-auto', declarations: ['@media(min-width: 992px) { width: auto !important; }']},
+    { selector: 'w-xl-25', declarations: ['@media(min-width: 1200px) { width: 25% !important; }']},
+    { selector: 'w-xl-50', declarations: ['@media(min-width: 1200px) { width: 50% !important; }']},
+    { selector: 'w-xl-75', declarations: ['@media(min-width: 1200px) { width: 75% !important; }']},
+    { selector: 'w-xl-100', declarations: ['@media(min-width: 1200px) { width: 100% !important; }']},
+    { selector: 'w-xl-auto', declarations: ['@media(min-width: 1200px) { width: auto !important; }']},
+  ])}
 />
 
 export const pageQuery = graphql`


### PR DESCRIPTION
Updated `w-` utility class to incorporate breakpoints. For example `w-sm-100`, `w-md-auto`.

**Format**
`w-{breakpoint}-{size}`

**Breakpoints**
`xs`: @media(min-width: 0)
`sm`: @media(min-width: 576px)
`md`: @media(min-width: 768px)
`lg`: @media(min-width: 992px)
`xl`: @media(min-width: 1200px)

**Sizes**
`25`: 25%
`50`: 50%
`75`: 75%
`100`: 100%
`auto`: auto