### PR TITLE
fix: remove modal dialog body before z-index for non scrollable modal

### DIFF
--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -131,8 +131,8 @@
   overflow: auto;
   position: relative;
 
-  &::before{
-    content:"";
+  &::before {
+    content: "";
     background-color: transparent;
     background-image: linear-gradient(#605c5c, #b8bebe, transparent 50%);
     display: block;
@@ -142,13 +142,18 @@
     margin-top: -$modal-inner-padding;
     margin-left: -$modal-inner-padding;
     margin-right: -$modal-inner-padding;
-    opacity: .5;
+    opacity: 0.5;
     z-index: 2;
   }
-  &::after{
-    content:"";
+  &::after {
+    content: "";
     background-color: transparent;
-    background-image: linear-gradient(360deg, #605c5c, #b8bebe, transparent 50%);
+    background-image: linear-gradient(
+      360deg,
+      #605c5c,
+      #b8bebe,
+      transparent 50%
+    );
     display: block;
     height: 20px;
     position: sticky;
@@ -156,32 +161,33 @@
     margin-bottom: -$modal-inner-padding;
     margin-left: -$modal-inner-padding;
     margin-right: -$modal-inner-padding;
-    opacity: .5;
+    opacity: 0.5;
   }
 
   &.pgn__modal-body-scroll-bottom {
-    &::before{
-      opacity: .5;
+    &::before {
+      opacity: 0.5;
     }
-    &::after{
+    &::after {
       opacity: 0;
     }
   }
 
   &.pgn__modal-body-scroll-top {
-    &::before{
+    &::before {
       opacity: 0;
+      z-index: 0;
     }
-    &::after{
-      opacity: .5;
+    &::after {
+      opacity: 0.5;
     }
   }
 
   &.pgn__modal-body-scroll-top.pgn__modal-body-scroll-bottom {
-    &::before{
+    &::before {
       opacity: 0;
     }
-    &::after{
+    &::after {
       opacity: 0;
     }
   }
@@ -223,8 +229,8 @@
   .pgn__modal-body {
     padding: $modal-inner-padding / 2 $modal-inner-padding;
 
-    &::before{
-      top: -$modal-inner-padding / 2
+    &::before {
+      top: -$modal-inner-padding / 2;
     }
   }
 }


### PR DESCRIPTION
[TNL-8563](https://openedx.atlassian.net/browse/TNL-8563)

Set `z-index: 0` in modal dialog body ::before selector for non scrollable modals.  Modal dialog body top shadow `z-index` and `negative margin` were overlaying the content/button of non-scrollable. Which were affecting content onClick action. Modal shadow will work as normal for scrollable body content. 

<img width="543" alt="Screenshot 2021-07-28 at 5 05 46 PM" src="https://user-images.githubusercontent.com/79941147/127319422-ce0e13e4-5506-407d-a62d-efd1f8901fdc.png">
