### PR TITLE
Modal dialog responsive view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14181,13 +14181,14 @@
       }
     },
     "react-responsive": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-6.1.2.tgz",
-      "integrity": "sha512-AXentVC/kN3KED9zhzJv2pu4vZ0i6cSHdTtbCScVV1MT6F5KXaG2qs5D7WLmhdaOvmiMX8UfmS4ZSO+WPwDt4g==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-8.2.0.tgz",
+      "integrity": "sha512-iagCqVrw4QSjhxKp3I/YK6+ODkWY6G+YPElvdYKiUUbywwh9Ds0M7r26Fj2/7dWFFbOpcGnJE6uE7aMck8j5Qg==",
       "requires": {
         "hyphenate-style-name": "^1.0.0",
         "matchmediaquery": "^0.3.0",
-        "prop-types": "^15.6.1"
+        "prop-types": "^15.6.1",
+        "shallow-equal": "^1.1.0"
       }
     },
     "react-style-singleton": {
@@ -15452,6 +15453,11 @@
           }
         }
       }
+    },
+    "shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-focus-on": "^3.5.0",
     "react-popper": "^2.2.4",
     "react-proptype-conditional-require": "^1.0.4",
-    "react-responsive": "^6.1.1",
+    "react-responsive": "^8.2.0",
     "react-table": "^7.6.1",
     "react-transition-group": "^4.0.0",
     "tabbable": "^4.0.0",

--- a/src/Modal/ModalDialog.jsx
+++ b/src/Modal/ModalDialog.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { useMediaQuery } from 'react-responsive';
 import ModalLayer from './ModalLayer';
 import { Icon, IconButton } from '..';
 import { Close } from '../../icons';
