### PR TITLE
fix: date-time input fields on blur issue

### DIFF
--- a/src/Form/_Form.scss
+++ b/src/Form/_Form.scss
@@ -231,7 +231,7 @@ $select-icon-padding: .5625rem !default;
 }
 
 .pgn__form-control-decorator-group.has-floating-label {
-  .form-control:not(:focus) {
+  .form-control:not(.has-value) {
     &::placeholder,
     &::-webkit-datetime-edit {
       opacity: 0;


### PR DESCRIPTION
Ticket ID: https://openedx.atlassian.net/browse/TNL-8726
Date/Time Fields were not showing value when blurred out of the field due to opacity set to 0 on blur.
This PR contains a fix that opacity will only be set to 0 when the field does not contain any value.