### PR TITLE
style: set stepper header step center alignment for mobile view

### DIFF
--- a/src/Stepper/Stepper.scss
+++ b/src/Stepper/Stepper.scss
@@ -1,6 +1,6 @@
 .pgn__stepper-header-step-list {
   list-style: none;
-  padding: .25rem 0;
+  padding: 0.25rem 0;
   display: flex;
   align-items: center;
   margin: 0;
@@ -11,8 +11,9 @@
 .pgn__stepper-header {
   display: flex;
   justify-content: center;
+  align-items: center;
   background: $white;
-  padding: .75rem 1rem;
+  padding: 0.75rem 1rem;
   min-height: 5.13rem;
 }
 
@@ -28,11 +29,11 @@
     width: 1.5rem;
     border-radius: 50%;
     background: currentColor;
-    margin-right: .5rem;
+    margin-right: 0.5rem;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: .75rem;
+    font-size: 0.75rem;
     flex-shrink: 0;
     * {
       color: $white;
@@ -79,5 +80,5 @@
   height: 1px;
   background: $light;
   flex-basis: 80px;
-  margin: 0 .5rem;
+  margin: 0 0.5rem;
 }


### PR DESCRIPTION
[TNL-8572](https://openedx.atlassian.net/browse/TNL-8572)

1. Fix step alignment issue for mobile view in the stepper header component

Before center align
<img width="289" alt="Screenshot 2021-07-29 at 4 39 33 PM" src="https://user-images.githubusercontent.com/79941147/127485774-0b4f5ac7-5afb-44f0-8af0-aacbee14f92b.png">

After center align
<img width="282" alt="Screenshot 2021-07-29 at 4 36 41 PM" src="https://user-images.githubusercontent.com/79941147/127485515-3e5f7d93-0ee4-4603-b34e-03f72376c18b.png">