@@ -22,7 +23,10 @@ function ModalDialog({
   closeLabel,
   isFullscreenScroll,
   className,
+  isFullscreenOnMobile,
 }) {
+  const isTabletOrMobile = useMediaQuery({ query: '(max-width: 768px)' });
+  const showFullScreen = (isFullscreenOnMobile && isTabletOrMobile);
   return (
     <ModalLayer isOpen={isOpen} onClose={onClose}>
       <div
@@ -31,7 +35,7 @@ function ModalDialog({
         className={classNames(
           'pgn__modal',
           {
-            [`pgn__modal-${size}`]: size,
+            [`pgn__modal-${showFullScreen ? 'fullscreen' : size}`]: showFullScreen ? 'fullscreen' : size,
             [`pgn__modal-${variant}`]: variant,
             'pgn__modal-scroll-fullscreen': isFullscreenScroll,
           },
@@ -92,6 +96,10 @@ ModalDialog.propTypes = {
    * the browser window itself receives the scrollbar.
    */
   isFullscreenScroll: PropTypes.bool,
+  /**
+   * to show full screen view on mobile screens
+   * */
+  isFullscreenOnMobile: PropTypes.bool,
 };
 
 ModalDialog.defaultProps = {
@@ -102,6 +110,7 @@ ModalDialog.defaultProps = {
   closeLabel: 'Close',
   className: undefined,
   isFullscreenScroll: false,
+  isFullscreenOnMobile: false,
 };
 
 ModalDialog.Header = ModalDialogHeader;

--- a/src/Modal/ModalDialog.jsx
+++ b/src/Modal/ModalDialog.jsx
@@ -35,7 +35,7 @@ function ModalDialog({
         className={classNames(
           'pgn__modal',
           {
-            [`pgn__modal-${showFullScreen ? 'fullscreen' : size}`]: showFullScreen ? 'fullscreen' : size,
+            [`pgn__modal-${showFullScreen ? 'fullscreen' : size}`]: size,
             [`pgn__modal-${variant}`]: variant,
             'pgn__modal-scroll-fullscreen': isFullscreenScroll,
           },

--- a/src/Modal/modal-dialog.mdx
+++ b/src/Modal/modal-dialog.mdx
@@ -40,6 +40,7 @@ label for the dialog element.
         size={modalSize}
         variant={modalVariant}
         hasCloseButton
+        isFullscreenOnMobile
       >
         <ModalDialog.Header>
           <ModalDialog.Title>

--- a/src/Responsive/Responsive.test.jsx
+++ b/src/Responsive/Responsive.test.jsx
@@ -147,7 +147,7 @@ describe('<ExtraLarge />', () => {
   //  global.innerWidth = breakpoints.extraLarge.maxWidth;
 
     const wrapper = mount((
-      <ResponsiveContext.Provider value={{ width: breakpoints.extraLarge.minWidth }}>
+      <ResponsiveContext.Provider value={{ width: breakpoints.extraLarge.maxWidth }}>
         <ExtraLarge>
           <p>Hello world</p>
         </ExtraLarge>
@@ -168,12 +168,12 @@ describe('<ExtraLarge />', () => {
   });
 
   it('should not render children for larger than extra large displays', () => {
-    global.innerWidth = breakpoints.extraExtraLarge.minWidth;
-
     const wrapper = mount((
-      <Large>
-        <p>Hello world</p>
-      </Large>
+      <ResponsiveContext.Provider value={{ width: breakpoints.extraExtraLarge.minWidth }}>
+        <Large>
+          <p>Hello world</p>
+        </Large>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(0);
   });
@@ -181,23 +181,23 @@ describe('<ExtraLarge />', () => {
 
 describe('<ExtraExtraLarge />', () => {
   it('should render children for extra large displays', () => {
-    global.innerWidth = breakpoints.extraExtraLarge.minWidth;
-
     const wrapper = mount((
-      <ExtraExtraLarge>
-        <p>Hello world</p>
-      </ExtraExtraLarge>
+      <ResponsiveContext.Provider value={{ width: breakpoints.extraExtraLarge.minWidth }}>
+        <ExtraExtraLarge>
+          <p>Hello world</p>
+        </ExtraExtraLarge>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(1);
   });
 
   it('should not render children for smaller than extra large displays', () => {
-    global.innerWidth = breakpoints.extraLarge.maxWidth;
-
     const wrapper = mount((
-      <ExtraExtraLarge>
-        <p>Hello world</p>
-      </ExtraExtraLarge>
+      <ResponsiveContext.Provider value={{ width: breakpoints.extraLarge.maxWidth }}>
+        <ExtraExtraLarge>
+          <p>Hello world</p>
+        </ExtraExtraLarge>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(0);
   });

--- a/src/Responsive/Responsive.test.jsx
+++ b/src/Responsive/Responsive.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-
-import '../__mocks__/reactResponsive.mock';
+import { Context as ResponsiveContext } from 'react-responsive';
 
 import {
   breakpoints,
@@ -16,23 +15,23 @@ import {
 
 describe('<ExtraSmall />', () => {
   it('should render children for extra small displays', () => {
-    global.innerWidth = breakpoints.extraSmall.maxWidth;
-
     const wrapper = mount((
-      <ExtraSmall>
-        <p>Hello world</p>
-      </ExtraSmall>
+      <ResponsiveContext.Provider value={{ width: breakpoints.extraSmall.maxWidth }}>
+        <ExtraSmall>
+          <p>Hello world</p>
+        </ExtraSmall>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(1);
   });
 
   it('should not render children for larger than extra small displays', () => {
-    global.innerWidth = breakpoints.small.minWidth;
-
     const wrapper = mount((
-      <ExtraSmall>
-        <p>Hello world</p>
-      </ExtraSmall>
+      <ResponsiveContext.Provider value={{ width: breakpoints.small.minWidth }}>
+        <ExtraSmall>
+          <p>Hello world</p>
+        </ExtraSmall>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(0);
   });
@@ -40,34 +39,34 @@ describe('<ExtraSmall />', () => {
 
 describe('<Small />', () => {
   it('should render children for small displays', () => {
-    global.innerWidth = breakpoints.small.maxWidth;
-
     const wrapper = mount((
-      <Small>
-        <p>Hello world</p>
-      </Small>
+      <ResponsiveContext.Provider value={{ width: breakpoints.small.maxWidth }}>
+        <Small>
+          <p>Hello world</p>
+        </Small>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(1);
   });
 
   it('should not render children for smaller than small displays', () => {
-    global.innerWidth = breakpoints.extraSmall.maxWidth;
-
     const wrapper = mount((
-      <Small>
-        <p>Hello world</p>
-      </Small>
+      <ResponsiveContext.Provider value={{ width: breakpoints.extraSmall.maxWidth }}>
+        <Small>
+          <p>Hello world</p>
+        </Small>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(0);
   });
 
   it('should not render children for larger than small displays', () => {
-    global.innerWidth = breakpoints.medium.minWidth;
-
     const wrapper = mount((
-      <Small>
-        <p>Hello world</p>
-      </Small>
+      <ResponsiveContext.Provider value={{ width: breakpoints.medium.minWidth }}>
+        <Small>
+          <p>Hello world</p>
+        </Small>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(0);
   });
@@ -75,34 +74,34 @@ describe('<Small />', () => {
 
 describe('<Medium />', () => {
   it('should render children for medium displays', () => {
-    global.innerWidth = breakpoints.medium.maxWidth;
-
     const wrapper = mount((
-      <Medium>
-        <p>Hello world</p>
-      </Medium>
+      <ResponsiveContext.Provider value={{ width: breakpoints.medium.maxWidth }}>
+        <Medium>
+          <p>Hello world</p>
+        </Medium>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(1);
   });
 
   it('should not render children for smaller than medium displays', () => {
-    global.innerWidth = breakpoints.small.maxWidth;
-
     const wrapper = mount((
-      <Medium>
-        <p>Hello world</p>
-      </Medium>
+      <ResponsiveContext.Provider value={{ width: breakpoints.small.maxWidth }}>
+        <Medium>
+          <p>Hello world</p>
+        </Medium>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(0);
   });
 
   it('should not render children for larger than medium displays', () => {
-    global.innerWidth = breakpoints.large.minWidth;
-
     const wrapper = mount((
-      <Medium>
-        <p>Hello world</p>
-      </Medium>
+      <ResponsiveContext.Provider value={{ width: breakpoints.large.minWidth }}>
+        <Medium>
+          <p>Hello world</p>
+        </Medium>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(0);
   });
@@ -110,34 +109,34 @@ describe('<Medium />', () => {
 
 describe('<Large />', () => {
   it('should render children for large displays', () => {
-    global.innerWidth = breakpoints.large.maxWidth;
-
     const wrapper = mount((
-      <Large>
-        <p>Hello world</p>
-      </Large>
+      <ResponsiveContext.Provider value={{ width: breakpoints.large.maxWidth }}>
+        <Large>
+          <p>Hello world</p>
+        </Large>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(1);
   });
 
   it('should not render children for smaller than large displays', () => {
-    global.innerWidth = breakpoints.medium.maxWidth;
-
     const wrapper = mount((
-      <Large>
-        <p>Hello world</p>
-      </Large>
+      <ResponsiveContext.Provider value={{ width: breakpoints.medium.maxWidth }}>
+        <Large>
+          <p>Hello world</p>
+        </Large>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(0);
   });
 
   it('should not render children for larger than large displays', () => {
-    global.innerWidth = breakpoints.extraLarge.minWidth;
-
     const wrapper = mount((
-      <Large>
-        <p>Hello world</p>
-      </Large>
+      <ResponsiveContext.Provider value={{ width: breakpoints.extraLarge.minWidth }}>
+        <Large>
+          <p>Hello world</p>
+        </Large>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(0);
   });
@@ -145,23 +144,25 @@ describe('<Large />', () => {
 
 describe('<ExtraLarge />', () => {
   it('should render children for extra large displays', () => {
-    global.innerWidth = breakpoints.extraLarge.maxWidth;
+  //  global.innerWidth = breakpoints.extraLarge.maxWidth;
 
     const wrapper = mount((
-      <ExtraLarge>
-        <p>Hello world</p>
-      </ExtraLarge>
+      <ResponsiveContext.Provider value={{ width: breakpoints.extraLarge.minWidth }}>
+        <ExtraLarge>
+          <p>Hello world</p>
+        </ExtraLarge>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(1);
   });
 
   it('should not render children for smaller than extra large displays', () => {
-    global.innerWidth = breakpoints.large.maxWidth;
-
     const wrapper = mount((
-      <ExtraLarge>
-        <p>Hello world</p>
-      </ExtraLarge>
+      <ResponsiveContext.Provider value={{ width: breakpoints.large.maxWidth }}>
+        <ExtraLarge>
+          <p>Hello world</p>
+        </ExtraLarge>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(0);
   });
@@ -204,23 +205,23 @@ describe('<ExtraExtraLarge />', () => {
 
 describe('<ExtraLarge />', () => {
   it('should render children for larger than extra small displays', () => {
-    global.innerWidth = breakpoints.small.minWidth;
-
     const wrapper = mount((
-      <LargerThanExtraSmall>
-        <p>Hello world</p>
-      </LargerThanExtraSmall>
+      <ResponsiveContext.Provider value={{ width: breakpoints.small.minWidth }}>
+        <LargerThanExtraSmall>
+          <p>Hello world</p>
+        </LargerThanExtraSmall>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(1);
   });
 
   it('should not render children for extra small displays', () => {
-    global.innerWidth = breakpoints.extraSmall.maxWidth;
-
     const wrapper = mount((
-      <LargerThanExtraSmall>
-        <p>Hello world</p>
-      </LargerThanExtraSmall>
+      <ResponsiveContext.Provider value={{ width: breakpoints.extraSmall.maxWidth }}>
+        <LargerThanExtraSmall>
+          <p>Hello world</p>
+        </LargerThanExtraSmall>
+      </ResponsiveContext.Provider>
     ));
     expect(wrapper.find('p')).toHaveLength(0);
   });


### PR DESCRIPTION
This Pr is created in reference to the ticket (https://openedx.atlassian.net/browse/TNL-8477) which requires modal dialog to be fullscreen on mobile view and on desktop as modal. 
- react responsive version is updated to 8.2.0
- isFullscreenOnMobile prop is passed in the modal dialog component which will help calculate if the fullscreen design is needed on mobile view. 
- docs are updated to match requirements
- updated test case for responsive component
- updated test cases for pagination