### PR TITLE
fix: style fix for shadow on modal dialog scroll top

### DIFF
--- a/src/Modal/_ModalDialog.scss
+++ b/src/Modal/_ModalDialog.scss
@@ -176,7 +176,7 @@
   &.pgn__modal-body-scroll-top {
     &::before {
       opacity: 0;
-      z-index: 0;
+      z-index: -1;
     }
     &::after {
       opacity: 0.5;


### PR DESCRIPTION
elements are disturbed when fully scrolled to the top due to shadow border content hence setting its index to -1.