### PR TITLE
fix: remove opacity on stateful button

### DIFF
--- a/src/StatefulButton/StatefulButton.scss
+++ b/src/StatefulButton/StatefulButton.scss
@@ -2,3 +2,7 @@
   margin-right: 0.5em;
   margin-left: -0.25em;
 }
+
+.pgn__stateful-btn-state-pending {
+  opacity: 1 !important;
+}


### PR DESCRIPTION
Remove the opacity on pending state of the stateful button so that a crisp original color would be displayed in pending state.

VAN-605

**Before the fix:**
<img width="512" alt="Screen Shot 2021-07-07 at 4 36 23 AM" src="https://user-images.githubusercontent.com/15120237/124678895-e7ea5e80-dedc-11eb-9a5e-7bef86c5198c.png">

**After the fix:**
<img width="307" alt="Screen Shot 2021-07-07 at 4 38 03 AM" src="https://user-images.githubusercontent.com/15120237/124679007-2122ce80-dedd-11eb-95cf-3c350f2b5e0d.png">
