### PR TITLE
fix: remove last margin of elements in Alert

### DIFF
--- a/src/Alert/Alert.scss
+++ b/src/Alert/Alert.scss
@@ -18,7 +18,7 @@
   @include border-radius($alert-border-radius);
   box-shadow: $alert-box-shadow;
 
-  & > :last-child {
+  .alert-message-content > :last-child {
     margin-bottom: 0;
   }
 

--- a/src/Alert/__snapshots__/Alert.test.jsx.snap
+++ b/src/Alert/__snapshots__/Alert.test.jsx.snap
@@ -25,7 +25,9 @@ exports[`<Alert /> correct rendering renders with correct with icon 1`] = `
       />
     </svg>
   </span>
-  <div>
+  <div
+    className="alert-message-content"
+  >
     Alert
   </div>
 </div>
@@ -36,7 +38,9 @@ exports[`<Alert /> correct rendering renders without icon prop 1`] = `
   className="fade alert-content undefined alert show"
   role="alert"
 >
-  <div>
+  <div
+    className="alert-message-content"
+  >
     Alert
   </div>
 </div>

--- a/src/Alert/index.jsx
+++ b/src/Alert/index.jsx
@@ -14,7 +14,7 @@ const WrappedAlert = React.forwardRef(({
     ref={ref}
   >
     {icon && <Icon src={icon} className="alert-icon" />}
-    <div>
+    <div className="alert-message-content">
       {children}
     </div>
   </Alert>


### PR DESCRIPTION
Extraneous margin: 
![image](https://user-images.githubusercontent.com/1615421/124762922-6658f780-df01-11eb-8d67-3623d8d7701f.png)

After: 
![image](https://user-images.githubusercontent.com/1615421/124762956-7244b980-df01-11eb-84d3-30ff5d1e280e.png)
