### PR TITLE
feat: menu and menu item components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14034,6 +14034,11 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-arrow-key-navigation-hook": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/react-arrow-key-navigation-hook/-/react-arrow-key-navigation-hook-1.0.2.tgz",
+      "integrity": "sha512-ClU6OTB91/BgQdei8+LRMOhy9x7IA15tlT9I+bdwwE/pdv7l1a0w2M5HoFxzVbI0OZJdn0oDZ6FveNR7GAUxpA=="
+    },
     "react-bootstrap": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "lodash.uniqby": "^4.7.0",
     "mailto-link": "^1.0.0",
     "prop-types": "^15.7.2",
+    "react-arrow-key-navigation-hook": "^1.0.2",
     "react-bootstrap": "^1.3.0",
     "react-focus-on": "^3.5.0",
     "react-popper": "^2.2.4",

--- a/src/Menu/Menu.scss
+++ b/src/Menu/Menu.scss
@@ -1,0 +1,94 @@
+.pgn__menu-item {
+    .pgn__menu-item-content-spacer {
+      flex-grow: 1;
+    }
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    width: 100%;
+    font-family: $btn-font-family;
+    font-weight: $btn-font-weight;
+    color: $body-color;
+    text-align: center;
+    vertical-align: middle;
+    user-select: none;
+    background-color: transparent;
+    border: $btn-border-width solid transparent;
+
+    padding: $btn-padding-y $btn-padding-x;
+    font-size: $btn-font-size;
+    line-height: $btn-line-height;
+    border-radius: 0;
+
+    @include hover {
+      color: $body-color;
+      text-decoration: none;
+
+    }
+
+    // Disabled comes first so active can properly restyle
+    &.disabled,
+    &:disabled {
+      opacity: $btn-disabled-opacity;
+    }
+
+    $background: $btn-tertiary-bg;
+    $border: transparent;
+    $hover-background: $btn-tertiary-hover-bg;
+    $hover-border: transparent;
+    $active-background: $btn-tertiary-active-bg;
+    $active-border: transparent;
+
+    color: $btn-tertiary-color;
+    border-color: $border;
+
+    @include hover {
+      color: $btn-tertiary-color;
+      border-color: $hover-border;
+      background: $hover-background;
+    }
+
+    &:not(:disabled):not(.disabled):active,
+    &:not(:disabled):not(.disabled).active,
+    .show > &.dropdown-toggle {
+      color: $btn-tertiary-color;
+      background-color: $active-background;
+      border-color: $active-border;
+    }
+
+    &.focus,
+    &:focus{
+        font-weight: $font-weight-bolder;
+        color: $btn-tertiary-color;
+        background-color: $active-background;
+        border-color: $active-border;
+    }
+
+    .btn-icon-before {
+      margin-inline-end: 0.5rem;
+      margin-left: -0.25em;
+    }
+
+    .btn-icon-after {
+      margin-inline-start: 0.5rem;
+      margin-right: -0.25em;
+    }
+  }
+.pgn__menu-item:nth-last-child(1) {
+    @include hover {
+      border-bottom-right-radius: 0.25em;
+      border-bottom-left-radius: 0.25em;
+    }
+}
+.pgn__menu-item:nth-child(1) {
+  @include hover {
+    border-top-right-radius: 0.25em;
+    border-top-left-radius: 0.25em;
+  }
+}
+.pgn__menu{
+  border-radius: 0.25em;
+  box-shadow: $box-shadow;
+  background-color: $btn-tertiary-bg;
+  border-color: transparent;
+}

