### PR TITLE
fix: mobile view breakpoint resolution in useMediaQuery

### DIFF
--- a/src/Modal/ModalDialog.jsx
+++ b/src/Modal/ModalDialog.jsx
@@ -25,7 +25,7 @@ function ModalDialog({
   className,
   isFullscreenOnMobile,
 }) {
-  const isMobile = useMediaQuery({ query: '(max-width: 768px)' });
+  const isMobile = useMediaQuery({ query: '(max-width: 767.98px)' });
   const showFullScreen = (isFullscreenOnMobile && isMobile);
   return (
     <ModalLayer isOpen={isOpen} onClose={onClose}>


### PR DESCRIPTION
[TNL-8583](https://openedx.atlassian.net/browse/TNL-8583)

Update mobile responsive breakpoint value from `max-width: 768px`  to `max-width: 767.98px` in modal dialog  useMediaQuery.  768px breakpoint was making fullscreen display in tablet view. Modal Dial should only full screen in mobile view. 
<img width="529" alt="Screenshot 2021-07-28 at 9 34 09 PM" src="https://user-images.githubusercontent.com/79941147/127361475-693ecd83-4983-4ea3-bab6-2d49319ecdf6.png">

<img width="506" alt="Screenshot 2021-07-28 at 9 35 05 PM" src="https://user-images.githubusercontent.com/79941147/127361596-987e3ff0-6f55-49d0-a379-4032e283bc52.png">
  