### PR TITLE
fix: set launch icon and external text alignment to the vertical center

### DIFF
--- a/src/Hyperlink/index.jsx
+++ b/src/Hyperlink/index.jsx
@@ -29,7 +29,7 @@ function Hyperlink(props) {
     if (showLaunchIcon) {
       externalLinkIcon = (
         // Space between content and icon
-        <span className="d-inline-block align-text-top ml-2">
+        <span className="d-inline-block align-middle ml-2">
           <Icon src={Launch} style={{ height: '1em', width: '1em' }} />
         </span>
       );


### PR DESCRIPTION
[TNL-8588](https://openedx.atlassian.net/browse/TNL-8588)
Fix launch icon and text alignment to the vertical center 

before 
<img width="133" alt="Screenshot 2021-08-02 at 11 01 15 AM" src="https://user-images.githubusercontent.com/79941147/127811767-84d360bd-d10c-45df-829e-55c7d0aef126.png">

after
<img width="157" alt="Screenshot 2021-08-02 at 11 01 45 AM" src="https://user-images.githubusercontent.com/79941147/127811780-b786ab30-a64e-4dd5-8074-aed09b83fd92.png">