--- a/src/Menu/Menu.test.jsx
+++ b/src/Menu/Menu.test.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import renderer from 'react-test-renderer';
+import { MenuItem } from '..';
+import Menu from '.';
+import { Add, Check } from '../../icons';
+import Hyperlink from '../Hyperlink';
+import Button from '../Button';
+import Form from '../Form';
+
+// Mock the whole navigation modulue
+
+describe('Menu Item renders correctly', () => {
+  it('renders as just a div With empty usage', () => {
+    const wrapper = mount(<Menu />);
+    expect(wrapper.find('div').exists()).toEqual(true);
+  });
+  it('renders as expected with menu items', () => {
+    const tree = renderer.create((
+      <Menu>
+        <MenuItem> A Menu Item</MenuItem>
+        <MenuItem iconBefore={Add} stoven>A Menu Item With an Icon Before</MenuItem>
+        <MenuItem iconAfter={Check}>A Menu Item With an Icon After </MenuItem>
+        <MenuItem disabled>A Disabled Menu Item</MenuItem>
+        <MenuItem as={Hyperlink} href="https://en.wikipedia.org/wiki/Hyperlink">A Link Menu Item</MenuItem>
+        <MenuItem as={Button} variant="primary" size="inline">A Button Menu Item</MenuItem>
+        <MenuItem as={Form.Checkbox}>A Checkbox Menu Item</MenuItem>
+      </Menu>
+    )).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('Renders disabled menutitems, but you cant click them', () => {
+    const clickFn = jest.fn();
+    const wrapper = mount((
+      <Menu>
+        <MenuItem as={Button} iconBefore={Add} onClick={clickFn} disabled>Cant Touch This</MenuItem>
+      </Menu>
+    ));
+    expect(clickFn).toHaveBeenCalledTimes(0);
+    wrapper
+      .find('button')
+      .simulate('click');
+    expect(clickFn).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('Keyoard Interactions', () => {
+  const wrapper = mount(
+    <Menu>
+      <MenuItem>Default</MenuItem>
+      <MenuItem as={Button} iconBefore={Add}>Cant Touch This</MenuItem>
+      <MenuItem iconBefore={Add}>Icon Before</MenuItem>
+    </Menu>,
+  );
+
+  const menuContainer = wrapper.find(Menu);
+  const menuItems = wrapper.find(MenuItem);
+
+  it('should focus on the first item after click', () => {
+    menuItems.at(0).simulate('click');
+    expect(menuItems.at(0) === document.activeElement);
+  });
+  it('should focus the next item after ArrowDown keyDown', () => {
+    menuContainer
+      .simulate('keyDown', { key: 'ArrowDown' });
+    expect(menuItems.at(1) === document.activeElement);
+  });
+  it('should focus the next item after Tab keyDown', () => {
+    menuContainer.simulate('keyDown', { key: 'Tab' });
+    expect(menuItems.at(2) === document.activeElement);
+  });
+
+  it('should loop focus to the first item after Tab keyDown on last item', () => {
+    menuContainer.simulate('keyDown', { key: 'Tab' });
+    expect(menuItems.at(0) === document.activeElement);
+  });
+
+  it('should loop focus to the last item after ArrowUp keyDown on first item', () => {
+    menuContainer.simulate('keyDown', { key: 'ArrowUp' });
+    expect(menuItems.at(2) === document.activeElement);
+  });
+
+  it('should focus the previous item after Shift + Tab keyDown', () => {
+    menuContainer.simulate('keyDown', { key: 'Tab', shiftKey: true });
+    expect(menuItems.at(1) === document.activeElement);
+  });
+});

--- a/src/Menu/MenuItem.jsx
+++ b/src/Menu/MenuItem.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { Icon } from '..';
+
+const MenuItem = ({
+  as,
+  children,
+  iconAfter,
+  iconBefore,
+  ...props
+}) => {
+  const className = classNames(props.className, 'pgn__menu-item');
+
+  return React.createElement(
+    as,
+    {
+      ...props,
+      className,
+    },
+    (
+      <>
+        {iconBefore && <Icon className="btn-icon-before" src={iconBefore} />}
+        {children}
+        <span className="pgn__menu-item-content-spacer" />
+        {iconAfter && <Icon className="btn-icon-after" src={iconAfter} />}
+      </>
+    ),
+  );
+};
+
+MenuItem.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+  as: PropTypes.elementType,
+  iconBefore: PropTypes.node,
+  iconAfter: PropTypes.node,
+};
+
+MenuItem.defaultProps = {
+  as: 'button',
+  className: undefined,
+  children: null,
+  iconBefore: undefined,
+  iconAfter: undefined,
+};
+
+export default MenuItem;

--- a/src/Menu/MenuItem.test.jsx
+++ b/src/Menu/MenuItem.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import renderer from 'react-test-renderer';
+import { MenuItem } from '..';
+import Button from '../Button';
+import { Add, Check } from '../../icons';
+
+const children = 'Hello World';
+
+describe('Menu Item', () => {
+  it('renders as expected with both icons', () => {
+    const tree = renderer.create((
+      <MenuItem iconBefore={Add} iconAfter={Check}>{children}</MenuItem>
+    )).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('The Button can be clicked', () => {
+    const clickFn = jest.fn();
+    const wrapper = mount((
+      <MenuItem as={Button} iconBefore={Add} onClick={clickFn}>{children}</MenuItem>
+    ));
+    expect(clickFn).toHaveBeenCalledTimes(0);
+    wrapper
+      .find('button')
+      .simulate('click');
+    expect(clickFn).toHaveBeenCalledTimes(1);
+  });
+  it('Disabled Button cant be clicked', () => {
+    const clickFn = jest.fn();
+    const wrapper = mount(
+      <MenuItem as={Button} iconBefore={Add} onClick={clickFn} disabled>
+        I am nonoperational
+      </MenuItem>,
+    );
+    expect(clickFn).toHaveBeenCalledTimes(0);
+    wrapper
+      .find('button')
+      .simulate('click');
+    expect(clickFn).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/Menu/README.md
+++ b/src/Menu/README.md
@@ -1,0 +1,78 @@
+---
+title: 'Menu'
+type: 'component'
+components:
+- MenuItem
+- Menu
+categories:
+- Navigation
+- Buttonlike
+status: 'New'
+designStatus: 'Done'
+devStatus: 'Done'
+notes: ''
+---
+
+### MenuItem
+
+A menu item is a link, button, or checkbox for use by any kind of menu overlay, dropdown menu, or nav menu. A menu item can be text-only or combined with an icon.
+
+```jsx live
+() => {
+  return (
+      <div className="bg-white p-3 rounded shadow" style={{width: 400}}>
+        <MenuItem> A Menu Item</MenuItem>
+        <MenuItem as={Button} iconBefore={Add}>A Menu Item With an Icon Before</MenuItem>
+        <MenuItem iconAfter={Check}>A Menu Item With an Icon After </MenuItem>
+        <MenuItem disabled>A Disabled Menu Item</MenuItem>
+        <MenuItem as= {Hyperlink} href = "https://en.wikipedia.org/wiki/Hyperlink">A Link Menu Item</MenuItem>
+        <MenuItem as= {Button} variant="primary" size="inline">A Button Menu Item</MenuItem>
+        <MenuItem as= {Form.Checkbox} >A Checkbox Menu Item</MenuItem>
+      </div>
+  );
+}
+```
+
+### Menu
+
+An arrow-key naivgable Menu which consists of MenuItems. A Menu can be employed to produce its common variants, including dropdown menus, select menus, and others. Menus are keyboard navigable with both tab and arrow keys.
+
+```jsx live
+() => {
+  return (
+    <Menu>
+        <MenuItem> A Menu Item</MenuItem>
+        <MenuItem iconBefore={Add} stoven>A Menu Item With an Icon Before</MenuItem>
+        <MenuItem iconAfter={Check}>A Menu Item With an Icon After </MenuItem>
+        <MenuItem disabled>A Disabled Menu Item</MenuItem>
+        <MenuItem as={Hyperlink} href="https://en.wikipedia.org/wiki/Hyperlink">A Link Menu Item</MenuItem>
+        <MenuItem as={Button} variant="primary" size="inline">A Button Menu Item</MenuItem>
+        <MenuItem as={Form.Checkbox}>A Checkbox Menu Item</MenuItem>
+    </Menu>
+  );
+}
+```
+
+A Menu can include things like forms.
+
+```jsx live
+() => {
+  return (
+    <Menu>
+      <Form.Group>
+        <MenuItem as ={Form.Label}>Which Color?</MenuItem>
+        <Form.CheckboxSet
+          name="color-two"
+          onChange={(e) => console.log(e.target.value)}
+          defaultValue={['green']}
+        >
+        <MenuItem as = {Form.Checkbox} value="red">Red</MenuItem>
+        <MenuItem as = {Form.Checkbox} value="blue">Blue</MenuItem>
+        <MenuItem as = {Form.Checkbox} value="green">Green</MenuItem>
+        <MenuItem as = {Form.Checkbox} value="yellow">Yellow</MenuItem>
+        </Form.CheckboxSet>
+      </Form.Group>
+    </Menu>
+  );
+}
+```

--- a/src/Menu/__snapshots__/Menu.test.jsx.snap
+++ b/src/Menu/__snapshots__/Menu.test.jsx.snap
@@ -1,0 +1,253 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Menu Item renders as expected with menu items 1`] = `
+<div
+  className="pgn__menu"
+>
+  <div
+    className="pgn__menu-bg"
+  >
+    <button
+      className="pgn__menu-item"
+    >
+       A Menu Item
+      <span
+        className="pgn__menu-item-content-spacer"
+      />
+    </button>
+    <button
+      className="pgn__menu-item"
+      stoven={true}
+    >
+      <span
+        className="pgn__icon btn-icon-before"
+      >
+        <svg
+          aria-hidden={true}
+          aria-label=""
+          fill="none"
+          focusable={false}
+          height={24}
+          role="img"
+          viewBox="0 0 24 24"
+          width={24}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+      A Menu Item With an Icon Before
+      <span
+        className="pgn__menu-item-content-spacer"
+      />
+    </button>
+    <button
+      className="pgn__menu-item"
+    >
+      A Menu Item With an Icon After 
+      <span
+        className="pgn__menu-item-content-spacer"
+      />
+      <span
+        className="pgn__icon btn-icon-after"
+      >
+        <svg
+          aria-hidden={true}
+          aria-label=""
+          fill="none"
+          focusable={false}
+          height={24}
+          role="img"
+          viewBox="0 0 24 24"
+          width={24}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+    </button>
+    <button
+      className="pgn__menu-item"
+      disabled={true}
+    >
+      A Disabled Menu Item
+      <span
+        className="pgn__menu-item-content-spacer"
+      />
+    </button>
+    <a
+      className="pgn__menu-item"
+      href="https://en.wikipedia.org/wiki/Hyperlink"
+      onClick={[Function]}
+      target="_self"
+    >
+      A Link Menu Item
+      <span
+        className="pgn__menu-item-content-spacer"
+      />
+    </a>
+    <button
+      className="pgn__menu-item btn btn-primary btn-inline"
+      disabled={false}
+      type="button"
+    >
+      A Button Menu Item
+      <span
+        className="pgn__menu-item-content-spacer"
+      />
+    </button>
+    <div
+      className="pgn__form-checkbox pgn__menu-item"
+    >
+      <input
+        className="pgn__form-checkbox-input"
+        id="form-field1"
+        type="checkbox"
+      />
+      <div>
+        <label
+          className="pgn__form-label"
+          htmlFor="form-field1"
+        >
+          A Checkbox Menu Item
+          <span
+            className="pgn__menu-item-content-spacer"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Menu Item renders correctly renders as expected with menu items 1`] = `
+<div
+  className="pgn__menu"
+>
+  <div
+    className="pgn__menu-bg"
+  >
+    <button
+      className="pgn__menu-item"
+    >
+       A Menu Item
+      <span
+        className="pgn__menu-item-content-spacer"
+      />
+    </button>
+    <button
+      className="pgn__menu-item"
+      stoven={true}
+    >
+      <span
+        className="pgn__icon btn-icon-before"
+      >
+        <svg
+          aria-hidden={true}
+          aria-label=""
+          fill="none"
+          focusable={false}
+          height={24}
+          role="img"
+          viewBox="0 0 24 24"
+          width={24}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+      A Menu Item With an Icon Before
+      <span
+        className="pgn__menu-item-content-spacer"
+      />
+    </button>
+    <button
+      className="pgn__menu-item"
+    >
+      A Menu Item With an Icon After 
+      <span
+        className="pgn__menu-item-content-spacer"
+      />
+      <span
+        className="pgn__icon btn-icon-after"
+      >
+        <svg
+          aria-hidden={true}
+          aria-label=""
+          fill="none"
+          focusable={false}
+          height={24}
+          role="img"
+          viewBox="0 0 24 24"
+          width={24}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+    </button>
+    <button
+      className="pgn__menu-item"
+      disabled={true}
+    >
+      A Disabled Menu Item
+      <span
+        className="pgn__menu-item-content-spacer"
+      />
+    </button>
+    <a
+      className="pgn__menu-item"
+      href="https://en.wikipedia.org/wiki/Hyperlink"
+      onClick={[Function]}
+      target="_self"
+    >
+      A Link Menu Item
+      <span
+        className="pgn__menu-item-content-spacer"
+      />
+    </a>
+    <button
+      className="pgn__menu-item btn btn-primary btn-inline"
+      disabled={false}
+      type="button"
+    >
+      A Button Menu Item
+      <span
+        className="pgn__menu-item-content-spacer"
+      />
+    </button>
+    <div
+      className="pgn__form-checkbox pgn__menu-item"
+    >
+      <input
+        className="pgn__form-checkbox-input"
+        id="form-field1"
+        type="checkbox"
+      />
+      <div>
+        <label
+          className="pgn__form-label"
+          htmlFor="form-field1"
+        >
+          A Checkbox Menu Item
+          <span
+            className="pgn__menu-item-content-spacer"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/Menu/__snapshots__/MenuItem.test.jsx.snap
+++ b/src/Menu/__snapshots__/MenuItem.test.jsx.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Menu Item renders as expected with both icons 1`] = `
+<button
+  className="pgn__menu-item"
+>
+  <span
+    className="pgn__icon btn-icon-before"
+  >
+    <svg
+      aria-hidden={true}
+      aria-label=""
+      fill="none"
+      focusable={false}
+      height={24}
+      role="img"
+      viewBox="0 0 24 24"
+      width={24}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+        fill="currentColor"
+      />
+    </svg>
+  </span>
+  Hello World
+  <span
+    className="pgn__menu-item-content-spacer"
+  />
+  <span
+    className="pgn__icon btn-icon-after"
+  >
+    <svg
+      aria-hidden={true}
+      aria-label=""
+      fill="none"
+      focusable={false}
+      height={24}
+      role="img"
+      viewBox="0 0 24 24"
+      width={24}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
+        fill="currentColor"
+      />
+    </svg>
+  </span>
+</button>
+`;

--- a/src/Menu/index.jsx
+++ b/src/Menu/index.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import useArrowKeyNavigationHook from 'react-arrow-key-navigation-hook';
+
+const Menu = ({
+  as,
+  arrowKeyNavigationSelector,
+  children,
+  ...props
+}) => {
+  const parentRef = useArrowKeyNavigationHook({ selectors: arrowKeyNavigationSelector });
+  const className = classNames(props.className, 'pgn__menu');
+
+  return React.createElement(
+    as,
+    {
+      ...props,
+      ref: parentRef,
+      className,
+    },
+    (
+      <>
+        <div className="pgn__menu-bg">
+          {children}
+        </div>
+      </>
+    ),
+  );
+};
+
+Menu.propTypes = {
+  className: PropTypes.string,
+  arrowKeyNavigationSelector: PropTypes.string,
+  as: PropTypes.elementType,
+  children: PropTypes.node,
+};
+
+Menu.defaultProps = {
+  className: undefined,
+  arrowKeyNavigationSelector: 'a:not(:disabled),button:not(:disabled),input:not(:disabled)',
+  as: 'div',
+  children: null,
+};
+
+export default Menu;

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,8 @@ export { default as ListBox } from './ListBox';
 export { default as ListBoxOption } from './ListBoxOption';
 export { default as MailtoLink } from './MailtoLink';
 export { default as Media } from './Media';
+export { default as Menu } from './Menu';
+export { default as MenuItem } from './Menu/MenuItem';
 export { default as Modal } from './Modal';
 export { default as ModalCloseButton } from './Modal/ModalCloseButton';
 export { default as FullscreenModal } from './Modal/FullscreenModal';

--- a/src/index.scss
+++ b/src/index.scss
@@ -15,6 +15,7 @@
 @import './Icon/Icon.scss';
 @import './Image/Image.scss';
 @import './Media/Media.scss';
+@import './Menu/Menu.scss';
 @import './Modal/Modal.scss';
 @import './Nav/Nav.scss';
 @import './Navbar/Navbar.scss';


### PR DESCRIPTION
Create Menu and menuItem components for use in the paragon library. [Per specs](https://www.figma.com/file/eGmDp94FlqEr4iSqy1Uc1K/Paragon-Design-System?node-id=14061%3A17) The menu component is arrow key as well as tab/escape/return key navigable.
Based on [This WIP](https://github.com/edx/paragon/pull/746/files). Unit tests and pages to include in the paragon documentation are include. Please let me know if there is anything else which goes into contributing to Paragon, which is not outlined on the Readme.