### PR TITLE
fix: resolve PropType warning for indeterminate prop in DataTable

### DIFF
--- a/src/DataTable/selection/ControlledSelect.jsx
+++ b/src/DataTable/selection/ControlledSelect.jsx
@@ -1,8 +1,9 @@
-import React, { useContext, useCallback } from 'react';
+import React, { useContext, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import { CheckboxControl } from '../../Form';
 import DataTableContext from '../DataTableContext';
+import useConvertIndeterminateProp from '../utils/useConvertIndeterminateProp';
 
 import {
   deleteSelectedRowAction,
@@ -26,10 +27,13 @@ const ControlledSelect = ({ row }) => {
     [itemCount, row],
   );
 
+  const toggleRowSelectedProps = useMemo(() => row.getToggleRowSelectedProps(), [row.getToggleRowSelectedProps]);
+  const updatedProps = useConvertIndeterminateProp(toggleRowSelectedProps);
+
   return (
     <div className="d-flex align-content-center p-1">
       <CheckboxControl
-        {...row.getToggleRowSelectedProps()}
+        {...updatedProps}
         onChange={toggleSelected}
       />
     </div>

--- a/src/DataTable/utils/getVisibleColumns.jsx
+++ b/src/DataTable/utils/getVisibleColumns.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { CheckboxControl } from '../../Form';
+import useConvertIndeterminateProp from './useConvertIndeterminateProp';
 
 export const selectColumn = {
   id: 'selection',
@@ -10,14 +11,19 @@ export const selectColumn = {
   // Proptypes disabled as these props are passed in separately
   /* eslint-disable-next-line react/prop-types */
   Header: ({ getToggleAllPageRowsSelectedProps, getToggleAllRowsSelectedProps, page }) => {
-    const getToggleRowsSelectedProps = page ? getToggleAllPageRowsSelectedProps : getToggleAllRowsSelectedProps;
-    const toggleRowsSelectedProps = getToggleRowsSelectedProps();
-    toggleRowsSelectedProps.isIndeterminate = toggleRowsSelectedProps.indeterminate;
-    // delete unused ``indeterminate`` prop
-    delete toggleRowsSelectedProps.indeterminate;
+    const toggleRowsSelectedProps = useMemo(
+      () => {
+        // determine if this selection is for an individual page or the entire table
+        const getToggleRowsSelectedProps = page ? getToggleAllPageRowsSelectedProps : getToggleAllRowsSelectedProps;
+        return getToggleRowsSelectedProps();
+      },
+      [getToggleAllPageRowsSelectedProps, getToggleAllRowsSelectedProps, page],
+    );
+    const updatedProps = useConvertIndeterminateProp(toggleRowsSelectedProps);
+
     return (
       <div className="d-flex align-content-center p-1">
-        <CheckboxControl {...toggleRowsSelectedProps} />
+        <CheckboxControl {...updatedProps} />
       </div>
     );
   },
@@ -25,11 +31,16 @@ export const selectColumn = {
   // to the render a checkbox
   // Proptypes disabled as this prop is passed in separately
   /* eslint-disable react/prop-types */
-  Cell: ({ row }) => (
-    <div className="d-flex align-content-center p-1">
-      <CheckboxControl {...row.getToggleRowSelectedProps()} />
-    </div>
-  ),
+  Cell: ({ row }) => {
+    const toggleRowSelectedProps = useMemo(() => row.getToggleRowSelectedProps(), [row.getToggleRowSelectedProps]);
+    const updatedProps = useConvertIndeterminateProp(toggleRowSelectedProps);
+
+    return (
+      <div className="d-flex align-content-center p-1">
+        <CheckboxControl {...updatedProps} />
+      </div>
+    );
+  },
   /* eslint-enable react/prop-types */
   disableSortBy: true,
 };

--- a/src/DataTable/utils/useConvertIndeterminateProp.js
+++ b/src/DataTable/utils/useConvertIndeterminateProp.js
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+
+/**
+ * A React hook to convert ``indeterminate`` prop to ``isIndeterminate``.
+ *
+ * @param {object} props An object containing props.
+ * @returns Updated props object.
+ */
+const useConvertIndeterminateProp = (props) => {
+  const updatedProps = useMemo(
+    () => {
+      const newProps = { ...props };
+      newProps.isIndeterminate = newProps.indeterminate;
+      // delete unused ``indeterminate`` prop
+      delete newProps.indeterminate;
+      return newProps;
+    },
+    [props],
+  );
+  return updatedProps;
+};
+
+export default useConvertIndeterminateProp;

--- a/src/DataTable/utils/useConvertIndeterminateProp.js
+++ b/src/DataTable/utils/useConvertIndeterminateProp.js
@@ -9,11 +9,8 @@ import { useMemo } from 'react';
 const useConvertIndeterminateProp = (props) => {
   const updatedProps = useMemo(
     () => {
-      const newProps = { ...props };
-      newProps.isIndeterminate = newProps.indeterminate;
-      // delete unused ``indeterminate`` prop
-      delete newProps.indeterminate;
-      return newProps;
+      const { indeterminate, ...rest } = props;
+      return { isIndeterminate: indeterminate, ...rest };
     },
     [props],
   );


### PR DESCRIPTION
Resolves the following prop type warning regarding `indeterminate` checkboxes in the `DataTable` component.

![image](https://user-images.githubusercontent.com/2828721/133249310-d83912cf-f796-4721-9dc3-b4bdf744bd8e.png)
