### PR TITLE
feat: change the default icons for the Collapsible element

### DIFF
--- a/src/Collapsible/index.jsx
+++ b/src/Collapsible/index.jsx
@@ -7,12 +7,12 @@ import CollapsibleBody from './CollapsibleBody';
 import CollapsibleTrigger from './CollapsibleTrigger';
 import CollapsibleVisible from './CollapsibleVisible';
 import Icon from '../Icon';
-import { Add, Remove } from '../../icons';
+import { ExpandLess, ExpandMore } from '../../icons';
 
 const styleIcons = {
   basic: {
-    iconWhenClosed: <Icon src={Add} />,
-    iconWhenOpen: <Icon src={Remove} />,
+    iconWhenClosed: <Icon src={ExpandMore} />,
+    iconWhenOpen: <Icon src={ExpandLess} />,
   },
   // card and card-lg use the defaults specified in defaultProps
 };
@@ -66,8 +66,8 @@ Collapsible.propTypes = {
 Collapsible.defaultProps = {
   className: undefined,
   defaultOpen: false,
-  iconWhenClosed: <Icon src={Add} />,
-  iconWhenOpen: <Icon src={Remove} />,
+  iconWhenClosed: <Icon src={ExpandMore} />,
+  iconWhenOpen: <Icon src={ExpandLess} />,
   onClose: undefined,
   onOpen: undefined,
   onToggle: undefined,


### PR DESCRIPTION
Update the default icons on the collapsible from +/- to up-carat/down-carat

<img width="1000" alt="Screen Shot 2021-09-14 at 12 07 22 PM" src="https://user-images.githubusercontent.com/5054596/133293947-f430409e-7d71-4551-a6cc-65a8919ed1da.png">
<img width="1000" alt="Screen Shot 2021-09-14 at 12 07 29 PM" src="https://user-images.githubusercontent.com/5054596/133293949-0c416b96-5312-4ec9-82b0-505272f6f5e2.png">
