### PR TITLE
style: add 8px margin between external link help text and launch icon

### DIFF
--- a/src/Hyperlink/index.jsx
+++ b/src/Hyperlink/index.jsx
@@ -29,7 +29,7 @@ function Hyperlink(props) {
     if (showLaunchIcon) {
       externalLinkIcon = (
         // Space between content and icon
-        <span className="d-inline-block align-text-top">{' '}
+        <span className="d-inline-block align-text-top ml-2">
           <Icon src={Launch} style={{ height: '1em', width: '1em' }} />
         </span>
       );


### PR DESCRIPTION
[TNL-8566](https://openedx.atlassian.net/browse/TNL-8566)

Add 8px margin-left space between external link help text and launch icon in Hyperlink component. 
<img width="325" alt="Screenshot 2021-07-28 at 7 36 42 PM" src="https://user-images.githubusercontent.com/79941147/127341928-df839414-ad7e-44f0-86c6-ffcbb505d782.png">
