### PR TITLE
fix: fix field error spacing issue

### DIFF
--- a/src/Form/_FormText.scss
+++ b/src/Form/_FormText.scss
@@ -1,6 +1,5 @@
 .pgn__form-text {
   font-size: $small-font-size;
-  display: flex;
   align-items: center;
   .pgn__icon {
     height: 1em;


### PR DESCRIPTION
Fix Field error spacing issue in safari. Following is the screenshot of the reported problem.
[VAN-619](https://openedx.atlassian.net/browse/VAN-619)

![image-20210614-214622](https://user-images.githubusercontent.com/15120237/126922411-4ac7f5c6-9465-4d3b-bfe8-355cb5878f25.png)