### PR TITLE
fix: filtercheckbox filterchoices properly renders number 0

### DIFF
--- a/src/DataTable/filters/CheckboxFilter.jsx
+++ b/src/DataTable/filters/CheckboxFilter.jsx
@@ -33,7 +33,7 @@ function CheckboxFilter({
           id={headerBasedId}
           checked={checkedBoxes.includes(value)}
           onChange={() => { changeCheckbox(value); }}
-          label={<>{name} {number && <Badge variant="light">{number}</Badge>}</>}
+          label={<>{name} {number !== undefined && <Badge variant="light">{number}</Badge>}</>}
         />
       ))}
     </Form.Group>


### PR DESCRIPTION
Small conditional change to 0 is rendered properly on filter label.
Before:
![Screen Shot 2021-09-17 at 2 05 05 PM](https://user-images.githubusercontent.com/6687387/133833966-79a66965-1b76-4654-9172-9097fd56a7d8.png)

After: 
![Screen Shot 2021-09-17 at 2 04 24 PM](https://user-images.githubusercontent.com/6687387/133833997-31fb0a89-c243-49d6-ac8e-ea7eb7afe494.png)

