### PR TITLE
fix: label text spilling out of the field

### DIFF
--- a/src/Form/_Form.scss
+++ b/src/Form/_Form.scss
@@ -156,6 +156,10 @@ $select-icon-padding: .5625rem !default;
     // a color. Adding an alpha channel smooths it out.
     background-color: rgba($input-bg, 0.01);
     white-space: nowrap;
+    max-width: 75vw;
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .has-leading-element & {


### PR DESCRIPTION
On small screens, longer text labels spilling out of the input field, added text-overflow ellipses.

[VAN-672](https://openedx.atlassian.net/browse/VAN-672)

## Before
![screencapture-localhost-1999-register-2021-07-23-16_06_25](https://user-images.githubusercontent.com/2851134/126774237-235b46cb-45e8-45fe-98b5-2c44db4fc8f8.png) 

## After
![screencapture-localhost-1999-register-2021-07-23-16_06_04](https://user-images.githubusercontent.com/2851134/126774262-66144b85-a942-46e3-8b4d-8615dfee4fe2.png)
