### PR TITLE
docs: fix unescaped quote in docs test data

### DIFF
--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -446,7 +446,7 @@ a responsive grid of cards.
   },
   {
     'id': 'ea660b10-85c4-4ae3-8a5f-41cea3648e3e',
-    'title': 'Kiki's Delivery Service',
+    'title': 'Kiki\'s Delivery Service',
     'director': 'Hayao Miyazaki',
     'producer': 'Hayao Miyazaki',
     'release_date': '1989',


### PR DESCRIPTION
This was breaking the docs site.

<img width="953" alt="Screen Shot 2021-06-30 at 3 34 35 PM" src="https://user-images.githubusercontent.com/410630/124020747-b3484580-d9b8-11eb-9c75-c469cee6737c.png">
