### PR TITLE
DataTable side filter on side in large windows

### DIFF
--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -33,6 +33,35 @@ $data-table-footer-position: center !default;
   -webkit-overflow-scrolling: touch;
 }
 
+.pgn__data-table-layout-wrapper{
+  display: flex;
+  align-items: flex-start;
+  .pgn__data-table-layout-sidebar{
+    border-radius: $border-radius;
+    box-shadow: $data-table-box-shadow;
+    padding: $data-table-padding-small;
+    margin-right: map_get($spacers, 4);
+    flex-grow: 0;
+  }
+
+  .pgn__data-table-side-filters{
+    .pgn__data-table-side-filters-title{
+      margin-bottom: map_get($spacers, 3);
+    }
+    .pgn__data-table-side-filters-status{
+      margin-bottom: map_get($spacers, 2);
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
+  
+
+
+  .pgn__data-table-layout-main{
+    flex-grow: 1;
+  }
+}
+
 .pgn__data-table {
   width: 100%;
 

--- a/src/DataTable/DataTableLayout.jsx
+++ b/src/DataTable/DataTableLayout.jsx
@@ -1,0 +1,37 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import SidebarFilters from './SidebarFilters';
+import DataTableContext from './DataTableContext';
+
+const DataTableLayout = ({
+  className,
+  children,
+}) => {
+  const { setFilter, showFiltersInSidebar } = useContext(DataTableContext);
+
+  return (
+    <div className={classNames('pgn__data-table-layout-wrapper', className)}>
+      {(showFiltersInSidebar && setFilter) && (
+        <div className="pgn__data-table-layout-sidebar">
+          <SidebarFilters />
+        </div>
+      )}
+      <div className="pgn__data-table-layout-main">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+DataTableLayout.defaultProps = {
+  className: null,
+};
+
+DataTableLayout.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};
+
+export default DataTableLayout;

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -608,3 +608,85 @@ a responsive grid of cards.
   <TableFooter />
 </DataTable>
 ```
+
+## Sidebar Filter
+For a more desktop friendly view, you can move filters into a sidebar by providing ``showFiltersInSidebar`` prop, try it out! 
+
+```jsx live
+  <DataTable
+    showFiltersInSidebar
+    isFilterable
+    isSortable
+    defaultColumnValues={{ Filter: TextFilter }}
+    itemCount={5}
+    data={[
+      {
+        name: 'Lil Bub',
+        color: 'brown tabby',
+        famous_for: 'weird tongue',
+      },
+      {
+        name: 'Grumpy Cat',
+        color: 'siamese',
+        famous_for: 'serving moods',
+      },
+      {
+        name: 'Smoothie',
+        color: 'orange tabby',
+        famous_for: 'modeling',
+      },
+      {
+        name: 'Maru',
+        color: 'brown tabby',
+        famous_for: 'being a lovable oaf',
+      },
+      {
+        name: 'Keyboard Cat',
+        color: 'orange tabby',
+        famous_for: 'piano virtuoso',
+      }
+    ]}
+    columns={[
+      {
+        Header: 'Name',
+        accessor: 'name',
+
+      },
+      {
+        Header: 'Famous For',
+        accessor: 'famous_for',
+      },
+      {
+        Header: 'Coat Color',
+        accessor: 'color',
+        Filter: CheckboxFilter,
+        filter: 'includesValue',
+        filterChoices: [{
+          name: 'russian white',
+          number: 1,
+          value: 'russian white',
+        },
+        {
+          name: 'orange tabby',
+          number: 2,
+          value: 'orange tabby',
+        },
+        {
+          name: 'brown tabby',
+          number: 3,
+          value: 'brown tabby',
+        },
+        {
+          name: 'siamese',
+          number: 1,
+          value: 'siamese',
+        }]
+      },
+    ]}
+  >
+    <DataTable.TableControlBar />
+    <DataTable.Table />
+    <DataTable.EmptyTable content="No results found" />
+    <DataTable.TableFooter />
+  </DataTable>
+```

--- a/src/DataTable/SidebarFilters.jsx
+++ b/src/DataTable/SidebarFilters.jsx
@@ -1,0 +1,35 @@
+import React, { useContext, useMemo } from 'react';
+
+import DataTableContext from './DataTableContext';
+import FilterStatus from './FilterStatus';
+
+const SidebarFilters = () => {
+  const { state, columns } = useContext(DataTableContext);
+  const availableFilters = useMemo(() => columns.filter((column) => column.canFilter), [columns]);
+  const filtersApplied = state?.filters && state.filters.length > 0;
+  return (
+    <div className="pgn__data-table-side-filters">
+      <h4 className="pgn__data-table-side-filters-title">Filters</h4>
+      <hr />
+      {availableFilters.map(column => (
+        <div
+          key={column.Header}
+          className="pgn__data-table-side-filters-item"
+        >
+          {column.render('Filter')}
+        </div>
+      ))}
+      {filtersApplied && (
+      <>
+        <FilterStatus
+          className="pgn__data-table-side-filters-status"
+          showFilteredFields={false}
+          variant="tertiary"
+        />
+      </>
+      )}
+    </div>
+  );
+};
+
+export default SidebarFilters;

--- a/src/DataTable/SmartStatus.jsx
+++ b/src/DataTable/SmartStatus.jsx
@@ -8,7 +8,7 @@ const SMART_STATUS_CLASS = 'pgn__smart-status';
 
 const SmartStatus = () => {
   const {
-    state, selectedFlatRows, SelectionStatusComponent, FilterStatusComponent, RowStatusComponent,
+    state, selectedFlatRows, SelectionStatusComponent, FilterStatusComponent, RowStatusComponent, showFiltersInSidebar,
   } = useContext(DataTableContext);
   const numSelectedRows = selectedFlatRows?.length;
   const SelectionStatus = SelectionStatusComponent || SelectionStatusDefault;
@@ -22,7 +22,7 @@ const SmartStatus = () => {
       />
     );
   }
-  if (state?.filters && state.filters.length > 0) {
+  if (state?.filters && state.filters.length > 0 && !showFiltersInSidebar) {
     return (
       <FilterStatus
         className={SMART_STATUS_CLASS}

--- a/src/DataTable/TableControlBar.jsx
+++ b/src/DataTable/TableControlBar.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+
 import SmartStatus from './SmartStatus';
 import DropdownFilters from './DropdownFilters';
 import DataTableContext from './DataTableContext';
@@ -10,12 +11,12 @@ import ActionDisplay from './ActionDisplay';
 const TableControlBar = ({
   className,
 }) => {
-  const { setFilter } = useContext(DataTableContext);
+  const { setFilter, showFiltersInSidebar } = useContext(DataTableContext);
 
   return (
     <div className={classNames('pgn__data-table-status-bar', className)}>
       {/* Using setFilter as a proxy for isFilterable */}
-      {setFilter && (
+      {(setFilter && !showFiltersInSidebar) && (
         <div className="pgn__data-table-actions">
           <div className="pgn__data-table-actions-left">
             <DropdownFilters />
@@ -29,7 +30,7 @@ const TableControlBar = ({
         <div className="pgn__data-table-status-left">
           <SmartStatus />
         </div>
-        {!setFilter && (<ActionDisplay />)}
+        {(!setFilter || (setFilter && showFiltersInSidebar)) && (<ActionDisplay />)}
       </div>
     </div>
   );

--- a/src/DataTable/filters/CheckboxFilter.jsx
+++ b/src/DataTable/filters/CheckboxFilter.jsx
@@ -31,6 +31,7 @@ function CheckboxFilter({
       {filterChoices.map(({ name, number, value }) => (
         <LabelledCheckbox
           id={headerBasedId}
+          key={headerBasedId + name}
           checked={checkedBoxes.includes(value)}
           onChange={() => { changeCheckbox(value); }}
           label={<>{name} {number && <Badge variant="light">{number}</Badge>}</>}

--- a/src/DataTable/filters/LabelledCheckbox.jsx
+++ b/src/DataTable/filters/LabelledCheckbox.jsx
@@ -22,7 +22,7 @@ const LabelledCheckbox = ({
 LabelledCheckbox.propTypes = {
   checked: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
-  label: PropTypes.func.isRequired,
+  label: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
   id: PropTypes.string.isRequired,
 };
 

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useMemo, useReducer } from 'react';
+import React, {
+  useEffect, useMemo, useReducer,
+} from 'react';
 import PropTypes from 'prop-types';
 import { useTable } from 'react-table';
 
@@ -25,6 +27,7 @@ import DataTableContext from './DataTableContext';
 import TableActions from './TableActions';
 import ControlledSelect from './selection/ControlledSelect';
 import ControlledSelectHeader from './selection/ControlledSelectHeader';
+import DataTableLayout from './DataTableLayout';
 
 import selectionsReducer, { initialState as initialSelectionsState } from './selection/data/reducer';
 
@@ -37,6 +40,7 @@ function DataTable({
   initialTableOptions,
   EmptyTableComponent,
   manualSelectColumn,
+  showFiltersInSidebar,
   children,
   ...props
 }) {
@@ -111,22 +115,25 @@ function DataTable({
     bulkActions,
     tableActions,
     controlledTableSelections,
+    showFiltersInSidebar,
     ...selectionProps,
     ...props,
   };
 
   return (
     <DataTableContext.Provider value={enhancedInstance}>
-      <div className="pgn__data-table-wrapper">
-        {children || (
+      <DataTableLayout>
+        <div className="pgn__data-table-wrapper">
+          {children || (
           <>
             <TableControlBar />
             <Table />
             <EmptyTableComponent content="No results found" />
             <TableFooter />
           </>
-        )}
-      </div>
+          )}
+        </div>
+      </DataTableLayout>
     </DataTableContext.Provider>
   );
 }
@@ -153,6 +160,7 @@ DataTable.defaultProps = {
   SelectionStatusComponent: SelectionStatus,
   FilterStatusComponent: FilterStatus,
   RowStatusComponent: RowStatus,
+  showFiltersInSidebar: false,
 };
 
 DataTable.propTypes = {
@@ -257,6 +265,8 @@ DataTable.propTypes = {
   FilterStatusComponent: PropTypes.func,
   /** If children are not provided a table with control bar and footer will be rendered */
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+  /** If true filters will be shown on sidebar instead */
+  showFiltersInSidebar: PropTypes.bool,
 };
 
 DataTable.BulkActions = BulkActions;


### PR DESCRIPTION
### [Closes PAR-270](https://openedx.atlassian.net/browse/PAR-270)

Adds `showFiltersInSidebar` prop to view filters in sidebar.
See examples below:

![Screen Shot 2021-08-31 at 9 44 56 AM](https://user-images.githubusercontent.com/6687387/131514131-e4cc9b55-f69e-4f84-81bd-7273bb339461.png)

Clear filter appears below when a filter is selected:

![Screen Shot 2021-08-31 at 9 46 06 AM](https://user-images.githubusercontent.com/6687387/131514145-ff4813d7-ea81-495e-ae62-91f72952a45a.png)
