### PR TITLE
fix: clean up SelectMenu Scrolling

### DIFF
--- a/src/Menu/Menu.scss
+++ b/src/Menu/Menu.scss
@@ -74,19 +74,19 @@
   border-radius: 0.25em;
   box-shadow: $box-shadow;
   background-color: $white;
-  border-color: transparent;
-  overflow: scroll;
-  min-width: 288px;
-  max-width: 450px;
+  overflow: auto;
   max-height: 264px;
 }
 .pgn__menu-select-popup{
-  max-height: 267px;
+
   color: $btn-tertiary-bg;
 }
 .pgn__menu-select-trigger-btn{
+  max-width: 450px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow:ellipsis;
   background: $white;
-  border: 1px solid #F2F0EF;
   box-sizing: border-box;
   color: $dark;
 

--- a/src/Menu/__snapshots__/SelectMenu.test.jsx.snap
+++ b/src/Menu/__snapshots__/SelectMenu.test.jsx.snap
@@ -4,7 +4,6 @@ exports[`Rendering Beahvior Renders as expected 1`] = `
 <pgn__menu-select
   className="pgn__menu-select"
 >
-  <span />
   <button
     aria-expanded={false}
     aria-haspopup="true"


### PR DESCRIPTION
The SelectMenu had several odd behaviors:
- The trigger button had no max size and would wrap text, causing inconvenience.
- Giving each menuItem a unique random uuid created difficulty because of the birthday paradox. Changed to use refs instead in much cleaner form.
- The popper could shift left/right if the size of the trigger button changed.
- offset sometimes wasn't perfect.

Note: this does not fix the scroll the whole page on center item errors.