### PR TITLE
fix: update usage stats and add summary tab

### DIFF
--- a/dependent-usage-analyzer/checkout-dependents.sh
+++ b/dependent-usage-analyzer/checkout-dependents.sh
@@ -2,7 +2,11 @@
 mkdir .projects
 (
   cd .projects &&
+  git clone git@github.com:edx/credentials.git --depth 1
+  git clone git@github.com:edx/edx-enterprise.git --depth 1
   git clone git@github.com:edx/edx-platform.git --depth 1
+  git clone git@github.com:edx/edx-ora2.git --depth 1
+  git clone git@github.com:edx/web-certificates.git --depth 1
   git clone git@github.com:edx/frontend-app-account.git --depth 1
   git clone git@github.com:edx/frontend-app-admin-portal.git --depth 1
   git clone git@github.com:edx/frontend-app-authn.git --depth 1
@@ -11,9 +15,11 @@ mkdir .projects
   git clone git@github.com:edx/frontend-app-ecommerce.git --depth 1
   git clone git@github.com:edx/frontend-app-enterprise-public-catalog.git --depth 1
   git clone git@github.com:edx/frontend-app-gradebook.git --depth 1
+  git clone git@github.com:edx/frontend-app-learner-record.git --depth 1
   git clone git@github.com:edx/frontend-app-learner-portal-enterprise.git --depth 1
   git clone git@github.com:edx/frontend-app-learner-portal-programs.git --depth 1
   git clone git@github.com:edx/frontend-app-learning.git --depth 1
+  git clone git@github.com:edx/frontend-app-ora-grading.git --depth 1
   git clone git@github.com:edx/frontend-app-payment.git --depth 1
   git clone git@github.com:edx/frontend-app-profile.git --depth 1
   git clone git@github.com:edx/frontend-app-program-console.git --depth 1

--- a/dependent-usage.json
+++ b/dependent-usage.json
@@ -1,5 +1,238 @@
 [
   {
+    "version": "16.14.2",
+    "name": "edx-credentials",
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/edx/credentials"
+    },
+    "folderName": "credentials",
+    "usages": {
+      "Table": [
+        {
+          "filePath": "credentials/static/components/FoldingTable.jsx",
+          "line": 26,
+          "column": 6,
+          "version": "16.14.2"
+        }
+      ],
+      "Button.Deprecated": [
+        {
+          "filePath": "credentials/static/components/MasqueradeBanner.jsx",
+          "line": 102,
+          "column": 12,
+          "version": "16.14.2"
+        },
+        {
+          "filePath": "credentials/static/components/ProgramRecord.jsx",
+          "line": 277,
+          "column": 14,
+          "version": "16.14.2"
+        },
+        {
+          "filePath": "credentials/static/components/ProgramRecord.jsx",
+          "line": 284,
+          "column": 12,
+          "version": "16.14.2"
+        },
+        {
+          "filePath": "credentials/static/components/ProgramRecord.jsx",
+          "line": 296,
+          "column": 12,
+          "version": "16.14.2"
+        },
+        {
+          "filePath": "credentials/static/components/SendLearnerRecordModal.jsx",
+          "line": 141,
+          "column": 10,
+          "version": "16.14.2"
+        },
+        {
+          "filePath": "credentials/static/components/ShareProgramRecordModal.jsx",
+          "line": 177,
+          "column": 18,
+          "version": "16.14.2"
+        }
+      ],
+      "StatusAlert": [
+        {
+          "filePath": "credentials/static/components/MasqueradeBanner.jsx",
+          "line": 109,
+          "column": 8,
+          "version": "16.14.2"
+        },
+        {
+          "filePath": "credentials/static/components/ProgramRecord.jsx",
+          "line": 305,
+          "column": 10,
+          "version": "16.14.2"
+        },
+        {
+          "filePath": "credentials/static/components/ProgramRecord.jsx",
+          "line": 318,
+          "column": 10,
+          "version": "16.14.2"
+        },
+        {
+          "filePath": "credentials/static/components/ProgramRecord.jsx",
+          "line": 334,
+          "column": 10,
+          "version": "16.14.2"
+        },
+        {
+          "filePath": "credentials/static/components/SendLearnerRecordModal.jsx",
+          "line": 109,
+          "column": 14,
+          "version": "16.14.2"
+        },
+        {
+          "filePath": "credentials/static/components/ShareProgramRecordModal.jsx",
+          "line": 138,
+          "column": 14,
+          "version": "16.14.2"
+        },
+        {
+          "filePath": "credentials/static/components/ShareProgramRecordModal.jsx",
+          "line": 152,
+          "column": 14,
+          "version": "16.14.2"
+        }
+      ],
+      "Icon": [
+        {
+          "filePath": "credentials/static/components/ProgramRecord.jsx",
+          "line": 312,
+          "column": 16,
+          "version": "16.14.2"
+        },
+        {
+          "filePath": "credentials/static/components/ShareProgramRecordModal.jsx",
+          "line": 191,
+          "column": 16,
+          "version": "16.14.2"
+        }
+      ],
+      "Modal": [
+        {
+          "filePath": "credentials/static/components/SendLearnerRecordModal.jsx",
+          "line": 90,
+          "column": 6,
+          "version": "16.14.2"
+        },
+        {
+          "filePath": "credentials/static/components/ShareProgramRecordModal.jsx",
+          "line": 130,
+          "column": 6,
+          "version": "16.14.2"
+        }
+      ],
+      "CheckBoxGroup": [
+        {
+          "filePath": "credentials/static/components/SendLearnerRecordModal.jsx",
+          "line": 123,
+          "column": 12,
+          "version": "16.14.2"
+        }
+      ],
+      "CheckBox": [
+        {
+          "filePath": "credentials/static/components/SendLearnerRecordModal.jsx",
+          "line": 125,
+          "column": 16,
+          "version": "16.14.2"
+        }
+      ],
+      "InputText": [
+        {
+          "filePath": "credentials/static/components/ShareProgramRecordModal.jsx",
+          "line": 165,
+          "column": 18,
+          "version": "16.14.2"
+        }
+      ]
+    }
+  },
+  {
+    "version": "12.3.0",
+    "name": "edx-enterprise",
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/edx/edx-enterprise"
+    },
+    "folderName": "edx-enterprise",
+    "usages": {}
+  },
+  {
+    "version": "12.8.0",
+    "name": "edx-ora2",
+    "repository": "https://github.com/edx/edx-ora2.git",
+    "folderName": "edx-ora2",
+    "usages": {
+      "Alert": [
+        {
+          "filePath": "openassessment/xblock/static/js/src/lms/components/WaitingStepContent.jsx",
+          "line": 40,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "openassessment/xblock/static/js/src/lms/containers/WaitingStepDetailsContainer.jsx",
+          "line": 64,
+          "column": 10,
+          "version": "12.8.0"
+        }
+      ],
+      "DataTable": [
+        {
+          "filePath": "openassessment/xblock/static/js/src/lms/components/WaitingStepList.jsx",
+          "line": 15,
+          "column": 4,
+          "version": "12.8.0"
+        }
+      ],
+      "DataTable.Table": [
+        {
+          "filePath": "openassessment/xblock/static/js/src/lms/components/WaitingStepList.jsx",
+          "line": 52,
+          "column": 6,
+          "version": "12.8.0"
+        }
+      ],
+      "DataTable.TableFooter": [
+        {
+          "filePath": "openassessment/xblock/static/js/src/lms/components/WaitingStepList.jsx",
+          "line": 53,
+          "column": 6,
+          "version": "12.8.0"
+        }
+      ],
+      "Container": [
+        {
+          "filePath": "openassessment/xblock/static/js/src/lms/containers/WaitingStepDetailsContainer.jsx",
+          "line": 46,
+          "column": 10,
+          "version": "12.8.0"
+        }
+      ],
+      "Row": [
+        {
+          "filePath": "openassessment/xblock/static/js/src/lms/containers/WaitingStepDetailsContainer.jsx",
+          "line": 47,
+          "column": 12,
+          "version": "12.8.0"
+        }
+      ],
+      "Spinner": [
+        {
+          "filePath": "openassessment/xblock/static/js/src/lms/containers/WaitingStepDetailsContainer.jsx",
+          "line": 48,
+          "column": 14,
+          "version": "12.8.0"
+        }
+      ]
+    }
+  },
+  {
     "version": "2.6.4",
     "name": "edx",
     "folderName": "edx-platform",
@@ -251,7 +484,7 @@
     }
   },
   {
-    "version": "16.0.1",
+    "version": "16.1.0",
     "name": "@edx/frontend-app-account",
     "repository": {
       "type": "git",
@@ -259,164 +492,504 @@
     },
     "folderName": "frontend-app-account",
     "usages": {
+      "Alert": [
+        {
+          "filePath": "src/account-settings/AccountSettingsPage.jsx",
+          "line": 215,
+          "column": 8,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/AccountSettingsPage.jsx",
+          "line": 237,
+          "column": 8,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/AccountSettingsPage.jsx",
+          "line": 325,
+          "column": 4,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/name-change/NameChange.jsx",
+          "line": 106,
+          "column": 8,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/OneTimeDismissibleAlert.jsx",
+          "line": 15,
+          "column": 4,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/id-verification/ImageFileUpload.jsx",
+          "line": 46,
+          "column": 6,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/id-verification/panels/ReviewRequirementsPanel.jsx",
+          "line": 50,
+          "column": 8,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/id-verification/panels/SummaryPanel.jsx",
+          "line": 166,
+          "column": 8,
+          "version": "16.1.0"
+        }
+      ],
       "Hyperlink": [
         {
           "filePath": "src/account-settings/AccountSettingsPage.jsx",
-          "line": 194,
+          "line": 245,
           "column": 16,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/BetaLanguageBanner.jsx",
           "line": 74,
           "column": 12,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/coaching/CoachingConsent.jsx",
           "line": 31,
           "column": 4,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/coaching/CoachingConsentForm.jsx",
           "line": 75,
           "column": 10,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/delete-account/BeforeProceedingBanner.jsx",
           "line": 29,
           "column": 12,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/delete-account/DeleteAccount.jsx",
           "line": 95,
           "column": 10,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/delete-account/PrintingInstructions.jsx",
           "line": 10,
           "column": 4,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/demographics/DemographicsSection.jsx",
           "line": 170,
           "column": 10,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/reset-password/ConfirmationAlert.jsx",
           "line": 14,
           "column": 4,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/third-party-auth/ThirdPartyAuth.jsx",
           "line": 25,
           "column": 8,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/panels/GetNameIdPanel.jsx",
           "line": 71,
           "column": 14,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/panels/ReviewRequirementsPanel.jsx",
           "line": 59,
           "column": 16,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/panels/SummaryPanel.jsx",
-          "line": 55,
+          "line": 57,
           "column": 14,
-          "version": "16.0.1"
+          "version": "16.1.0"
         }
       ],
       "Button": [
         {
+          "filePath": "src/account-settings/AccountSettingsPage.jsx",
+          "line": 310,
+          "column": 16,
+          "version": "16.1.0"
+        },
+        {
           "filePath": "src/account-settings/BetaLanguageBanner.jsx",
           "line": 68,
           "column": 12,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/coaching/CoachingConsentForm.jsx",
           "line": 70,
           "column": 10,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/delete-account/ConfirmationModal.jsx",
           "line": 122,
           "column": 10,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/delete-account/DeleteAccount.jsx",
           "line": 100,
           "column": 10,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/EditableField.jsx",
-          "line": 64,
+          "line": 66,
           "column": 13,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/EditableField.jsx",
-          "line": 145,
-          "column": 14,
-          "version": "16.0.1"
-        },
-        {
-          "filePath": "src/account-settings/EditableField.jsx",
-          "line": 159,
+          "line": 148,
           "column": 16,
-          "version": "16.0.1"
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/EditableField.jsx",
+          "line": 164,
+          "column": 16,
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/EmailField.jsx",
           "line": 91,
           "column": 13,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/EmailField.jsx",
           "line": 145,
           "column": 14,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/EmailField.jsx",
           "line": 159,
           "column": 16,
-          "version": "16.0.1"
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/name-change/NameChange.jsx",
+          "line": 137,
+          "column": 8,
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/CollapsibleImageHelp.jsx",
           "line": 52,
           "column": 12,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/IdVerificationPage.jsx",
-          "line": 70,
+          "line": 73,
           "column": 12,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/panels/SummaryPanel.jsx",
-          "line": 92,
+          "line": 107,
           "column": 6,
-          "version": "16.0.1"
+          "version": "16.1.0"
+        }
+      ],
+      "Alert.Heading": [
+        {
+          "filePath": "src/account-settings/AccountSettingsPage.jsx",
+          "line": 329,
+          "column": 6,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/OneTimeDismissibleAlert.jsx",
+          "line": 22,
+          "column": 6,
+          "version": "16.1.0"
+        }
+      ],
+      "Icon": [
+        {
+          "filePath": "src/account-settings/AccountSettingsPage.jsx",
+          "line": 356,
+          "column": 16,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/AccountSettingsPage.jsx",
+          "line": 358,
+          "column": 16,
+          "version": "16.1.0"
+        }
+      ],
+      "Form.Checkbox": [
+        {
+          "filePath": "src/account-settings/certificate-preference/CertificatePreference.jsx",
+          "line": 95,
+          "column": 6,
+          "version": "16.1.0"
+        }
+      ],
+      "ModalDialog": [
+        {
+          "filePath": "src/account-settings/certificate-preference/CertificatePreference.jsx",
+          "line": 99,
+          "column": 6,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/name-change/NameChange.jsx",
+          "line": 156,
+          "column": 4,
+          "version": "16.1.0"
+        }
+      ],
+      "Form": [
+        {
+          "filePath": "src/account-settings/certificate-preference/CertificatePreference.jsx",
+          "line": 107,
+          "column": 8,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/name-change/NameChange.jsx",
+          "line": 163,
+          "column": 6,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/id-verification/panels/GetNameIdPanel.jsx",
+          "line": 100,
+          "column": 6,
+          "version": "16.1.0"
+        }
+      ],
+      "ModalDialog.Header": [
+        {
+          "filePath": "src/account-settings/certificate-preference/CertificatePreference.jsx",
+          "line": 108,
+          "column": 10,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/name-change/NameChange.jsx",
+          "line": 164,
+          "column": 8,
+          "version": "16.1.0"
+        }
+      ],
+      "ModalDialog.Title": [
+        {
+          "filePath": "src/account-settings/certificate-preference/CertificatePreference.jsx",
+          "line": 109,
+          "column": 12,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/name-change/NameChange.jsx",
+          "line": 165,
+          "column": 10,
+          "version": "16.1.0"
+        }
+      ],
+      "ModalDialog.Body": [
+        {
+          "filePath": "src/account-settings/certificate-preference/CertificatePreference.jsx",
+          "line": 114,
+          "column": 10,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/name-change/NameChange.jsx",
+          "line": 170,
+          "column": 8,
+          "version": "16.1.0"
+        }
+      ],
+      "Form.Group": [
+        {
+          "filePath": "src/account-settings/certificate-preference/CertificatePreference.jsx",
+          "line": 115,
+          "column": 12,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/name-change/NameChange.jsx",
+          "line": 118,
+          "column": 6,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/id-verification/Camera.jsx",
+          "line": 286,
+          "column": 8,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/id-verification/panels/ChooseModePanel.jsx",
+          "line": 35,
+          "column": 8,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/id-verification/panels/GetNameIdPanel.jsx",
+          "line": 101,
+          "column": 8,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/id-verification/panels/GetNameIdPanel.jsx",
+          "line": 133,
+          "column": 8,
+          "version": "16.1.0"
+        }
+      ],
+      "Form.Label": [
+        {
+          "filePath": "src/account-settings/certificate-preference/CertificatePreference.jsx",
+          "line": 116,
+          "column": 14,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/name-change/NameChange.jsx",
+          "line": 119,
+          "column": 8,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/id-verification/panels/GetNameIdPanel.jsx",
+          "line": 102,
+          "column": 10,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/id-verification/panels/GetNameIdPanel.jsx",
+          "line": 134,
+          "column": 10,
+          "version": "16.1.0"
+        }
+      ],
+      "Form.RadioSet": [
+        {
+          "filePath": "src/account-settings/certificate-preference/CertificatePreference.jsx",
+          "line": 119,
+          "column": 14,
+          "version": "16.1.0"
+        }
+      ],
+      "Form.Radio": [
+        {
+          "filePath": "src/account-settings/certificate-preference/CertificatePreference.jsx",
+          "line": 124,
+          "column": 16,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/certificate-preference/CertificatePreference.jsx",
+          "line": 128,
+          "column": 16,
+          "version": "16.1.0"
+        }
+      ],
+      "ModalDialog.Footer": [
+        {
+          "filePath": "src/account-settings/certificate-preference/CertificatePreference.jsx",
+          "line": 136,
+          "column": 10,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/name-change/NameChange.jsx",
+          "line": 174,
+          "column": 8,
+          "version": "16.1.0"
+        }
+      ],
+      "ActionRow": [
+        {
+          "filePath": "src/account-settings/certificate-preference/CertificatePreference.jsx",
+          "line": 137,
+          "column": 12,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/name-change/NameChange.jsx",
+          "line": 175,
+          "column": 10,
+          "version": "16.1.0"
+        }
+      ],
+      "ModalDialog.CloseButton": [
+        {
+          "filePath": "src/account-settings/certificate-preference/CertificatePreference.jsx",
+          "line": 138,
+          "column": 14,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/name-change/NameChange.jsx",
+          "line": 176,
+          "column": 12,
+          "version": "16.1.0"
+        }
+      ],
+      "StatefulButton": [
+        {
+          "filePath": "src/account-settings/certificate-preference/CertificatePreference.jsx",
+          "line": 141,
+          "column": 14,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/EditableField.jsx",
+          "line": 129,
+          "column": 16,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/EmailField.jsx",
+          "line": 126,
+          "column": 14,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/name-change/NameChange.jsx",
+          "line": 144,
+          "column": 6,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/reset-password/ResetPassword.jsx",
+          "line": 24,
+          "column": 8,
+          "version": "16.1.0"
+        },
+        {
+          "filePath": "src/account-settings/third-party-auth/ThirdPartyAuth.jsx",
+          "line": 62,
+          "column": 8,
+          "version": "16.1.0"
         }
       ],
       "Input": [
@@ -424,55 +997,55 @@
           "filePath": "src/account-settings/coaching/CoachingConsentForm.jsx",
           "line": 43,
           "column": 10,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/coaching/CoachingConsentForm.jsx",
           "line": 56,
           "column": 10,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/coaching/CoachingToggle.jsx",
           "line": 47,
           "column": 6,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/delete-account/ConfirmationModal.jsx",
           "line": 111,
           "column": 14,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/demographics/DemographicsSection.jsx",
           "line": 202,
           "column": 16,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/demographics/DemographicsSection.jsx",
           "line": 279,
           "column": 16,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/EditableField.jsx",
-          "line": 113,
-          "column": 14,
-          "version": "16.0.1"
+          "line": 116,
+          "column": 16,
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/EmailField.jsx",
           "line": 116,
           "column": 14,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/panels/SummaryPanel.jsx",
-          "line": 212,
+          "line": 227,
           "column": 10,
-          "version": "16.0.1"
+          "version": "16.1.0"
         }
       ],
       "ValidationFormGroup": [
@@ -480,25 +1053,25 @@
           "filePath": "src/account-settings/coaching/CoachingToggle.jsx",
           "line": 40,
           "column": 4,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/delete-account/ConfirmationModal.jsx",
           "line": 103,
           "column": 12,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/EditableField.jsx",
-          "line": 106,
-          "column": 12,
-          "version": "16.0.1"
+          "line": 109,
+          "column": 14,
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/EmailField.jsx",
           "line": 109,
           "column": 12,
-          "version": "16.0.1"
+          "version": "16.1.0"
         }
       ],
       "Modal": [
@@ -506,19 +1079,19 @@
           "filePath": "src/account-settings/delete-account/ConfirmationModal.jsx",
           "line": 77,
           "column": 6,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/account-settings/delete-account/SuccessModal.jsx",
           "line": 11,
           "column": 4,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/IdVerificationPage.jsx",
-          "line": 76,
+          "line": 79,
           "column": 8,
-          "version": "16.0.1"
+          "version": "16.1.0"
         }
       ],
       "CheckBox": [
@@ -526,33 +1099,21 @@
           "filePath": "src/account-settings/demographics/Checkboxes.jsx",
           "line": 43,
           "column": 8,
-          "version": "16.0.1"
+          "version": "16.1.0"
         }
       ],
-      "StatefulButton": [
+      "Form.Control": [
         {
-          "filePath": "src/account-settings/EditableField.jsx",
-          "line": 126,
-          "column": 14,
-          "version": "16.0.1"
-        },
-        {
-          "filePath": "src/account-settings/EmailField.jsx",
-          "line": 126,
-          "column": 14,
-          "version": "16.0.1"
-        },
-        {
-          "filePath": "src/account-settings/reset-password/ResetPassword.jsx",
-          "line": 24,
+          "filePath": "src/account-settings/name-change/NameChange.jsx",
+          "line": 122,
           "column": 8,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
-          "filePath": "src/account-settings/third-party-auth/ThirdPartyAuth.jsx",
-          "line": 62,
-          "column": 8,
-          "version": "16.0.1"
+          "filePath": "src/id-verification/panels/GetNameIdPanel.jsx",
+          "line": 137,
+          "column": 10,
+          "version": "16.1.0"
         }
       ],
       "TransitionReplace": [
@@ -560,33 +1121,7 @@
           "filePath": "src/account-settings/SwitchContent.jsx",
           "line": 44,
           "column": 4,
-          "version": "16.0.1"
-        }
-      ],
-      "Form.Group": [
-        {
-          "filePath": "src/id-verification/Camera.jsx",
-          "line": 286,
-          "column": 8,
-          "version": "16.0.1"
-        },
-        {
-          "filePath": "src/id-verification/panels/ChooseModePanel.jsx",
-          "line": 35,
-          "column": 8,
-          "version": "16.0.1"
-        },
-        {
-          "filePath": "src/id-verification/panels/GetNameIdPanel.jsx",
-          "line": 101,
-          "column": 8,
-          "version": "16.0.1"
-        },
-        {
-          "filePath": "src/id-verification/panels/GetNameIdPanel.jsx",
-          "line": 133,
-          "column": 8,
-          "version": "16.0.1"
+          "version": "16.1.0"
         }
       ],
       "Form.Check": [
@@ -594,31 +1129,31 @@
           "filePath": "src/id-verification/Camera.jsx",
           "line": 287,
           "column": 10,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/panels/ChooseModePanel.jsx",
           "line": 36,
           "column": 10,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/panels/ChooseModePanel.jsx",
           "line": 44,
           "column": 10,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/panels/GetNameIdPanel.jsx",
           "line": 106,
           "column": 12,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/panels/GetNameIdPanel.jsx",
           "line": 120,
           "column": 12,
-          "version": "16.0.1"
+          "version": "16.1.0"
         }
       ],
       "Spinner": [
@@ -626,13 +1161,13 @@
           "filePath": "src/id-verification/Camera.jsx",
           "line": 296,
           "column": 53,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/panels/SummaryPanel.jsx",
-          "line": 241,
+          "line": 256,
           "column": 23,
-          "version": "16.0.1"
+          "version": "16.1.0"
         }
       ],
       "Form.Text": [
@@ -640,7 +1175,7 @@
           "filePath": "src/id-verification/Camera.jsx",
           "line": 297,
           "column": 10,
-          "version": "16.0.1"
+          "version": "16.1.0"
         }
       ],
       "Collapsible": [
@@ -648,73 +1183,31 @@
           "filePath": "src/id-verification/CameraHelp.jsx",
           "line": 17,
           "column": 8,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/CameraHelp.jsx",
           "line": 28,
           "column": 6,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/CameraHelp.jsx",
           "line": 38,
           "column": 6,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/CameraHelpWithUpload.jsx",
           "line": 28,
           "column": 6,
-          "version": "16.0.1"
+          "version": "16.1.0"
         },
         {
           "filePath": "src/id-verification/CollapsibleImageHelp.jsx",
           "line": 28,
           "column": 6,
-          "version": "16.0.1"
-        }
-      ],
-      "Alert": [
-        {
-          "filePath": "src/id-verification/ImageFileUpload.jsx",
-          "line": 46,
-          "column": 6,
-          "version": "16.0.1"
-        },
-        {
-          "filePath": "src/id-verification/panels/ReviewRequirementsPanel.jsx",
-          "line": 50,
-          "column": 8,
-          "version": "16.0.1"
-        },
-        {
-          "filePath": "src/id-verification/panels/SummaryPanel.jsx",
-          "line": 151,
-          "column": 8,
-          "version": "16.0.1"
-        }
-      ],
-      "Form": [
-        {
-          "filePath": "src/id-verification/panels/GetNameIdPanel.jsx",
-          "line": 100,
-          "column": 6,
-          "version": "16.0.1"
-        }
-      ],
-      "Form.Label": [
-        {
-          "filePath": "src/id-verification/panels/GetNameIdPanel.jsx",
-          "line": 102,
-          "column": 10,
-          "version": "16.0.1"
-        },
-        {
-          "filePath": "src/id-verification/panels/GetNameIdPanel.jsx",
-          "line": 134,
-          "column": 10,
-          "version": "16.0.1"
+          "version": "16.1.0"
         }
       ],
       "Form.Row": [
@@ -722,29 +1215,21 @@
           "filePath": "src/id-verification/panels/GetNameIdPanel.jsx",
           "line": 105,
           "column": 10,
-          "version": "16.0.1"
-        }
-      ],
-      "Form.Control": [
-        {
-          "filePath": "src/id-verification/panels/GetNameIdPanel.jsx",
-          "line": 137,
-          "column": 10,
-          "version": "16.0.1"
+          "version": "16.1.0"
         }
       ],
       "Alert.Link": [
         {
           "filePath": "src/id-verification/panels/SummaryPanel.jsx",
-          "line": 133,
+          "line": 148,
           "column": 12,
-          "version": "16.0.1"
+          "version": "16.1.0"
         }
       ]
     }
   },
   {
-    "version": "15.2.2",
+    "version": "16.8.0",
     "name": "frontend-app-admin-portal",
     "repository": "https://github.com/edx/frontend-app-admin-portal",
     "folderName": "frontend-app-admin-portal",
@@ -752,231 +1237,237 @@
       "Button": [
         {
           "filePath": "src/components/ActionButtonWithModal/index.jsx",
-          "line": 14,
+          "line": 15,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx",
-          "line": 56,
+          "line": 58,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx",
-          "line": 65,
+          "line": 67,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx",
-          "line": 73,
+          "line": 75,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx",
-          "line": 83,
+          "line": 85,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.jsx",
           "line": 36,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.jsx",
           "line": 133,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/ReviewList.jsx",
           "line": 17,
           "column": 11,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/ReviewList.jsx",
           "line": 20,
           "column": 9,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/ReviewList.jsx",
           "line": 55,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/table/BaseSelectionStatus.jsx",
-          "line": 30,
+          "line": 27,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/table/BaseSelectionStatus.jsx",
-          "line": 39,
+          "line": 36,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeAssignmentModal/index.jsx",
-          "line": 409,
+          "line": 412,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeManagement/index.jsx",
           "line": 274,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeReminderModal/index.jsx",
-          "line": 221,
+          "line": 224,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeRevokeModal/index.jsx",
-          "line": 231,
+          "line": 242,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeSearchResults/CodeSearchResultsHeading.jsx",
           "line": 13,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CouponDetails/ActionButton.jsx",
           "line": 80,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CouponDetails/CouponBulkActions.jsx",
           "line": 55,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CouponDetails/index.jsx",
           "line": 618,
           "column": 26,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CouponDetails/index.jsx",
           "line": 633,
           "column": 26,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CouponDetails/index.jsx",
           "line": 664,
           "column": 28,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/DownloadCsvButton/index.jsx",
           "line": 20,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/FileInput/index.jsx",
           "line": 131,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/InviteLearnersModal/index.jsx",
-          "line": 186,
+          "line": 189,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LicenseRemindModal/index.jsx",
-          "line": 179,
+          "line": 182,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LicenseRevokeModal/index.jsx",
-          "line": 161,
+          "line": 163,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/NumberCard/index.jsx",
           "line": 206,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 383,
+          "line": 384,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/RequestCodesPage/RequestCodesForm.jsx",
           "line": 118,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 337,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderDataForm.jsx",
           "line": 187,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SidebarToggle/index.jsx",
           "line": 18,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/subscriptions/buttons/ContactCustomerSupportButton.jsx",
+          "line": 8,
+          "column": 2,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/SubscriptionCard.jsx",
           "line": 50,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/SubscriptionDetails.jsx",
-          "line": 30,
+          "line": 38,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SupportPage/SupportForm.jsx",
           "line": 114,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/TemplateSourceFields/index.jsx",
           "line": 127,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/TemplateSourceFields/index.jsx",
           "line": 153,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Form.Group": [
@@ -984,43 +1475,49 @@
           "filePath": "src/components/Admin/AdminSearchForm.jsx",
           "line": 58,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/Admin/AdminSearchForm.jsx",
           "line": 79,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CouponDetails/CouponBulkActions.jsx",
           "line": 33,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CouponDetails/CouponFilters.jsx",
           "line": 9,
           "column": 2,
-          "version": "15.2.2"
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/MultipleFileInputField/MultipleFileInputField.jsx",
+          "line": 58,
+          "column": 4,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReduxFormSelect/index.jsx",
           "line": 10,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/RenderField/index.jsx",
           "line": 19,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/TextAreaAutoSize/index.jsx",
           "line": 17,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Form.Label": [
@@ -1028,37 +1525,49 @@
           "filePath": "src/components/Admin/AdminSearchForm.jsx",
           "line": 59,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/Admin/AdminSearchForm.jsx",
           "line": 80,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/Admin/AdminSearchForm.jsx",
           "line": 111,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/MultipleFileInputField/MultipleFileInputField.jsx",
+          "line": 59,
+          "column": 6,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/MultipleFileInputField/MultipleFileInputField.jsx",
+          "line": 64,
+          "column": 6,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReduxFormSelect/index.jsx",
           "line": 11,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/RenderField/index.jsx",
           "line": 20,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/TextAreaAutoSize/index.jsx",
           "line": 18,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Form.Control": [
@@ -1066,37 +1575,43 @@
           "filePath": "src/components/Admin/AdminSearchForm.jsx",
           "line": 60,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/Admin/AdminSearchForm.jsx",
           "line": 88,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CouponDetails/CouponBulkActions.jsx",
           "line": 34,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CouponDetails/CouponFilters.jsx",
           "line": 10,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/MultipleFileInputField/MultipleFileInputField.jsx",
+          "line": 76,
+          "column": 6,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/RenderField/index.jsx",
           "line": 21,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/TextAreaAutoSize/index.jsx",
           "line": 19,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Icon": [
@@ -1104,479 +1619,479 @@
           "filePath": "src/components/Admin/index.jsx",
           "line": 227,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/Admin/index.jsx",
           "line": 244,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeAssignmentModal/index.jsx",
-          "line": 416,
+          "line": 419,
           "column": 62,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeManagement/index.jsx",
           "line": 281,
           "column": 20,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeManagement/index.jsx",
           "line": 290,
           "column": 20,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeModal/ModalError.jsx",
           "line": 14,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeReminderModal/index.jsx",
-          "line": 228,
+          "line": 231,
           "column": 55,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeRevokeModal/index.jsx",
-          "line": 238,
+          "line": 249,
           "column": 62,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeSearchResults/CodeSearchResultsHeading.jsx",
           "line": 18,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeSearchResults/CodeSearchResultsTable.jsx",
           "line": 116,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/Coupon/index.jsx",
           "line": 91,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/Coupon/index.jsx",
           "line": 100,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CouponDetails/index.jsx",
           "line": 360,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/DownloadCsvButton/index.jsx",
           "line": 27,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/FileInput/index.jsx",
           "line": 141,
           "column": 18,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/InviteLearnersModal/index.jsx",
-          "line": 193,
+          "line": 196,
           "column": 31,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LicenseRemindModal/index.jsx",
-          "line": 186,
+          "line": 189,
           "column": 31,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LicenseRevokeModal/index.jsx",
-          "line": 168,
+          "line": 170,
           "column": 29,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx",
           "line": 228,
           "column": 25,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx",
           "line": 229,
           "column": 25,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx",
           "line": 230,
           "column": 26,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx",
           "line": 231,
           "column": 23,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx",
           "line": 230,
           "column": 25,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx",
           "line": 231,
           "column": 25,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx",
           "line": 232,
           "column": 26,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx",
           "line": 233,
           "column": 23,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CornerstoneIntegrationConfigForm.jsx",
           "line": 230,
           "column": 23,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CornerstoneIntegrationConfigForm.jsx",
           "line": 231,
           "column": 23,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CornerstoneIntegrationConfigForm.jsx",
           "line": 232,
           "column": 24,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CornerstoneIntegrationConfigForm.jsx",
           "line": 233,
           "column": 21,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 330,
           "column": 23,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 331,
           "column": 23,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 332,
           "column": 24,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 333,
           "column": 21,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 281,
           "column": 25,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 282,
           "column": 25,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 283,
           "column": 26,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 284,
           "column": 23,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 305,
           "column": 25,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 306,
           "column": 25,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 307,
           "column": 26,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 308,
           "column": 23,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/NumberCard/index.jsx",
           "line": 159,
           "column": 15,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/NumberCard/index.jsx",
           "line": 190,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/NumberCard/index.jsx",
           "line": 220,
           "column": 20,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/index.jsx",
           "line": 138,
           "column": 22,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 372,
-          "column": 25,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
           "line": 373,
           "column": 25,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
           "line": 374,
-          "column": 26,
-          "version": "15.2.2"
+          "column": 25,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
           "line": 375,
-          "column": 23,
-          "version": "15.2.2"
+          "column": 26,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 387,
+          "line": 376,
+          "column": 23,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
+          "line": 388,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/RequestCodesPage/RequestCodesForm.jsx",
           "line": 124,
           "column": 33,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/index.jsx",
           "line": 170,
           "column": 22,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 325,
           "column": 25,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 326,
           "column": 25,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 327,
           "column": 26,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 328,
           "column": 23,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 342,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderDataForm.jsx",
           "line": 174,
           "column": 27,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderDataForm.jsx",
           "line": 175,
           "column": 27,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderDataForm.jsx",
           "line": 176,
           "column": 28,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderDataForm.jsx",
           "line": 177,
           "column": 25,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderDataForm.jsx",
           "line": 191,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SaveTemplateButton/index.jsx",
-          "line": 146,
+          "line": 152,
           "column": 19,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SaveTemplateButton/index.jsx",
-          "line": 147,
+          "line": 153,
           "column": 20,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/StatusAlert/index.jsx",
           "line": 31,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/licenses/LicenseManagementTabContentTable.jsx",
           "line": 146,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/licenses/LicenseManagementTabContentTable.jsx",
           "line": 192,
           "column": 20,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SupportPage/SupportForm.jsx",
           "line": 120,
           "column": 33,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "DataTable": [
         {
           "filePath": "src/components/BulkEnrollmentPage/CourseSearchResults.jsx",
-          "line": 117,
-          "column": 6,
-          "version": "15.2.2"
+          "line": 118,
+          "column": 8,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/AddLearnersStep.jsx",
-          "line": 126,
-          "column": 6,
-          "version": "15.2.2"
+          "line": 130,
+          "column": 8,
+          "version": "16.8.0"
         }
       ],
       "DataTable.TableControlBar": [
         {
           "filePath": "src/components/BulkEnrollmentPage/CourseSearchResults.jsx",
-          "line": 129,
-          "column": 8,
-          "version": "15.2.2"
+          "line": 130,
+          "column": 10,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/AddLearnersStep.jsx",
-          "line": 144,
-          "column": 12,
-          "version": "15.2.2"
+          "line": 149,
+          "column": 14,
+          "version": "16.8.0"
         }
       ],
       "DataTable.Table": [
         {
           "filePath": "src/components/BulkEnrollmentPage/CourseSearchResults.jsx",
-          "line": 130,
-          "column": 8,
-          "version": "15.2.2"
+          "line": 131,
+          "column": 10,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/AddLearnersStep.jsx",
-          "line": 145,
-          "column": 12,
-          "version": "15.2.2"
+          "line": 150,
+          "column": 14,
+          "version": "16.8.0"
         }
       ],
       "DataTable.TableFooter": [
         {
           "filePath": "src/components/BulkEnrollmentPage/CourseSearchResults.jsx",
-          "line": 131,
-          "column": 8,
-          "version": "15.2.2"
+          "line": 132,
+          "column": 10,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/AddLearnersStep.jsx",
-          "line": 146,
-          "column": 12,
-          "version": "15.2.2"
+          "line": 151,
+          "column": 14,
+          "version": "16.8.0"
         }
       ],
       "DataTable.RowStatus": [
         {
           "filePath": "src/components/BulkEnrollmentPage/CourseSearchResults.jsx",
-          "line": 132,
-          "column": 10,
-          "version": "15.2.2"
+          "line": 133,
+          "column": 12,
+          "version": "16.8.0"
         }
       ],
       "Container": [
@@ -1584,87 +2099,137 @@
           "filePath": "src/components/BulkEnrollmentPage/index.jsx",
           "line": 22,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx",
-          "line": 33,
-          "column": 8,
-          "version": "15.2.2"
+          "line": 34,
+          "column": 10,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx",
-          "line": 53,
+          "line": 55,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/SubscriptionManagementPage.jsx",
           "line": 22,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/UserActivationPage/index.jsx",
           "line": 61,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
+        }
+      ],
+      "DataTable.FilterStatus": [
+        {
+          "filePath": "src/components/BulkEnrollmentPage/stepper/AddLearnersStep.jsx",
+          "line": 36,
+          "column": 27,
+          "version": "16.8.0"
         }
       ],
       "Alert": [
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/AddLearnersStep.jsx",
-          "line": 125,
+          "line": 128,
           "column": 17,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/ReviewList.jsx",
           "line": 53,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeModal/ModalError.jsx",
           "line": 11,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/ErrorPage/index.jsx",
+          "line": 27,
+          "column": 10,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/FeatureAnnouncementBanner/index.jsx",
-          "line": 42,
+          "line": 44,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/InviteLearnersModal/index.jsx",
+          "line": 157,
+          "column": 8,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/LicenseRemindModal/index.jsx",
+          "line": 147,
+          "column": 8,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LicenseRevokeModal/index.jsx",
-          "line": 92,
+          "line": 93,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/LicenseRevokeModal/index.jsx",
+          "line": 130,
+          "column": 8,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx",
+          "line": 110,
+          "column": 4,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/subscriptions/licenses/LicenseAllocationBanner.jsx",
+          "line": 16,
+          "column": 4,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/licenses/LicenseManagementTabContentTable.jsx",
           "line": 141,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/licenses/LicenseManagementTabContentTable.jsx",
           "line": 159,
           "column": 18,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/licenses/LicenseManagementTabContentTable.jsx",
           "line": 191,
           "column": 18,
-          "version": "15.2.2"
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/subscriptions/SubscriptionData.jsx",
+          "line": 36,
+          "column": 4,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/UserActivationPage/index.jsx",
           "line": 64,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Stepper": [
@@ -1672,7 +2237,7 @@
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx",
           "line": 30,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Stepper.Header": [
@@ -1680,47 +2245,55 @@
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx",
           "line": 31,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
+        }
+      ],
+      "Scrollable": [
+        {
+          "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx",
+          "line": 33,
+          "column": 8,
+          "version": "16.8.0"
         }
       ],
       "Stepper.Step": [
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx",
-          "line": 34,
-          "column": 10,
-          "version": "15.2.2"
+          "line": 35,
+          "column": 12,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx",
-          "line": 42,
-          "column": 10,
-          "version": "15.2.2"
+          "line": 43,
+          "column": 12,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx",
-          "line": 49,
-          "column": 10,
-          "version": "15.2.2"
+          "line": 50,
+          "column": 12,
+          "version": "16.8.0"
         }
       ],
       "Stepper.ActionRow": [
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx",
-          "line": 54,
+          "line": 56,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx",
-          "line": 64,
+          "line": 66,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx",
-          "line": 82,
+          "line": 84,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "AlertModal": [
@@ -1728,7 +2301,7 @@
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.jsx",
           "line": 30,
           "column": 2,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "ActionRow": [
@@ -1736,7 +2309,19 @@
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.jsx",
           "line": 35,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/subscriptions/expiration/SubscriptionExpiredModal.jsx",
+          "line": 36,
+          "column": 8,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx",
+          "line": 66,
+          "column": 8,
+          "version": "16.8.0"
         }
       ],
       "MailtoLink": [
@@ -1744,49 +2329,31 @@
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.jsx",
           "line": 42,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ForbiddenPage/index.jsx",
           "line": 17,
           "column": 10,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx",
-          "line": 26,
-          "column": 10,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/components/subscriptions/expiration/SubscriptionExpiredModal.jsx",
-          "line": 41,
-          "column": 12,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx",
-          "line": 57,
-          "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/licenses/LicenseManagementTabContentTable.jsx",
           "line": 168,
           "column": 20,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SupportPage/index.jsx",
           "line": 55,
           "column": 18,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/UserActivationPage/index.jsx",
           "line": 73,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Form.Checkbox": [
@@ -1794,13 +2361,13 @@
           "filePath": "src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.jsx",
           "line": 126,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeAssignmentModal/index.jsx",
-          "line": 366,
+          "line": 369,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Card": [
@@ -1808,19 +2375,19 @@
           "filePath": "src/components/BulkEnrollmentPage/stepper/ReviewItem.jsx",
           "line": 19,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/SubscriptionCard.jsx",
           "line": 27,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/SubscriptionZeroStateMessage.jsx",
-          "line": 14,
+          "line": 16,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Card.Body": [
@@ -1828,19 +2395,19 @@
           "filePath": "src/components/BulkEnrollmentPage/stepper/ReviewItem.jsx",
           "line": 20,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/SubscriptionCard.jsx",
           "line": 28,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/SubscriptionZeroStateMessage.jsx",
-          "line": 15,
+          "line": 17,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Card.Text": [
@@ -1848,7 +2415,7 @@
           "filePath": "src/components/BulkEnrollmentPage/stepper/ReviewItem.jsx",
           "line": 21,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "IconButton": [
@@ -1856,7 +2423,13 @@
           "filePath": "src/components/BulkEnrollmentPage/stepper/ReviewItem.jsx",
           "line": 23,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/MultipleFileInputField/MultipleFileInputField.jsx",
+          "line": 93,
+          "column": 12,
+          "version": "16.8.0"
         }
       ],
       "Row": [
@@ -1864,43 +2437,43 @@
           "filePath": "src/components/BulkEnrollmentPage/stepper/ReviewStep.jsx",
           "line": 37,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/licenses/LicenseAllocationHeader.jsx",
-          "line": 20,
+          "line": 22,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/MultipleSubscriptionPicker.jsx",
           "line": 17,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/SubscriptionDetails.jsx",
-          "line": 28,
+          "line": 36,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/SubscriptionDetails.jsx",
-          "line": 37,
+          "line": 46,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/SubscriptionDetails.jsx",
-          "line": 39,
+          "line": 48,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/UserActivationPage/index.jsx",
           "line": 62,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "DataTableContext.Provider": [
@@ -1908,7 +2481,7 @@
           "filePath": "src/components/BulkEnrollmentPage/table/BaseSelectionStatus.test.jsx",
           "line": 22,
           "column": 2,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "CheckboxControl": [
@@ -1916,51 +2489,51 @@
           "filePath": "src/components/BulkEnrollmentPage/table/BulkEnrollSelect.jsx",
           "line": 27,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/BulkEnrollmentPage/table/BulkEnrollSelect.jsx",
           "line": 61,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Modal": [
         {
           "filePath": "src/components/CodeAssignmentModal/index.jsx",
-          "line": 403,
+          "line": 406,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeReminderModal/index.jsx",
-          "line": 215,
+          "line": 218,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CodeRevokeModal/index.jsx",
-          "line": 225,
+          "line": 236,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/InviteLearnersModal/index.jsx",
-          "line": 180,
+          "line": 183,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LicenseRemindModal/index.jsx",
-          "line": 173,
+          "line": 176,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LicenseRevokeModal/index.jsx",
-          "line": 155,
+          "line": 157,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Pagination": [
@@ -1968,19 +2541,19 @@
           "filePath": "src/components/CodeManagement/index.jsx",
           "line": 198,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/licenses/LicenseManagementTabContentTable.jsx",
           "line": 180,
           "column": 20,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/TableComponent/index.jsx",
           "line": 89,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Alert.Heading": [
@@ -1988,25 +2561,67 @@
           "filePath": "src/components/CodeModal/ModalError.jsx",
           "line": 16,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/ErrorPage/index.jsx",
+          "line": 31,
+          "column": 12,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/FeatureAnnouncementBanner/index.jsx",
-          "line": 43,
+          "line": 45,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/InviteLearnersModal/index.jsx",
+          "line": 161,
+          "column": 10,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/LicenseRemindModal/index.jsx",
+          "line": 151,
+          "column": 10,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx",
+          "line": 32,
+          "column": 6,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx",
+          "line": 41,
+          "column": 6,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx",
+          "line": 51,
+          "column": 6,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx",
+          "line": 58,
+          "column": 6,
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/licenses/LicenseManagementTabContentTable.jsx",
           "line": 147,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/licenses/LicenseManagementTabContentTable.jsx",
           "line": 193,
           "column": 20,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "TransitionReplace": [
@@ -2014,7 +2629,7 @@
           "filePath": "src/components/CodeSearchResults/index.jsx",
           "line": 86,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "CheckBox": [
@@ -2022,13 +2637,13 @@
           "filePath": "src/components/CouponDetails/index.jsx",
           "line": 88,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/CouponDetails/index.jsx",
           "line": 376,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Input": [
@@ -2036,421 +2651,421 @@
           "filePath": "src/components/CsvUpload/index.jsx",
           "line": 41,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx",
           "line": 129,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx",
           "line": 149,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx",
           "line": 168,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx",
           "line": 187,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx",
           "line": 204,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx",
           "line": 124,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx",
           "line": 144,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx",
           "line": 164,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx",
           "line": 184,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx",
           "line": 204,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CornerstoneIntegrationConfigForm.jsx",
           "line": 186,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CornerstoneIntegrationConfigForm.jsx",
           "line": 206,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 191,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 211,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 230,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 249,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 268,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 287,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 306,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 144,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 164,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 183,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 200,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 219,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 238,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 257,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 127,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 147,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 165,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 184,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 203,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 222,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 241,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 262,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 281,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/EmailDeliveryMethodForm.jsx",
           "line": 20,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/EmailDeliveryMethodForm.jsx",
           "line": 36,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/EmailDeliveryMethodForm.jsx",
           "line": 52,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
           "line": 159,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
           "line": 176,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 194,
+          "line": 195,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 212,
+          "line": 213,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 229,
+          "line": 230,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 252,
+          "line": 253,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 270,
+          "line": 271,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 296,
+          "line": 297,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 311,
+          "line": 312,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 339,
+          "line": 340,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/SFTPDeliveryMethodForm.jsx",
           "line": 19,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/SFTPDeliveryMethodForm.jsx",
           "line": 37,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/SFTPDeliveryMethodForm.jsx",
           "line": 56,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/SFTPDeliveryMethodForm.jsx",
           "line": 68,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/SFTPDeliveryMethodForm.jsx",
           "line": 84,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/SFTPDeliveryMethodForm.jsx",
           "line": 100,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlConfiguration/index.jsx",
           "line": 48,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 117,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 135,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 151,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 175,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 194,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 211,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 228,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 245,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 262,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 279,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 296,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderDataForm.jsx",
           "line": 109,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderDataForm.jsx",
           "line": 129,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderDataForm.jsx",
           "line": 149,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "ValidationFormGroup": [
@@ -2458,421 +3073,421 @@
           "filePath": "src/components/FileInput/index.jsx",
           "line": 71,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx",
           "line": 125,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx",
           "line": 142,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx",
           "line": 161,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx",
           "line": 180,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx",
           "line": 199,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx",
           "line": 120,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx",
           "line": 138,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx",
           "line": 158,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx",
           "line": 178,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx",
           "line": 198,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CornerstoneIntegrationConfigForm.jsx",
           "line": 182,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CornerstoneIntegrationConfigForm.jsx",
           "line": 199,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 187,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 204,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 223,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 242,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 261,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 280,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 299,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 140,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 157,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 176,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 195,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 212,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 231,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 250,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 123,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 140,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 158,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 177,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 196,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 215,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 234,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 257,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 276,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReduxFormCheckbox/index.jsx",
           "line": 15,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/EmailDeliveryMethodForm.jsx",
           "line": 13,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/EmailDeliveryMethodForm.jsx",
           "line": 45,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
           "line": 155,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
           "line": 171,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 189,
+          "line": 190,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 207,
+          "line": 208,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 224,
+          "line": 225,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 246,
+          "line": 247,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 265,
+          "line": 266,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 289,
+          "line": 290,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 306,
+          "line": 307,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 334,
+          "line": 335,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 355,
+          "line": 356,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/SFTPDeliveryMethodForm.jsx",
           "line": 12,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/SFTPDeliveryMethodForm.jsx",
           "line": 30,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/SFTPDeliveryMethodForm.jsx",
           "line": 49,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/SFTPDeliveryMethodForm.jsx",
           "line": 77,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/SFTPDeliveryMethodForm.jsx",
           "line": 93,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlConfiguration/index.jsx",
           "line": 42,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 113,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 130,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 146,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 168,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 187,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 206,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 223,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 240,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 257,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 274,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 291,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderDataForm.jsx",
           "line": 102,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderDataForm.jsx",
           "line": 122,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderDataForm.jsx",
           "line": 142,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Dropdown": [
@@ -2880,7 +3495,7 @@
           "filePath": "src/components/Header/index.jsx",
           "line": 46,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Dropdown.Toggle": [
@@ -2888,7 +3503,7 @@
           "filePath": "src/components/Header/index.jsx",
           "line": 47,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Dropdown.Menu": [
@@ -2896,7 +3511,7 @@
           "filePath": "src/components/Header/index.jsx",
           "line": 56,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Dropdown.Item": [
@@ -2904,7 +3519,7 @@
           "filePath": "src/components/Header/index.jsx",
           "line": 57,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Navbar": [
@@ -2912,7 +3527,7 @@
           "filePath": "src/components/Header/index.jsx",
           "line": 88,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Nav": [
@@ -2920,13 +3535,13 @@
           "filePath": "src/components/Header/index.jsx",
           "line": 89,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/Header/index.jsx",
           "line": 99,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Nav.Link": [
@@ -2934,7 +3549,7 @@
           "filePath": "src/components/Header/index.jsx",
           "line": 91,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "OverlayTrigger": [
@@ -2942,19 +3557,19 @@
           "filePath": "src/components/IconWithTooltip/index.jsx",
           "line": 13,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/TemplateSourceFields/index.jsx",
           "line": 116,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/TemplateSourceFields/index.jsx",
           "line": 142,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Tooltip": [
@@ -2962,19 +3577,19 @@
           "filePath": "src/components/IconWithTooltip/index.jsx",
           "line": 18,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/TemplateSourceFields/index.jsx",
           "line": 120,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/TemplateSourceFields/index.jsx",
           "line": 146,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "StatefulButton": [
@@ -2982,67 +3597,67 @@
           "filePath": "src/components/LmsConfigurations/BlackboardIntegrationConfigForm.jsx",
           "line": 217,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CanvasIntegrationConfigForm.jsx",
           "line": 219,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/CornerstoneIntegrationConfigForm.jsx",
           "line": 219,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/DegreedIntegrationConfigForm.jsx",
           "line": 319,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/MoodleIntegrationConfigForm.jsx",
           "line": 270,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/SuccessFactorsIntegrationConfigForm.jsx",
           "line": 294,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/ReportingConfigForm.jsx",
-          "line": 361,
+          "line": 362,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderConfigForm.jsx",
           "line": 314,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/SamlProviderDataForm.jsx",
           "line": 163,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SaveTemplateButton/index.jsx",
-          "line": 135,
+          "line": 141,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/buttons/DownloadCsvButton.jsx",
           "line": 42,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Collapsible": [
@@ -3050,73 +3665,131 @@
           "filePath": "src/components/LmsConfigurations/index.jsx",
           "line": 139,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/index.jsx",
           "line": 151,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/index.jsx",
           "line": 163,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/index.jsx",
           "line": 175,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/index.jsx",
           "line": 187,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/LmsConfigurations/index.jsx",
           "line": 199,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/index.jsx",
           "line": 133,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/ReportingConfig/index.jsx",
           "line": 166,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/index.jsx",
           "line": 165,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/index.jsx",
           "line": 205,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/index.jsx",
           "line": 235,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/SamlProviderConfiguration/index.jsx",
           "line": 249,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
+        }
+      ],
+      "FormControl.Feedback": [
+        {
+          "filePath": "src/components/MultipleFileInputField/MultipleFileInputField.jsx",
+          "line": 86,
+          "column": 25,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/MultipleFileInputField/MultipleFileInputField.jsx",
+          "line": 87,
+          "column": 19,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/ReduxFormSelect/index.jsx",
+          "line": 15,
+          "column": 19,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/RenderField/index.jsx",
+          "line": 31,
+          "column": 19,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/TextAreaAutoSize/index.jsx",
+          "line": 30,
+          "column": 19,
+          "version": "16.8.0"
+        }
+      ],
+      "Form.Text": [
+        {
+          "filePath": "src/components/MultipleFileInputField/MultipleFileInputField.jsx",
+          "line": 88,
+          "column": 22,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/ReduxFormSelect/index.jsx",
+          "line": 16,
+          "column": 22,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/RenderField/index.jsx",
+          "line": 32,
+          "column": 22,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/TextAreaAutoSize/index.jsx",
+          "line": 31,
+          "column": 22,
+          "version": "16.8.0"
         }
       ],
       "Form.Check": [
@@ -3124,7 +3797,7 @@
           "filePath": "src/components/ReduxFormCheckbox/index.jsx",
           "line": 19,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "FormControl": [
@@ -3132,47 +3805,7 @@
           "filePath": "src/components/ReduxFormSelect/index.jsx",
           "line": 12,
           "column": 6,
-          "version": "15.2.2"
-        }
-      ],
-      "FormControl.Feedback": [
-        {
-          "filePath": "src/components/ReduxFormSelect/index.jsx",
-          "line": 15,
-          "column": 19,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/components/RenderField/index.jsx",
-          "line": 31,
-          "column": 19,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/components/TextAreaAutoSize/index.jsx",
-          "line": 30,
-          "column": 19,
-          "version": "15.2.2"
-        }
-      ],
-      "Form.Text": [
-        {
-          "filePath": "src/components/ReduxFormSelect/index.jsx",
-          "line": 16,
-          "column": 22,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/components/RenderField/index.jsx",
-          "line": 32,
-          "column": 22,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/components/TextAreaAutoSize/index.jsx",
-          "line": 31,
-          "column": 22,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "SearchField": [
@@ -3180,7 +3813,7 @@
           "filePath": "src/components/SearchBar/index.jsx",
           "line": 6,
           "column": 2,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "StatusAlert": [
@@ -3188,67 +3821,111 @@
           "filePath": "src/components/StatusAlert/index.jsx",
           "line": 18,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "ModalDialog": [
         {
           "filePath": "src/components/subscriptions/expiration/SubscriptionExpiredModal.jsx",
-          "line": 23,
+          "line": 21,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx",
-          "line": 42,
+          "line": 43,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "ModalDialog.Body": [
         {
           "filePath": "src/components/subscriptions/expiration/SubscriptionExpiredModal.jsx",
-          "line": 29,
+          "line": 27,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx",
-          "line": 48,
+          "line": 55,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
+        }
+      ],
+      "ModalDialog.Footer": [
+        {
+          "filePath": "src/components/subscriptions/expiration/SubscriptionExpiredModal.jsx",
+          "line": 35,
+          "column": 6,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx",
+          "line": 65,
+          "column": 6,
+          "version": "16.8.0"
+        }
+      ],
+      "ModalDialog.CloseButton": [
+        {
+          "filePath": "src/components/subscriptions/expiration/SubscriptionExpiredModal.jsx",
+          "line": 37,
+          "column": 10,
+          "version": "16.8.0"
+        },
+        {
+          "filePath": "src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx",
+          "line": 67,
+          "column": 10,
+          "version": "16.8.0"
+        }
+      ],
+      "ModalDialog.Header": [
+        {
+          "filePath": "src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx",
+          "line": 49,
+          "column": 6,
+          "version": "16.8.0"
+        }
+      ],
+      "ModalDialog.Title": [
+        {
+          "filePath": "src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx",
+          "line": 50,
+          "column": 8,
+          "version": "16.8.0"
         }
       ],
       "Col": [
         {
           "filePath": "src/components/subscriptions/licenses/LicenseAllocationHeader.jsx",
-          "line": 21,
+          "line": 23,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/licenses/LicenseAllocationHeader.jsx",
-          "line": 29,
+          "line": 31,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/MultipleSubscriptionPicker.jsx",
           "line": 18,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/subscriptions/SubscriptionDetails.jsx",
-          "line": 38,
+          "line": 47,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/UserActivationPage/index.jsx",
           "line": 63,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Table": [
@@ -3256,13 +3933,13 @@
           "filePath": "src/components/subscriptions/licenses/LicenseManagementTabContentTable.jsx",
           "line": 173,
           "column": 20,
-          "version": "15.2.2"
+          "version": "16.8.0"
         },
         {
           "filePath": "src/components/TableComponent/index.jsx",
           "line": 75,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "CardGrid": [
@@ -3270,7 +3947,7 @@
           "filePath": "src/components/subscriptions/MultipleSubscriptionPicker.jsx",
           "line": 25,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Card.Title": [
@@ -3278,7 +3955,7 @@
           "filePath": "src/components/subscriptions/SubscriptionCard.jsx",
           "line": 29,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Badge": [
@@ -3286,7 +3963,7 @@
           "filePath": "src/components/subscriptions/SubscriptionCard.jsx",
           "line": 34,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ],
       "Toast": [
@@ -3294,13 +3971,13 @@
           "filePath": "src/components/Toasts/Toasts.jsx",
           "line": 9,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.8.0"
         }
       ]
     }
   },
   {
-    "version": "13.16.1",
+    "version": "16.14.1",
     "name": "@edx/frontend-app-authn",
     "repository": {
       "type": "git",
@@ -3308,394 +3985,938 @@
     },
     "folderName": "frontend-app-authn",
     "usages": {
-      "Alert": [
+      "Hyperlink": [
         {
-          "filePath": "src/common-components/APIFailureMessage.jsx",
-          "line": 29,
+          "filePath": "src/base-component/AuthExtraLargeLayout.jsx",
+          "line": 20,
           "column": 8,
-          "version": "13.16.1"
+          "version": "16.14.1"
         },
         {
-          "filePath": "src/common-components/ConfirmationAlert.jsx",
-          "line": 14,
-          "column": 4,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/common-components/ThirdPartyAuthAlert.jsx",
-          "line": 32,
-          "column": 9,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/forgot-password/ForgotPasswordPage.jsx",
-          "line": 44,
+          "filePath": "src/base-component/AuthMediumLayout.jsx",
+          "line": 19,
           "column": 8,
-          "version": "13.16.1"
+          "version": "16.14.1"
         },
         {
-          "filePath": "src/forgot-password/RequestInProgressAlert.jsx",
+          "filePath": "src/base-component/AuthSmallLayout.jsx",
+          "line": 19,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/base-component/LargeLayout.jsx",
           "line": 12,
-          "column": 4,
-          "version": "13.16.1"
+          "column": 6,
+          "version": "16.14.1"
         },
         {
-          "filePath": "src/login/AccountActivationMessage.jsx",
+          "filePath": "src/base-component/MediumLayout.jsx",
+          "line": 37,
+          "column": 8,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/base-component/SmallLayout.jsx",
+          "line": 32,
+          "column": 8,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/common-components/InstitutionLogistration.jsx",
           "line": 51,
-          "column": 4,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/login/LoginFailure.jsx",
-          "line": 170,
-          "column": 4,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/register/RegistrationFailure.jsx",
-          "line": 61,
-          "column": 6,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/reset-password/InvalidToken.jsx",
-          "line": 28,
-          "column": 10,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/reset-password/ResetPasswordPage.jsx",
-          "line": 139,
-          "column": 14,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/reset-password/ResetSuccess.jsx",
-          "line": 33,
-          "column": 12,
-          "version": "13.16.1"
-        }
-      ],
-      "Alert.Heading": [
-        {
-          "filePath": "src/common-components/APIFailureMessage.jsx",
-          "line": 30,
-          "column": 10,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/common-components/ConfirmationAlert.jsx",
-          "line": 15,
-          "column": 6,
-          "version": "13.16.1"
+          "column": 18,
+          "version": "16.14.1"
         },
         {
           "filePath": "src/forgot-password/ForgotPasswordPage.jsx",
-          "line": 45,
-          "column": 10,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/forgot-password/RequestInProgressAlert.jsx",
-          "line": 13,
-          "column": 6,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/login/AccountActivationMessage.jsx",
-          "line": 52,
+          "line": 130,
           "column": 18,
-          "version": "13.16.1"
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/forgot-password/ForgotPasswordPage.jsx",
+          "line": 141,
+          "column": 26,
+          "version": "16.14.1"
         },
         {
           "filePath": "src/login/LoginFailure.jsx",
-          "line": 171,
-          "column": 6,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/register/RegistrationFailure.jsx",
-          "line": 62,
-          "column": 8,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/reset-password/InvalidToken.jsx",
-          "line": 29,
-          "column": 12,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/reset-password/ResetPasswordPage.jsx",
-          "line": 140,
-          "column": 16,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/reset-password/ResetSuccess.jsx",
-          "line": 34,
-          "column": 14,
-          "version": "13.16.1"
-        }
-      ],
-      "Form.Label": [
-        {
-          "filePath": "src/common-components/AuthnValidationFormGroup.jsx",
-          "line": 54,
-          "column": 6,
-          "version": "13.16.1"
-        }
-      ],
-      "ValidationFormGroup": [
-        {
-          "filePath": "src/common-components/AuthnValidationFormGroup.jsx",
-          "line": 103,
+          "line": 27,
           "column": 4,
-          "version": "13.16.1"
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/login/LoginFailure.jsx",
+          "line": 76,
+          "column": 8,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/login/LoginPage.jsx",
+          "line": 146,
+          "column": 10,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/RegistrationPage.jsx",
+          "line": 616,
+          "column": 20,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/RegistrationPage.jsx",
+          "line": 621,
+          "column": 20,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/welcome/WelcomePage.jsx",
+          "line": 199,
+          "column": 14,
+          "version": "16.14.1"
         }
       ],
-      "Input": [
+      "Image": [
         {
-          "filePath": "src/common-components/AuthnValidationFormGroup.jsx",
-          "line": 107,
-          "column": 6,
-          "version": "13.16.1"
-        }
-      ],
-      "Alert.Link": [
+          "filePath": "src/base-component/AuthExtraLargeLayout.jsx",
+          "line": 21,
+          "column": 10,
+          "version": "16.14.1"
+        },
         {
-          "filePath": "src/common-components/ConfirmationAlert.jsx",
+          "filePath": "src/base-component/AuthMediumLayout.jsx",
+          "line": 20,
+          "column": 10,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/base-component/AuthSmallLayout.jsx",
+          "line": 20,
+          "column": 8,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/base-component/LargeLayout.jsx",
+          "line": 13,
+          "column": 8,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/base-component/MediumLayout.jsx",
+          "line": 38,
+          "column": 10,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/base-component/SmallLayout.jsx",
           "line": 33,
-          "column": 14,
-          "version": "13.16.1"
+          "column": 10,
+          "version": "16.14.1"
+        }
+      ],
+      "Row": [
+        {
+          "filePath": "src/base-component/AuthExtraLargeLayout.jsx",
+          "line": 25,
+          "column": 12,
+          "version": "16.14.1"
         },
         {
-          "filePath": "src/login/AccountActivationMessage.jsx",
+          "filePath": "src/base-component/AuthMediumLayout.jsx",
+          "line": 24,
+          "column": 12,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/base-component/AuthSmallLayout.jsx",
+          "line": 24,
+          "column": 10,
+          "version": "16.14.1"
+        }
+      ],
+      "Col": [
+        {
+          "filePath": "src/base-component/AuthExtraLargeLayout.jsx",
+          "line": 26,
+          "column": 14,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/base-component/AuthExtraLargeLayout.jsx",
+          "line": 38,
+          "column": 14,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/base-component/AuthMediumLayout.jsx",
+          "line": 25,
+          "column": 14,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/base-component/AuthMediumLayout.jsx",
           "line": 30,
-          "column": 8,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/login/LoginFailure.jsx",
-          "line": 53,
-          "column": 8,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/login/LoginFailure.jsx",
-          "line": 91,
-          "column": 8,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/login/LoginFailure.jsx",
-          "line": 117,
-          "column": 8,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/login/LoginFailure.jsx",
-          "line": 160,
           "column": 14,
-          "version": "13.16.1"
+          "version": "16.14.1"
         },
         {
-          "filePath": "src/reset-password/InvalidToken.jsx",
-          "line": 14,
-          "column": 4,
-          "version": "13.16.1"
+          "filePath": "src/base-component/AuthSmallLayout.jsx",
+          "line": 25,
+          "column": 12,
+          "version": "16.14.1"
         },
         {
-          "filePath": "src/reset-password/ResetSuccess.jsx",
-          "line": 14,
-          "column": 4,
-          "version": "13.16.1"
+          "filePath": "src/base-component/AuthSmallLayout.jsx",
+          "line": 37,
+          "column": 12,
+          "version": "16.14.1"
+        }
+      ],
+      "ExtraLarge": [
+        {
+          "filePath": "src/base-component/BaseComponent.jsx",
+          "line": 37,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/base-component/BaseComponent.jsx",
+          "line": 69,
+          "column": 8,
+          "version": "16.14.1"
+        }
+      ],
+      "ExtraExtraLarge": [
+        {
+          "filePath": "src/base-component/BaseComponent.jsx",
+          "line": 40,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/base-component/BaseComponent.jsx",
+          "line": 74,
+          "column": 8,
+          "version": "16.14.1"
+        }
+      ],
+      "ExtraSmall": [
+        {
+          "filePath": "src/base-component/BaseComponent.jsx",
+          "line": 45,
+          "column": 8,
+          "version": "16.14.1"
+        }
+      ],
+      "Small": [
+        {
+          "filePath": "src/base-component/BaseComponent.jsx",
+          "line": 51,
+          "column": 8,
+          "version": "16.14.1"
+        }
+      ],
+      "Medium": [
+        {
+          "filePath": "src/base-component/BaseComponent.jsx",
+          "line": 57,
+          "column": 8,
+          "version": "16.14.1"
+        }
+      ],
+      "Large": [
+        {
+          "filePath": "src/base-component/BaseComponent.jsx",
+          "line": 63,
+          "column": 8,
+          "version": "16.14.1"
+        }
+      ],
+      "Toast": [
+        {
+          "filePath": "src/base-component/DiscountBanner.jsx",
+          "line": 29,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/base-component/LargeLeftLayout.jsx",
+          "line": 24,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/base-component/MediumLayout.jsx",
+          "line": 30,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/base-component/SmallLayout.jsx",
+          "line": 26,
+          "column": 8,
+          "version": "16.14.1"
+        }
+      ],
+      "PageBanner": [
+        {
+          "filePath": "src/base-component/DiscountBanner.jsx",
+          "line": 35,
+          "column": 6,
+          "version": "16.14.1"
         }
       ],
       "Form": [
         {
           "filePath": "src/common-components/EnterpriseSSO.jsx",
-          "line": 36,
+          "line": 35,
           "column": 12,
-          "version": "13.16.1"
+          "version": "16.14.1"
         },
         {
           "filePath": "src/forgot-password/ForgotPasswordPage.jsx",
-          "line": 99,
-          "column": 14,
-          "version": "13.16.1"
+          "line": 100,
+          "column": 16,
+          "version": "16.14.1"
         },
         {
           "filePath": "src/login/LoginPage.jsx",
-          "line": 222,
-          "column": 14,
-          "version": "13.16.1"
+          "line": 227,
+          "column": 10,
+          "version": "16.14.1"
         },
         {
           "filePath": "src/register/RegistrationPage.jsx",
-          "line": 509,
-          "column": 14,
-          "version": "13.16.1"
+          "line": 545,
+          "column": 10,
+          "version": "16.14.1"
         },
         {
           "filePath": "src/reset-password/ResetPasswordPage.jsx",
-          "line": 144,
-          "column": 12,
-          "version": "13.16.1"
+          "line": 155,
+          "column": 14,
+          "version": "16.14.1"
         },
         {
           "filePath": "src/welcome/WelcomePage.jsx",
-          "line": 114,
+          "line": 160,
           "column": 10,
-          "version": "13.16.1"
+          "version": "16.14.1"
         }
       ],
       "Button": [
         {
           "filePath": "src/common-components/EnterpriseSSO.jsx",
-          "line": 38,
+          "line": 37,
           "column": 14,
-          "version": "13.16.1"
+          "version": "16.14.1"
         },
         {
           "filePath": "src/common-components/EnterpriseSSO.jsx",
-          "line": 64,
+          "line": 63,
           "column": 14,
-          "version": "13.16.1"
+          "version": "16.14.1"
         },
         {
           "filePath": "src/common-components/InstitutionLogistration.jsx",
-          "line": 14,
-          "column": 6,
-          "version": "13.16.1"
+          "line": 13,
+          "column": 4,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/UsernameField.jsx",
+          "line": 19,
+          "column": 12,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/welcome/WelcomePageModal.jsx",
+          "line": 40,
+          "column": 10,
+          "version": "16.14.1"
         }
       ],
-      "Hyperlink": [
+      "Form.Group": [
         {
-          "filePath": "src/common-components/InstitutionLogistration.jsx",
-          "line": 43,
-          "column": 12,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/common-components/InstitutionLogistration.jsx",
-          "line": 60,
-          "column": 18,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/login/LoginHelpLinks.jsx",
-          "line": 33,
+          "filePath": "src/common-components/FormGroup.jsx",
+          "line": 24,
           "column": 4,
-          "version": "13.16.1"
+          "version": "16.14.1"
         },
         {
-          "filePath": "src/login/LoginHelpLinks.jsx",
-          "line": 43,
+          "filePath": "src/common-components/PasswordField.jsx",
+          "line": 58,
           "column": 4,
-          "version": "13.16.1"
+          "version": "16.14.1"
         },
         {
-          "filePath": "src/login/LoginHelpLinks.jsx",
-          "line": 50,
-          "column": 6,
-          "version": "13.16.1"
+          "filePath": "src/register/OptionalFields.jsx",
+          "line": 35,
+          "column": 8,
+          "version": "16.14.1"
         },
         {
-          "filePath": "src/login/LoginPage.jsx",
-          "line": 210,
-          "column": 16,
-          "version": "13.16.1"
+          "filePath": "src/register/OptionalFields.jsx",
+          "line": 49,
+          "column": 8,
+          "version": "16.14.1"
         },
         {
-          "filePath": "src/login/LoginPage.jsx",
-          "line": 249,
-          "column": 16,
-          "version": "13.16.1"
+          "filePath": "src/register/OptionalFields.jsx",
+          "line": 64,
+          "column": 8,
+          "version": "16.14.1"
         },
         {
-          "filePath": "src/register/RegistrationPage.jsx",
-          "line": 499,
-          "column": 16,
-          "version": "13.16.1"
-        },
-        {
-          "filePath": "src/register/RegistrationPage.jsx",
-          "line": 601,
-          "column": 24,
-          "version": "13.16.1"
+          "filePath": "src/register/OptionalFields.jsx",
+          "line": 78,
+          "column": 8,
+          "version": "16.14.1"
         },
         {
           "filePath": "src/register/RegistrationPage.jsx",
-          "line": 606,
-          "column": 24,
-          "version": "13.16.1"
+          "line": 629,
+          "column": 14,
+          "version": "16.14.1"
         },
         {
           "filePath": "src/welcome/WelcomePage.jsx",
-          "line": 157,
+          "line": 161,
+          "column": 12,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/welcome/WelcomePage.jsx",
+          "line": 173,
+          "column": 12,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/welcome/WelcomePage.jsx",
+          "line": 186,
+          "column": 12,
+          "version": "16.14.1"
+        }
+      ],
+      "Form.Control": [
+        {
+          "filePath": "src/common-components/FormGroup.jsx",
+          "line": 25,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/common-components/PasswordField.jsx",
+          "line": 60,
+          "column": 8,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/OptionalFields.jsx",
+          "line": 36,
+          "column": 10,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/OptionalFields.jsx",
+          "line": 50,
+          "column": 10,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/OptionalFields.jsx",
+          "line": 65,
+          "column": 10,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/OptionalFields.jsx",
+          "line": 79,
+          "column": 10,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/welcome/WelcomePage.jsx",
+          "line": 162,
           "column": 14,
-          "version": "13.16.1"
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/welcome/WelcomePage.jsx",
+          "line": 174,
+          "column": 14,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/welcome/WelcomePage.jsx",
+          "line": 187,
+          "column": 14,
+          "version": "16.14.1"
         }
       ],
       "TransitionReplace": [
         {
+          "filePath": "src/common-components/FormGroup.jsx",
+          "line": 44,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
           "filePath": "src/common-components/SwitchContent.jsx",
           "line": 41,
           "column": 4,
-          "version": "13.16.1"
+          "version": "16.14.1"
+        }
+      ],
+      "Icon": [
+        {
+          "filePath": "src/common-components/InstitutionLogistration.jsx",
+          "line": 19,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/common-components/Logistration.jsx",
+          "line": 45,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/common-components/PasswordField.jsx",
+          "line": 43,
+          "column": 42,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/common-components/PasswordField.jsx",
+          "line": 43,
+          "column": 95,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/common-components/PasswordField.jsx",
+          "line": 47,
+          "column": 42,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/common-components/PasswordField.jsx",
+          "line": 47,
+          "column": 95,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/common-components/PasswordField.jsx",
+          "line": 51,
+          "column": 35,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/common-components/PasswordField.jsx",
+          "line": 51,
+          "column": 88,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/forgot-password/ForgotPasswordPage.jsx",
+          "line": 61,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/login/LoginPage.jsx",
+          "line": 147,
+          "column": 12,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/OptionalFields.jsx",
+          "line": 41,
+          "column": 29,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/OptionalFields.jsx",
+          "line": 55,
+          "column": 29,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/OptionalFields.jsx",
+          "line": 70,
+          "column": 29,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/RegistrationPage.jsx",
+          "line": 424,
+          "column": 26,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/reset-password/ResetPasswordPage.jsx",
+          "line": 120,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/welcome/WelcomePage.jsx",
+          "line": 167,
+          "column": 33,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/welcome/WelcomePage.jsx",
+          "line": 179,
+          "column": 33,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/welcome/WelcomePage.jsx",
+          "line": 192,
+          "column": 33,
+          "version": "16.14.1"
+        }
+      ],
+      "Tabs": [
+        {
+          "filePath": "src/common-components/Logistration.jsx",
+          "line": 59,
+          "column": 12,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/common-components/Logistration.jsx",
+          "line": 66,
+          "column": 16,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/forgot-password/ForgotPasswordPage.jsx",
+          "line": 69,
+          "column": 8,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/reset-password/ResetPasswordPage.jsx",
+          "line": 144,
+          "column": 10,
+          "version": "16.14.1"
+        }
+      ],
+      "Tab": [
+        {
+          "filePath": "src/common-components/Logistration.jsx",
+          "line": 60,
+          "column": 14,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/common-components/Logistration.jsx",
+          "line": 67,
+          "column": 18,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/common-components/Logistration.jsx",
+          "line": 68,
+          "column": 18,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/forgot-password/ForgotPasswordPage.jsx",
+          "line": 70,
+          "column": 10,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/reset-password/ResetPasswordPage.jsx",
+          "line": 145,
+          "column": 12,
+          "version": "16.14.1"
+        }
+      ],
+      "IconButton": [
+        {
+          "filePath": "src/common-components/PasswordField.jsx",
+          "line": 33,
+          "column": 4,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/common-components/PasswordField.jsx",
+          "line": 37,
+          "column": 4,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/CountryDropdown.jsx",
+          "line": 151,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/CountryDropdown.jsx",
+          "line": 165,
+          "column": 6,
+          "version": "16.14.1"
+        }
+      ],
+      "Tooltip": [
+        {
+          "filePath": "src/common-components/PasswordField.jsx",
+          "line": 41,
+          "column": 4,
+          "version": "16.14.1"
+        }
+      ],
+      "OverlayTrigger": [
+        {
+          "filePath": "src/common-components/PasswordField.jsx",
+          "line": 59,
+          "column": 6,
+          "version": "16.14.1"
+        }
+      ],
+      "Alert": [
+        {
+          "filePath": "src/common-components/ThirdPartyAuthAlert.jsx",
+          "line": 23,
+          "column": 4,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/forgot-password/ForgotPasswordAlert.jsx",
+          "line": 80,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/login/AccountActivationMessage.jsx",
+          "line": 57,
+          "column": 4,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/login/LoginFailure.jsx",
+          "line": 159,
+          "column": 4,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/RegistrationFailure.jsx",
+          "line": 38,
+          "column": 4,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/RegistrationPage.jsx",
+          "line": 415,
+          "column": 8,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/reset-password/ResetPasswordFailure.jsx",
+          "line": 37,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/reset-password/ResetPasswordSuccess.jsx",
+          "line": 12,
+          "column": 4,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/welcome/WelcomePage.jsx",
+          "line": 155,
+          "column": 12,
+          "version": "16.14.1"
+        }
+      ],
+      "Alert.Heading": [
+        {
+          "filePath": "src/common-components/ThirdPartyAuthAlert.jsx",
+          "line": 25,
+          "column": 8,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/forgot-password/ForgotPasswordAlert.jsx",
+          "line": 86,
+          "column": 8,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/login/AccountActivationMessage.jsx",
+          "line": 63,
+          "column": 18,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/login/LoginFailure.jsx",
+          "line": 160,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/RegistrationFailure.jsx",
+          "line": 39,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/reset-password/ResetPasswordFailure.jsx",
+          "line": 38,
+          "column": 8,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/reset-password/ResetPasswordSuccess.jsx",
+          "line": 13,
+          "column": 6,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/welcome/WelcomePage.jsx",
+          "line": 156,
+          "column": 14,
+          "version": "16.14.1"
+        }
+      ],
+      "Alert.Link": [
+        {
+          "filePath": "src/forgot-password/ForgotPasswordAlert.jsx",
+          "line": 37,
+          "column": 14,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/login/AccountActivationMessage.jsx",
+          "line": 36,
+          "column": 8,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/RegistrationPage.jsx",
+          "line": 418,
+          "column": 12,
+          "version": "16.14.1"
+        },
+        {
+          "filePath": "src/register/RegistrationPage.jsx",
+          "line": 433,
+          "column": 10,
+          "version": "16.14.1"
         }
       ],
       "StatefulButton": [
         {
           "filePath": "src/forgot-password/ForgotPasswordPage.jsx",
-          "line": 123,
-          "column": 16,
-          "version": "13.16.1"
+          "line": 118,
+          "column": 18,
+          "version": "16.14.1"
         },
         {
           "filePath": "src/login/LoginPage.jsx",
-          "line": 252,
-          "column": 16,
-          "version": "13.16.1"
+          "line": 245,
+          "column": 12,
+          "version": "16.14.1"
         },
         {
           "filePath": "src/register/RegistrationPage.jsx",
-          "line": 629,
-          "column": 16,
-          "version": "13.16.1"
+          "line": 642,
+          "column": 12,
+          "version": "16.14.1"
         },
         {
           "filePath": "src/reset-password/ResetPasswordPage.jsx",
-          "line": 178,
-          "column": 14,
-          "version": "13.16.1"
+          "line": 174,
+          "column": 16,
+          "version": "16.14.1"
         },
         {
           "filePath": "src/welcome/WelcomePage.jsx",
-          "line": 166,
+          "line": 211,
           "column": 14,
-          "version": "13.16.1"
+          "version": "16.14.1"
         },
         {
           "filePath": "src/welcome/WelcomePage.jsx",
-          "line": 175,
+          "line": 223,
           "column": 14,
-          "version": "13.16.1"
+          "version": "16.14.1"
+        }
+      ],
+      "Form.Check": [
+        {
+          "filePath": "src/register/RegistrationPage.jsx",
+          "line": 630,
+          "column": 16,
+          "version": "16.14.1"
         }
       ],
       "Spinner": [
         {
-          "filePath": "src/reset-password/Spinner.jsx",
-          "line": 7,
+          "filePath": "src/reset-password/ResetPasswordPage.jsx",
+          "line": 129,
+          "column": 13,
+          "version": "16.14.1"
+        }
+      ],
+      "ModalDialog": [
+        {
+          "filePath": "src/welcome/WelcomePageModal.jsx",
+          "line": 20,
+          "column": 4,
+          "version": "16.14.1"
+        }
+      ],
+      "ModalDialog.Header": [
+        {
+          "filePath": "src/welcome/WelcomePageModal.jsx",
+          "line": 28,
           "column": 6,
-          "version": "13.16.1"
+          "version": "16.14.1"
+        }
+      ],
+      "ModalDialog.Title": [
+        {
+          "filePath": "src/welcome/WelcomePageModal.jsx",
+          "line": 29,
+          "column": 8,
+          "version": "16.14.1"
+        }
+      ],
+      "ModalDialog.Body": [
+        {
+          "filePath": "src/welcome/WelcomePageModal.jsx",
+          "line": 34,
+          "column": 6,
+          "version": "16.14.1"
+        }
+      ],
+      "ModalDialog.Footer": [
+        {
+          "filePath": "src/welcome/WelcomePageModal.jsx",
+          "line": 38,
+          "column": 6,
+          "version": "16.14.1"
+        }
+      ],
+      "ActionRow": [
+        {
+          "filePath": "src/welcome/WelcomePageModal.jsx",
+          "line": 39,
+          "column": 8,
+          "version": "16.14.1"
         }
       ]
     }
   },
   {
-    "version": "15.2.2",
+    "version": "16.6.4",
     "name": "@edx/frontend-app-course-authoring",
     "repository": {
       "type": "git",
@@ -3703,42 +4924,162 @@
     },
     "folderName": "frontend-app-course-authoring",
     "usages": {
+      "Collapsible.Advanced": [
+        {
+          "filePath": "src/generic/CollapsableEditor.jsx",
+          "line": 19,
+          "column": 2,
+          "version": "16.6.4"
+        }
+      ],
+      "Collapsible.Trigger": [
+        {
+          "filePath": "src/generic/CollapsableEditor.jsx",
+          "line": 26,
+          "column": 4,
+          "version": "16.6.4"
+        }
+      ],
+      "Collapsible.Visible": [
+        {
+          "filePath": "src/generic/CollapsableEditor.jsx",
+          "line": 33,
+          "column": 6,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/generic/CollapsableEditor.jsx",
+          "line": 40,
+          "column": 6,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-list/FeaturesList.jsx",
+          "line": 25,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-list/FeaturesList.jsx",
+          "line": 28,
+          "column": 10,
+          "version": "16.6.4"
+        }
+      ],
+      "Icon": [
+        {
+          "filePath": "src/generic/CollapsableEditor.jsx",
+          "line": 34,
+          "column": 8,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/generic/CollapsableEditor.jsx",
+          "line": 56,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/Settings.jsx",
+          "line": 139,
+          "column": 22,
+          "version": "16.6.4"
+        }
+      ],
+      "IconButton": [
+        {
+          "filePath": "src/generic/CollapsableEditor.jsx",
+          "line": 43,
+          "column": 12,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/pages/PageCard.jsx",
+          "line": 39,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/pages/PageCard.jsx",
+          "line": 51,
+          "column": 6,
+          "version": "16.6.4"
+        }
+      ],
+      "Collapsible.Body": [
+        {
+          "filePath": "src/generic/CollapsableEditor.jsx",
+          "line": 64,
+          "column": 4,
+          "version": "16.6.4"
+        }
+      ],
       "Alert": [
         {
           "filePath": "src/generic/ConnectionErrorAlert.jsx",
           "line": 10,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/generic/PermissionDeniedAlert.jsx",
           "line": 7,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/generic/SaveFormConnectionErrorAlert.jsx",
           "line": 10,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 202,
+          "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
+          "line": 203,
+          "column": 16,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/DiscussionsSettings.jsx",
+          "line": 127,
+          "column": 18,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 226,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 393,
+          "column": 6,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 420,
+          "column": 6,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 413,
-          "column": 6,
-          "version": "15.2.2"
+          "line": 209,
+          "column": 12,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 435,
+          "line": 420,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 442,
+          "column": 6,
+          "version": "16.6.4"
         }
       ],
       "Alert.Link": [
@@ -3746,195 +5087,419 @@
           "filePath": "src/generic/ConnectionErrorAlert.jsx",
           "line": 16,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/generic/SaveFormConnectionErrorAlert.jsx",
           "line": 16,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 123,
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 136,
           "column": 35,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 135,
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 148,
           "column": 35,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 427,
-          "column": 40,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 453,
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 408,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 437,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 130,
+          "column": 35,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 142,
+          "column": 35,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 434,
+          "column": 40,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 460,
+          "column": 14,
+          "version": "16.6.4"
+        }
+      ],
+      "TransitionReplace": [
+        {
+          "filePath": "src/generic/FormikErrorFeedback.jsx",
+          "line": 12,
+          "column": 4,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
+          "line": 37,
+          "column": 4,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/AnonymousPostingFields.jsx",
+          "line": 26,
+          "column": 6,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/BlackoutDatesField.jsx",
+          "line": 101,
+          "column": 8,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
+          "line": 128,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
+          "line": 137,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx",
+          "line": 71,
+          "column": 6,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx",
+          "line": 84,
+          "column": 12,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/InContextDiscussionFields.jsx",
+          "line": 26,
+          "column": 6,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 40,
+          "column": 4,
+          "version": "16.6.4"
         }
       ],
       "Form.Group": [
         {
           "filePath": "src/generic/FormSwitchGroup.jsx",
-          "line": 21,
+          "line": 23,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx",
-          "line": 53,
-          "column": 8,
-          "version": "15.2.2"
+          "line": 88,
+          "column": 12,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx",
-          "line": 66,
-          "column": 8,
-          "version": "15.2.2"
+          "line": 101,
+          "column": 12,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx",
-          "line": 79,
-          "column": 8,
-          "version": "15.2.2"
+          "line": 114,
+          "column": 12,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx",
+          "line": 134,
+          "column": 12,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/BlackoutDatesField.jsx",
-          "line": 81,
+          "line": 88,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 181,
-          "column": 12,
-          "version": "15.2.2"
+          "line": 115,
+          "column": 8,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx",
-          "line": 101,
+          "line": 90,
           "column": 22,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 213,
-          "column": 8,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 235,
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 269,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 279,
-          "column": 8,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 303,
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 295,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 326,
+          "column": 12,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 349,
+          "column": 12,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/Settings.jsx",
+          "line": 105,
+          "column": 12,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 81,
+          "column": 12,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 92,
+          "column": 12,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 103,
+          "column": 12,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 125,
+          "column": 12,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 336,
+          "line": 220,
+          "column": 8,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 242,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 286,
+          "column": 8,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 310,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 343,
+          "column": 12,
+          "version": "16.6.4"
         }
       ],
       "Form.Label": [
         {
           "filePath": "src/generic/FormSwitchGroup.jsx",
-          "line": 27,
+          "line": 29,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 236,
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 270,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 280,
-          "column": 10,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 304,
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 296,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 327,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 350,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 104,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 126,
+          "column": 14,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 337,
+          "line": 243,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 287,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 311,
+          "column": 12,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 344,
+          "column": 14,
+          "version": "16.6.4"
         }
       ],
       "SwitchControl": [
         {
           "filePath": "src/generic/FormSwitchGroup.jsx",
-          "line": 30,
+          "line": 32,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "Form.Text": [
         {
           "filePath": "src/generic/FormSwitchGroup.jsx",
-          "line": 39,
+          "line": 41,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx",
+          "line": 131,
+          "column": 12,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/BlackoutDatesField.jsx",
-          "line": 96,
+          "line": 112,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 223,
-          "column": 10,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 263,
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 282,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 295,
-          "column": 10,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 321,
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 309,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/Settings.jsx",
+          "line": 115,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 89,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 100,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 135,
+          "column": 14,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 364,
+          "line": 230,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 270,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 302,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 328,
+          "column": 12,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 371,
+          "column": 14,
+          "version": "16.6.4"
         }
       ],
       "Spinner": [
@@ -3942,441 +5507,583 @@
           "filePath": "src/generic/Loading.jsx",
           "line": 13,
           "column": 6,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
-          "line": 147,
-          "column": 10,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 387,
+          "line": 394,
           "column": 33,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
-      "Badge": [
-        {
-          "filePath": "src/generic/status-badge/StatusBadge.jsx",
-          "line": 13,
-          "column": 10,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/generic/status-badge/StatusBadge.jsx",
-          "line": 14,
-          "column": 10,
-          "version": "15.2.2"
-        }
-      ],
-      "TransitionReplace": [
+      "ModalDialog": [
         {
           "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
-          "line": 22,
+          "line": 65,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/AnonymousPostingFields.jsx",
-          "line": 26,
+          "filePath": "src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx",
+          "line": 114,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 194,
-          "column": 14,
-          "version": "15.2.2"
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 499,
+          "column": 4,
+          "version": "16.6.4"
+        }
+      ],
+      "ModalDialog.Header": [
+        {
+          "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
+          "line": 74,
+          "column": 6,
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 203,
-          "column": 14,
-          "version": "15.2.2"
+          "filePath": "src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx",
+          "line": 120,
+          "column": 8,
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx",
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 510,
+          "column": 8,
+          "version": "16.6.4"
+        }
+      ],
+      "ModalDialog.Title": [
+        {
+          "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
+          "line": 75,
+          "column": 8,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx",
+          "line": 121,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 511,
+          "column": 10,
+          "version": "16.6.4"
+        }
+      ],
+      "ModalDialog.Body": [
+        {
+          "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
+          "line": 79,
+          "column": 6,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx",
+          "line": 125,
+          "column": 8,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 515,
+          "column": 8,
+          "version": "16.6.4"
+        }
+      ],
+      "ModalDialog.Footer": [
+        {
+          "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
           "line": 82,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx",
-          "line": 95,
+          "filePath": "src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx",
+          "line": 128,
+          "column": 8,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 523,
+          "column": 8,
+          "version": "16.6.4"
+        }
+      ],
+      "ActionRow": [
+        {
+          "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
+          "line": 83,
+          "column": 8,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx",
+          "line": 129,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 528,
+          "column": 10,
+          "version": "16.6.4"
+        }
+      ],
+      "ModalDialog.CloseButton": [
+        {
+          "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
+          "line": 84,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx",
+          "line": 130,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/InContextDiscussionFields.jsx",
-          "line": 26,
-          "column": 6,
-          "version": "15.2.2"
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 529,
+          "column": 12,
+          "version": "16.6.4"
         }
       ],
       "Hyperlink": [
         {
           "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
-          "line": 75,
+          "line": 152,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/AppExternalLinks.jsx",
           "line": 28,
           "column": 16,
-          "version": "15.2.2"
-        }
-      ],
-      "ModalLayer": [
+          "version": "16.6.4"
+        },
         {
-          "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
-          "line": 85,
+          "filePath": "src/pages-and-resources/pages/PageCard.jsx",
+          "line": 38,
+          "column": 8,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/PagesAndResources.jsx",
+          "line": 45,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 210,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "Form": [
         {
           "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
-          "line": 112,
-          "column": 14,
-          "version": "15.2.2"
+          "line": 179,
+          "column": 10,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.jsx",
-          "line": 86,
+          "line": 88,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx",
-          "line": 50,
+          "line": 66,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 509,
+          "column": 6,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 198,
+          "line": 205,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
-      "Button": [
+      "StatefulButton": [
         {
           "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
-          "line": 134,
-          "column": 18,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
-          "line": 137,
-          "column": 18,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.jsx",
-          "line": 70,
+          "line": 191,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 113,
-          "column": 10,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 116,
-          "column": 10,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/pages-and-resources/discussions/app-list/AppListNextButton.jsx",
-          "line": 20,
+          "filePath": "src/pages-and-resources/discussions/app-config-form/AppConfigFormSaveButton.jsx",
+          "line": 23,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/pages-and-resources/discussions/DiscussionsSettings.jsx",
-          "line": 101,
-          "column": 20,
-          "version": "15.2.2"
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 532,
+          "column": 12,
+          "version": "16.6.4"
+        }
+      ],
+      "Alert.Heading": [
+        {
+          "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
+          "line": 204,
+          "column": 18,
+          "version": "16.6.4"
+        }
+      ],
+      "Badge": [
+        {
+          "filePath": "src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx",
+          "line": 220,
+          "column": 22,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/pages/PageCard.jsx",
-          "line": 67,
-          "column": 10,
-          "version": "15.2.2"
+          "line": 80,
+          "column": 14,
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/pages-and-resources/resources/ResourcesList.jsx",
-          "line": 18,
-          "column": 10,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 374,
-          "column": 8,
-          "version": "15.2.2"
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 248,
+          "column": 18,
+          "version": "16.6.4"
         }
       ],
       "Container": [
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx",
-          "line": 92,
+          "line": 111,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-list/AppList.jsx",
           "line": 51,
           "column": 6,
-          "version": "15.2.2"
-        }
-      ],
-      "StatefulButton": [
-        {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/AppConfigFormSaveButton.jsx",
-          "line": 22,
-          "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "Card": [
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.jsx",
-          "line": 85,
+          "line": 87,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx",
-          "line": 49,
+          "line": 65,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 104,
+          "line": 78,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-list/AppCard.jsx",
-          "line": 20,
+          "line": 22,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/pages/PageCard.jsx",
-          "line": 37,
+          "line": 63,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
+        }
+      ],
+      "MailtoLink": [
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx",
+          "line": 77,
+          "column": 20,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/AppExternalLinks.jsx",
+          "line": 47,
+          "column": 16,
+          "version": "16.6.4"
         }
       ],
       "Form.Control": [
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx",
-          "line": 54,
-          "column": 10,
-          "version": "15.2.2"
+          "line": 89,
+          "column": 14,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx",
-          "line": 67,
-          "column": 10,
-          "version": "15.2.2"
+          "line": 102,
+          "column": 14,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx",
-          "line": 80,
-          "column": 10,
-          "version": "15.2.2"
+          "line": 115,
+          "column": 14,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/BlackoutDatesField.jsx",
-          "line": 84,
+          "line": 93,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 186,
-          "column": 14,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 287,
+          "line": 120,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 273,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 299,
+          "column": 12,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/Settings.jsx",
+          "line": 106,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 82,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 93,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 127,
+          "column": 14,
+          "version": "16.6.4"
         },
         {
           "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 311,
+          "line": 294,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 318,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
-      "MailtoLink": [
+      "Form.Check": [
         {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/AppExternalLinks.jsx",
-          "line": 47,
+          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx",
+          "line": 135,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx",
+          "line": 143,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 221,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 250,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 260,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 351,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 361,
+          "column": 14,
+          "version": "16.6.4"
+        }
+      ],
+      "Button": [
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.jsx",
+          "line": 78,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
+          "line": 87,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
+          "line": 90,
+          "column": 10,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/app-list/AppListNextButton.jsx",
+          "line": 20,
+          "column": 4,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/discussions/DiscussionsSettings.jsx",
+          "line": 108,
+          "column": 20,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/PagesAndResources.jsx",
+          "line": 51,
+          "column": 12,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/Settings.jsx",
+          "line": 134,
+          "column": 20,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 47,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 50,
+          "column": 14,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
+          "line": 381,
+          "column": 8,
+          "version": "16.6.4"
         }
       ],
       "Card.Body": [
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 105,
+          "line": 79,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-list/AppCard.jsx",
-          "line": 49,
+          "line": 51,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/pages/PageCard.jsx",
-          "line": 44,
+          "line": 72,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "Card.Text": [
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 109,
+          "line": 83,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/app-list/AppCard.jsx",
-          "line": 54,
+          "line": 56,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/pages/PageCard.jsx",
-          "line": 62,
+          "line": 86,
           "column": 8,
-          "version": "15.2.2"
-        }
-      ],
-      "Collapsible.Advanced": [
-        {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 133,
-          "column": 8,
-          "version": "15.2.2"
-        }
-      ],
-      "Collapsible.Trigger": [
-        {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 140,
-          "column": 10,
-          "version": "15.2.2"
-        }
-      ],
-      "Collapsible.Visible": [
-        {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 144,
-          "column": 12,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 156,
-          "column": 12,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/pages-and-resources/discussions/app-list/FeaturesList.jsx",
-          "line": 24,
-          "column": 10,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/pages-and-resources/discussions/app-list/FeaturesList.jsx",
-          "line": 27,
-          "column": 10,
-          "version": "15.2.2"
-        }
-      ],
-      "IconButton": [
-        {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 147,
-          "column": 16,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 160,
-          "column": 18,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 170,
-          "column": 16,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/pages-and-resources/pages/PageCard.jsx",
-          "line": 49,
-          "column": 12,
-          "version": "15.2.2"
-        }
-      ],
-      "Collapsible.Body": [
-        {
-          "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx",
-          "line": 180,
-          "column": 10,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "Form.CheckboxSet": [
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx",
-          "line": 102,
+          "line": 91,
           "column": 24,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "Form.Checkbox": [
         {
           "filePath": "src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx",
-          "line": 110,
+          "line": 99,
           "column": 30,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "CheckboxControl": [
         {
           "filePath": "src/pages-and-resources/discussions/app-list/AppCard.jsx",
-          "line": 41,
+          "line": 42,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "Card.Subtitle": [
         {
           "filePath": "src/pages-and-resources/discussions/app-list/AppCard.jsx",
-          "line": 53,
+          "line": 55,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "CardGrid": [
@@ -4384,13 +6091,13 @@
           "filePath": "src/pages-and-resources/discussions/app-list/AppList.jsx",
           "line": 62,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/pages/PageGrid.jsx",
           "line": 9,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "Collapsible": [
@@ -4398,133 +6105,153 @@
           "filePath": "src/pages-and-resources/discussions/app-list/FeaturesList.jsx",
           "line": 21,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "DataTable": [
         {
           "filePath": "src/pages-and-resources/discussions/app-list/FeaturesTable.jsx",
-          "line": 10,
+          "line": 11,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "DataTable.Table": [
         {
           "filePath": "src/pages-and-resources/discussions/app-list/FeaturesTable.jsx",
-          "line": 55,
+          "line": 56,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "FullscreenModal": [
         {
           "filePath": "src/pages-and-resources/discussions/DiscussionsSettings.jsx",
-          "line": 59,
+          "line": 66,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/DiscussionsSettings.jsx",
-          "line": 72,
+          "line": 79,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/DiscussionsSettings.jsx",
-          "line": 87,
+          "line": 94,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "Stepper": [
         {
           "filePath": "src/pages-and-resources/discussions/DiscussionsSettings.jsx",
-          "line": 86,
+          "line": 93,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "Stepper.Header": [
         {
           "filePath": "src/pages-and-resources/discussions/DiscussionsSettings.jsx",
-          "line": 93,
+          "line": 100,
           "column": 28,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "Stepper.ActionRow": [
         {
           "filePath": "src/pages-and-resources/discussions/DiscussionsSettings.jsx",
-          "line": 96,
+          "line": 103,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/DiscussionsSettings.jsx",
-          "line": 99,
+          "line": 106,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "Stepper.Step": [
         {
           "filePath": "src/pages-and-resources/discussions/DiscussionsSettings.jsx",
-          "line": 113,
+          "line": 120,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
           "filePath": "src/pages-and-resources/discussions/DiscussionsSettings.jsx",
-          "line": 119,
+          "line": 133,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.6.4"
         }
       ],
       "Card.Title": [
         {
           "filePath": "src/pages-and-resources/pages/PageCard.jsx",
-          "line": 45,
-          "column": 8,
-          "version": "15.2.2"
+          "line": 74,
+          "column": 10,
+          "version": "16.6.4"
         }
       ],
-      "Form.Check": [
+      "Form.RadioSet": [
         {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 214,
-          "column": 10,
-          "version": "15.2.2"
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 330,
+          "column": 14,
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 243,
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 353,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 253,
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 107,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.6.4"
+        }
+      ],
+      "Form.Radio": [
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 335,
+          "column": 16,
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 344,
-          "column": 14,
-          "version": "15.2.2"
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 338,
+          "column": 16,
+          "version": "16.6.4"
         },
         {
-          "filePath": "src/proctored-exam-settings/ProctoredExamSettings.jsx",
-          "line": 354,
-          "column": 14,
-          "version": "15.2.2"
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 358,
+          "column": 16,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/proctoring/Settings.jsx",
+          "line": 361,
+          "column": 16,
+          "version": "16.6.4"
+        },
+        {
+          "filePath": "src/pages-and-resources/teams/TeamSetEditor.jsx",
+          "line": 114,
+          "column": 18,
+          "version": "16.6.4"
         }
       ]
     }
   },
   {
-    "version": "12.0.5",
+    "version": "16.13.2",
     "name": "@edx/frontend-app-discussions",
     "repository": {
       "type": "git",
@@ -4532,36 +6259,420 @@
     },
     "folderName": "frontend-app-discussions",
     "usages": {
-      "Dropdown": [
+      "TransitionReplace": [
         {
-          "filePath": "src/components/selectable-dropdown/SelectableDropdown.jsx",
-          "line": 10,
+          "filePath": "src/components/FormikErrorFeedback.jsx",
+          "line": 17,
           "column": 4,
-          "version": "12.0.5"
+          "version": "16.13.2"
         }
       ],
-      "Dropdown.Toggle": [
+      "SelectMenu": [
         {
-          "filePath": "src/components/selectable-dropdown/SelectableDropdown.jsx",
-          "line": 11,
-          "column": 6,
-          "version": "12.0.5"
+          "filePath": "src/components/SelectableDropdown.jsx",
+          "line": 12,
+          "column": 4,
+          "version": "16.13.2"
         }
       ],
-      "Dropdown.Menu": [
+      "MenuItem": [
         {
-          "filePath": "src/components/selectable-dropdown/SelectableDropdown.jsx",
-          "line": 14,
+          "filePath": "src/components/SelectableDropdown.jsx",
+          "line": 15,
+          "column": 10,
+          "version": "16.13.2"
+        }
+      ],
+      "Button": [
+        {
+          "filePath": "src/discussions/comments/comment-icons/CommentIcons.jsx",
+          "line": 26,
+          "column": 12,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/comments/comment-icons/CommentIcons.jsx",
+          "line": 30,
+          "column": 12,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/comments/comment/Comment.jsx",
+          "line": 75,
+          "column": 12,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/comments/comment/ResponseEditor.jsx",
+          "line": 20,
+          "column": 8,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/comments/CommentsView.jsx",
+          "line": 68,
+          "column": 14,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post-actions-bar/PostActionsBar.jsx",
+          "line": 21,
           "column": 6,
-          "version": "12.0.5"
+          "version": "16.13.2"
+        }
+      ],
+      "Icon": [
+        {
+          "filePath": "src/discussions/comments/comment-icons/CommentIcons.jsx",
+          "line": 27,
+          "column": 14,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/comments/comment-icons/CommentIcons.jsx",
+          "line": 31,
+          "column": 14,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/common/ActionsDropdown.jsx",
+          "line": 66,
+          "column": 16,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post-filter-bar/PostFilterBar.jsx",
+          "line": 74,
+          "column": 14,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post/PostHeader.jsx",
+          "line": 22,
+          "column": 45,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post/PostHeader.jsx",
+          "line": 23,
+          "column": 47,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post/PostHeader.jsx",
+          "line": 24,
+          "column": 24,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post/PostHeader.jsx",
+          "line": 66,
+          "column": 12,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post/PostLink.jsx",
+          "line": 37,
+          "column": 10,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post/PostLink.jsx",
+          "line": 42,
+          "column": 8,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/topics/topic-group/topic/Topic.jsx",
+          "line": 36,
+          "column": 10,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/topics/topic-group/topic/Topic.jsx",
+          "line": 40,
+          "column": 10,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/topics/topic-group/topic/Topic.jsx",
+          "line": 45,
+          "column": 12,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/topics/topic-search-bar/TopicSearchBar.jsx",
+          "line": 29,
+          "column": 15,
+          "version": "16.13.2"
+        }
+      ],
+      "Form": [
+        {
+          "filePath": "src/discussions/comments/comment/CommentEditor.jsx",
+          "line": 50,
+          "column": 10,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post-editor/PostEditor.jsx",
+          "line": 146,
+          "column": 8,
+          "version": "16.13.2"
+        }
+      ],
+      "StatefulButton": [
+        {
+          "filePath": "src/discussions/comments/comment/CommentEditor.jsx",
+          "line": 66,
+          "column": 14,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/comments/comment/CommentEditor.jsx",
+          "line": 73,
+          "column": 14,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post-editor/PostEditor.jsx",
+          "line": 254,
+          "column": 12,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post-editor/PostEditor.jsx",
+          "line": 261,
+          "column": 12,
+          "version": "16.13.2"
+        }
+      ],
+      "Avatar": [
+        {
+          "filePath": "src/discussions/comments/comment/CommentHeader.jsx",
+          "line": 24,
+          "column": 8,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post/PostHeader.jsx",
+          "line": 44,
+          "column": 6,
+          "version": "16.13.2"
+        }
+      ],
+      "Spinner": [
+        {
+          "filePath": "src/discussions/comments/CommentsView.jsx",
+          "line": 47,
+          "column": 6,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/PostsView.jsx",
+          "line": 61,
+          "column": 10,
+          "version": "16.13.2"
+        }
+      ],
+      "IconButton": [
+        {
+          "filePath": "src/discussions/common/ActionsDropdown.jsx",
+          "line": 35,
+          "column": 8,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post/LikeButton.jsx",
+          "line": 37,
+          "column": 8,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post/Post.jsx",
+          "line": 62,
+          "column": 10,
+          "version": "16.13.2"
+        }
+      ],
+      "ModalPopup": [
+        {
+          "filePath": "src/discussions/common/ActionsDropdown.jsx",
+          "line": 43,
+          "column": 6,
+          "version": "16.13.2"
+        }
+      ],
+      "Dropdown.Divider": [
+        {
+          "filePath": "src/discussions/common/ActionsDropdown.jsx",
+          "line": 53,
+          "column": 17,
+          "version": "16.13.2"
         }
       ],
       "Dropdown.Item": [
         {
-          "filePath": "src/components/selectable-dropdown/SelectableDropdown.jsx",
-          "line": 17,
+          "filePath": "src/discussions/common/ActionsDropdown.jsx",
+          "line": 55,
+          "column": 14,
+          "version": "16.13.2"
+        }
+      ],
+      "Breadcrumb": [
+        {
+          "filePath": "src/discussions/navigation/breadcrumb-menu/BreadcrumbMenu.jsx",
+          "line": 57,
+          "column": 6,
+          "version": "16.13.2"
+        }
+      ],
+      "Nav": [
+        {
+          "filePath": "src/discussions/navigation/navigation-bar/NavigationBar.jsx",
+          "line": 30,
+          "column": 4,
+          "version": "16.13.2"
+        }
+      ],
+      "Nav.Item": [
+        {
+          "filePath": "src/discussions/navigation/navigation-bar/NavigationBar.jsx",
+          "line": 32,
+          "column": 8,
+          "version": "16.13.2"
+        }
+      ],
+      "Nav.Link": [
+        {
+          "filePath": "src/discussions/navigation/navigation-bar/NavigationBar.jsx",
+          "line": 33,
+          "column": 10,
+          "version": "16.13.2"
+        }
+      ],
+      "SearchField": [
+        {
+          "filePath": "src/discussions/posts/post-actions-bar/PostActionsBar.jsx",
+          "line": 15,
+          "column": 6,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/topics/topic-search-bar/TopicSearchBar.jsx",
+          "line": 20,
+          "column": 6,
+          "version": "16.13.2"
+        }
+      ],
+      "Form.Radio": [
+        {
+          "filePath": "src/discussions/posts/post-editor/PostEditor.jsx",
+          "line": 33,
+          "column": 6,
+          "version": "16.13.2"
+        }
+      ],
+      "Card": [
+        {
+          "filePath": "src/discussions/posts/post-editor/PostEditor.jsx",
+          "line": 34,
+          "column": 6,
+          "version": "16.13.2"
+        }
+      ],
+      "Card.Body": [
+        {
+          "filePath": "src/discussions/posts/post-editor/PostEditor.jsx",
+          "line": 35,
+          "column": 8,
+          "version": "16.13.2"
+        }
+      ],
+      "Card.Text": [
+        {
+          "filePath": "src/discussions/posts/post-editor/PostEditor.jsx",
+          "line": 36,
+          "column": 10,
+          "version": "16.13.2"
+        }
+      ],
+      "Form.RadioSet": [
+        {
+          "filePath": "src/discussions/posts/post-editor/PostEditor.jsx",
+          "line": 152,
+          "column": 10,
+          "version": "16.13.2"
+        }
+      ],
+      "Form.Group": [
+        {
+          "filePath": "src/discussions/posts/post-editor/PostEditor.jsx",
+          "line": 175,
+          "column": 10,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post-editor/PostEditor.jsx",
+          "line": 203,
+          "column": 10,
+          "version": "16.13.2"
+        }
+      ],
+      "Form.Control": [
+        {
+          "filePath": "src/discussions/posts/post-editor/PostEditor.jsx",
+          "line": 176,
           "column": 12,
-          "version": "12.0.5"
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post-editor/PostEditor.jsx",
+          "line": 210,
+          "column": 12,
+          "version": "16.13.2"
+        }
+      ],
+      "Form.Checkbox": [
+        {
+          "filePath": "src/discussions/posts/post-editor/PostEditor.jsx",
+          "line": 233,
+          "column": 14,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post-editor/PostEditor.jsx",
+          "line": 242,
+          "column": 14,
+          "version": "16.13.2"
+        }
+      ],
+      "OverlayTrigger": [
+        {
+          "filePath": "src/discussions/posts/post/LikeButton.jsx",
+          "line": 30,
+          "column": 6,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post/Post.jsx",
+          "line": 54,
+          "column": 8,
+          "version": "16.13.2"
+        }
+      ],
+      "Tooltip": [
+        {
+          "filePath": "src/discussions/posts/post/LikeButton.jsx",
+          "line": 32,
+          "column": 10,
+          "version": "16.13.2"
+        },
+        {
+          "filePath": "src/discussions/posts/post/Post.jsx",
+          "line": 57,
+          "column": 12,
+          "version": "16.13.2"
         }
       ]
     }
@@ -4602,7 +6713,7 @@
     }
   },
   {
-    "version": "14.14.1",
+    "version": "16.10.0",
     "name": "@edx/frontend-app-enterprise-public-catalog",
     "repository": {
       "type": "git",
@@ -4610,154 +6721,306 @@
     },
     "folderName": "frontend-app-enterprise-public-catalog",
     "usages": {
-      "Container": [
+      "ModalDialog": [
         {
-          "filePath": "src/components/callToAction/callToAction.jsx",
-          "line": 18,
-          "column": 4,
-          "version": "14.14.1"
-        },
-        {
-          "filePath": "src/components/catalogSelectionDeck/CatalogSelectionDeck.jsx",
-          "line": 13,
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 41,
           "column": 6,
-          "version": "14.14.1"
+          "version": "16.10.0"
+        }
+      ],
+      "ModalDialog.Body": [
+        {
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 50,
+          "column": 8,
+          "version": "16.10.0"
+        }
+      ],
+      "ModalDialog.Hero": [
+        {
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 51,
+          "column": 10,
+          "version": "16.10.0"
+        }
+      ],
+      "Image": [
+        {
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 54,
+          "column": 10,
+          "version": "16.10.0"
         },
         {
           "filePath": "src/components/hero/Hero.jsx",
-          "line": 19,
-          "column": 4,
-          "version": "14.14.1"
+          "line": 23,
+          "column": 10,
+          "version": "16.10.0"
         },
         {
-          "filePath": "src/components/PageWrapper.jsx",
-          "line": 11,
-          "column": 2,
-          "version": "14.14.1"
+          "filePath": "src/components/hero/Hero.jsx",
+          "line": 32,
+          "column": 10,
+          "version": "16.10.0"
         }
       ],
-      "Button": [
+      "ModalDialog.Title": [
         {
-          "filePath": "src/components/callToAction/callToAction.jsx",
-          "line": 24,
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 56,
+          "column": 12,
+          "version": "16.10.0"
+        },
+        {
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 59,
+          "column": 12,
+          "version": "16.10.0"
+        },
+        {
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 64,
+          "column": 14,
+          "version": "16.10.0"
+        },
+        {
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 67,
+          "column": 14,
+          "version": "16.10.0"
+        },
+        {
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 73,
+          "column": 14,
+          "version": "16.10.0"
+        }
+      ],
+      "Badge": [
+        {
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 76,
+          "column": 14,
+          "version": "16.10.0"
+        },
+        {
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 80,
+          "column": 16,
+          "version": "16.10.0"
+        },
+        {
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 85,
+          "column": 16,
+          "version": "16.10.0"
+        },
+        {
+          "filePath": "src/components/catalogSearchResults/CatalogSearchResults.jsx",
+          "line": 146,
+          "column": 17,
+          "version": "16.10.0"
+        },
+        {
+          "filePath": "src/components/catalogSearchResults/CatalogSearchResults.jsx",
+          "line": 150,
+          "column": 17,
+          "version": "16.10.0"
+        },
+        {
+          "filePath": "src/components/catalogSearchResults/CatalogSearchResults.jsx",
+          "line": 154,
+          "column": 17,
+          "version": "16.10.0"
+        },
+        {
+          "filePath": "src/components/catalogSelectionCard/CatalogSelectionCard.jsx",
+          "line": 41,
           "column": 8,
-          "version": "14.14.1"
+          "version": "16.10.0"
+        }
+      ],
+      "ModalDialog.Footer": [
+        {
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 102,
+          "column": 8,
+          "version": "16.10.0"
+        }
+      ],
+      "ActionRow": [
+        {
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 103,
+          "column": 10,
+          "version": "16.10.0"
         }
       ],
       "Hyperlink": [
         {
-          "filePath": "src/components/catalogPage/CatalogPage.jsx",
-          "line": 31,
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 104,
+          "column": 12,
+          "version": "16.10.0"
+        }
+      ],
+      "Button": [
+        {
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 111,
           "column": 14,
-          "version": "14.14.1"
+          "version": "16.10.0"
         },
         {
-          "filePath": "src/components/catalogPage/CatalogPage.jsx",
-          "line": 36,
-          "column": 14,
-          "version": "14.14.1"
+          "filePath": "src/components/catalogSearchResults/CatalogSearchResults.jsx",
+          "line": 125,
+          "column": 8,
+          "version": "16.10.0"
+        }
+      ],
+      "Icon": [
+        {
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 114,
+          "column": 16,
+          "version": "16.10.0"
+        }
+      ],
+      "ModalDialog.CloseButton": [
+        {
+          "filePath": "src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx",
+          "line": 117,
+          "column": 12,
+          "version": "16.10.0"
         }
       ],
       "Alert": [
         {
-          "filePath": "src/components/catalogs/CatalogSearchResults.jsx",
-          "line": 60,
+          "filePath": "src/components/catalogSearchResults/CatalogSearchResults.jsx",
+          "line": 63,
           "column": 6,
-          "version": "14.14.1"
+          "version": "16.10.0"
         },
         {
-          "filePath": "src/components/catalogs/CatalogSearchResults.jsx",
-          "line": 73,
+          "filePath": "src/components/catalogSearchResults/CatalogSearchResults.jsx",
+          "line": 76,
           "column": 6,
-          "version": "14.14.1"
+          "version": "16.10.0"
         }
       ],
       "DataTable": [
         {
-          "filePath": "src/components/catalogs/CatalogSearchResults.jsx",
-          "line": 105,
+          "filePath": "src/components/catalogSearchResults/CatalogSearchResults.jsx",
+          "line": 182,
           "column": 8,
-          "version": "14.14.1"
+          "version": "16.10.0"
         }
       ],
       "DataTable.TableControlBar": [
         {
-          "filePath": "src/components/catalogs/CatalogSearchResults.jsx",
-          "line": 112,
+          "filePath": "src/components/catalogSearchResults/CatalogSearchResults.jsx",
+          "line": 189,
           "column": 10,
-          "version": "14.14.1"
+          "version": "16.10.0"
         }
       ],
       "DataTable.Table": [
         {
-          "filePath": "src/components/catalogs/CatalogSearchResults.jsx",
-          "line": 113,
+          "filePath": "src/components/catalogSearchResults/CatalogSearchResults.jsx",
+          "line": 190,
           "column": 10,
-          "version": "14.14.1"
+          "version": "16.10.0"
         }
       ],
       "DataTable.TableFooter": [
         {
-          "filePath": "src/components/catalogs/CatalogSearchResults.jsx",
-          "line": 114,
+          "filePath": "src/components/catalogSearchResults/CatalogSearchResults.jsx",
+          "line": 191,
           "column": 10,
-          "version": "14.14.1"
+          "version": "16.10.0"
         }
       ],
       "DataTable.RowStatus": [
         {
-          "filePath": "src/components/catalogs/CatalogSearchResults.jsx",
-          "line": 115,
+          "filePath": "src/components/catalogSearchResults/CatalogSearchResults.jsx",
+          "line": 192,
           "column": 12,
-          "version": "14.14.1"
+          "version": "16.10.0"
         }
       ],
-      "Form.Checkbox": [
+      "Form.Radio": [
         {
           "filePath": "src/components/catalogSelectionCard/CatalogSelectionCard.jsx",
-          "line": 22,
+          "line": 25,
           "column": 4,
-          "version": "14.14.1"
+          "version": "16.10.0"
         }
       ],
       "Card": [
         {
           "filePath": "src/components/catalogSelectionCard/CatalogSelectionCard.jsx",
-          "line": 32,
+          "line": 38,
           "column": 2,
-          "version": "14.14.1"
+          "version": "16.10.0"
         }
       ],
       "Card.Body": [
         {
           "filePath": "src/components/catalogSelectionCard/CatalogSelectionCard.jsx",
-          "line": 33,
+          "line": 39,
           "column": 4,
-          "version": "14.14.1"
+          "version": "16.10.0"
         }
       ],
       "Card.Title": [
         {
           "filePath": "src/components/catalogSelectionCard/CatalogSelectionCard.jsx",
-          "line": 34,
+          "line": 40,
           "column": 6,
-          "version": "14.14.1"
+          "version": "16.10.0"
         }
       ],
       "Card.Text": [
         {
           "filePath": "src/components/catalogSelectionCard/CatalogSelectionCard.jsx",
-          "line": 37,
+          "line": 50,
           "column": 6,
-          "version": "14.14.1"
+          "version": "16.10.0"
+        }
+      ],
+      "Container": [
+        {
+          "filePath": "src/components/catalogSelectionDeck/CatalogSelectionDeck.jsx",
+          "line": 18,
+          "column": 6,
+          "version": "16.10.0"
+        },
+        {
+          "filePath": "src/components/hero/Hero.jsx",
+          "line": 19,
+          "column": 4,
+          "version": "16.10.0"
+        },
+        {
+          "filePath": "src/components/PageWrapper.jsx",
+          "line": 11,
+          "column": 2,
+          "version": "16.10.0"
+        },
+        {
+          "filePath": "src/components/subheader/subheader.jsx",
+          "line": 11,
+          "column": 4,
+          "version": "16.10.0"
         }
       ],
       "CardDeck": [
         {
           "filePath": "src/components/catalogSelectionDeck/CatalogSelectionDeck.jsx",
-          "line": 15,
+          "line": 20,
           "column": 8,
-          "version": "14.14.1"
+          "version": "16.10.0"
         }
       ],
       "Large": [
@@ -4765,21 +7028,7 @@
           "filePath": "src/components/hero/Hero.jsx",
           "line": 22,
           "column": 8,
-          "version": "14.14.1"
-        }
-      ],
-      "Image": [
-        {
-          "filePath": "src/components/hero/Hero.jsx",
-          "line": 23,
-          "column": 10,
-          "version": "14.14.1"
-        },
-        {
-          "filePath": "src/components/hero/Hero.jsx",
-          "line": 32,
-          "column": 10,
-          "version": "14.14.1"
+          "version": "16.10.0"
         }
       ],
       "ExtraLarge": [
@@ -4787,7 +7036,7 @@
           "filePath": "src/components/hero/Hero.jsx",
           "line": 31,
           "column": 8,
-          "version": "14.14.1"
+          "version": "16.10.0"
         }
       ]
     }
@@ -4803,133 +7052,41 @@
     "usages": {
       "Alert": [
         {
-          "filePath": "src/components/BulkManagementTab/BulkManagementAlerts.jsx",
-          "line": 19,
+          "filePath": "src/components/BulkManagementHistoryView/BulkManagementAlerts.jsx",
+          "line": 21,
           "column": 4,
           "version": "14.16.4"
         },
         {
-          "filePath": "src/components/BulkManagementTab/BulkManagementAlerts.jsx",
-          "line": 26,
+          "filePath": "src/components/BulkManagementHistoryView/BulkManagementAlerts.jsx",
+          "line": 28,
           "column": 4,
-          "version": "14.16.4"
-        }
-      ],
-      "Form": [
-        {
-          "filePath": "src/components/BulkManagementTab/FileUploadForm.jsx",
-          "line": 61,
-          "column": 8,
-          "version": "14.16.4"
-        }
-      ],
-      "FormGroup": [
-        {
-          "filePath": "src/components/BulkManagementTab/FileUploadForm.jsx",
-          "line": 62,
-          "column": 10,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/components/GradesTab/ScoreViewInput.jsx",
-          "line": 15,
-          "column": 2,
-          "version": "14.16.4"
-        }
-      ],
-      "FormControl": [
-        {
-          "filePath": "src/components/BulkManagementTab/FileUploadForm.jsx",
-          "line": 63,
-          "column": 12,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/components/GradesTab/ScoreViewInput.jsx",
-          "line": 17,
-          "column": 4,
-          "version": "14.16.4"
-        }
-      ],
-      "Button": [
-        {
-          "filePath": "src/components/BulkManagementTab/FileUploadForm.jsx",
-          "line": 73,
-          "column": 8,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/components/GradebookFilters/AssignmentGradeFilter/index.jsx",
-          "line": 55,
-          "column": 10,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/components/GradebookFilters/CourseGradeFilter/index.jsx",
-          "line": 62,
-          "column": 10,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/components/GradesTab/EditModal/index.jsx",
-          "line": 68,
-          "column": 10,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/components/GradesTab/FilterBadges/FilterBadge.jsx",
-          "line": 32,
-          "column": 6,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/components/GradesTab/GradebookTable/GradeButton.jsx",
-          "line": 42,
-          "column": 8,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/components/GradesTab/PageButtons/index.jsx",
-          "line": 31,
-          "column": 8,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/components/GradesTab/PageButtons/index.jsx",
-          "line": 39,
-          "column": 8,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/components/GradesTab/SearchControls.jsx",
-          "line": 37,
-          "column": 10,
           "version": "14.16.4"
         }
       ],
       "Table": [
         {
-          "filePath": "src/components/BulkManagementTab/HistoryTable.jsx",
-          "line": 39,
+          "filePath": "src/components/BulkManagementHistoryView/HistoryTable.jsx",
+          "line": 34,
           "column": 4,
           "version": "14.16.4"
         },
         {
-          "filePath": "src/components/GradesTab/EditModal/OverrideTable/index.jsx",
-          "line": 33,
+          "filePath": "src/components/GradesView/EditModal/OverrideTable/index.jsx",
+          "line": 30,
           "column": 4,
           "version": "14.16.4"
         },
         {
-          "filePath": "src/components/GradesTab/GradebookTable/index.jsx",
-          "line": 61,
+          "filePath": "src/components/GradesView/GradebookTable/index.jsx",
+          "line": 66,
           "column": 10,
           "version": "14.16.4"
         }
       ],
       "Hyperlink": [
         {
-          "filePath": "src/components/BulkManagementTab/ResultsSummary.jsx",
+          "filePath": "src/components/BulkManagementHistoryView/ResultsSummary.jsx",
           "line": 21,
           "column": 2,
           "version": "14.16.4"
@@ -4943,52 +7100,144 @@
       ],
       "Icon": [
         {
-          "filePath": "src/components/BulkManagementTab/ResultsSummary.jsx",
+          "filePath": "src/components/BulkManagementHistoryView/ResultsSummary.jsx",
           "line": 28,
           "column": 4,
           "version": "14.16.4"
         },
         {
           "filePath": "src/components/GradebookFilters/index.jsx",
-          "line": 54,
+          "line": 61,
           "column": 14,
           "version": "14.16.4"
         },
         {
-          "filePath": "src/components/GradesTab/BulkManagementControls.jsx",
-          "line": 15,
-          "column": 13,
+          "filePath": "src/components/GradesView/FilterMenuToggle.jsx",
+          "line": 22,
+          "column": 4,
           "version": "14.16.4"
         },
         {
-          "filePath": "src/components/GradesTab/BulkManagementControls.jsx",
-          "line": 16,
-          "column": 13,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/components/GradesTab/GradebookTable/LabelReplacements.jsx",
-          "line": 31,
+          "filePath": "src/components/GradesView/GradebookTable/LabelReplacements.jsx",
+          "line": 36,
           "column": 10,
           "version": "14.16.4"
         },
         {
-          "filePath": "src/components/GradesTab/SearchControls.jsx",
+          "filePath": "src/components/GradesView/SpinnerIcon.jsx",
+          "line": 17,
+          "column": 4,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/NetworkButton/index.jsx",
           "line": 42,
+          "column": 16,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/NetworkButton/index.jsx",
+          "line": 43,
+          "column": 16,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/NetworkButton/test.jsx",
+          "line": 54,
+          "column": 20,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/NetworkButton/test.jsx",
+          "line": 55,
+          "column": 20,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/NetworkButton/test.jsx",
+          "line": 63,
+          "column": 20,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/NetworkButton/test.jsx",
+          "line": 64,
+          "column": 20,
+          "version": "14.16.4"
+        }
+      ],
+      "Button": [
+        {
+          "filePath": "src/components/GradebookFilters/AssignmentGradeFilter/index.jsx",
+          "line": 59,
+          "column": 10,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/GradebookFilters/CourseGradeFilter/index.jsx",
+          "line": 66,
+          "column": 10,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/GradebookHeader/index.jsx",
+          "line": 52,
           "column": 12,
           "version": "14.16.4"
         },
         {
-          "filePath": "src/components/GradesTab/SpinnerIcon.jsx",
+          "filePath": "src/components/GradebookHeader/test.jsx",
+          "line": 78,
+          "column": 10,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/GradebookHeader/test.jsx",
+          "line": 92,
+          "column": 10,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/GradesView/EditModal/index.jsx",
+          "line": 68,
+          "column": 10,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/GradesView/FilterBadges/FilterBadge.jsx",
+          "line": 36,
+          "column": 6,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/GradesView/FilterMenuToggle.jsx",
           "line": 17,
-          "column": 4,
+          "column": 2,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/GradesView/GradebookTable/GradeButton.jsx",
+          "line": 42,
+          "column": 8,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/GradesView/PageButtons/index.jsx",
+          "line": 33,
+          "column": 8,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/GradesView/PageButtons/index.jsx",
+          "line": 41,
+          "column": 8,
           "version": "14.16.4"
         }
       ],
       "Collapsible": [
         {
           "filePath": "src/components/GradebookFilters/index.jsx",
-          "line": 42,
+          "line": 44,
           "column": 4,
           "version": "14.16.4"
         }
@@ -4996,7 +7245,7 @@
       "IconButton": [
         {
           "filePath": "src/components/GradebookFilters/index.jsx",
-          "line": 55,
+          "line": 62,
           "column": 10,
           "version": "14.16.4"
         }
@@ -5004,7 +7253,7 @@
       "Form.Checkbox": [
         {
           "filePath": "src/components/GradebookFilters/index.jsx",
-          "line": 82,
+          "line": 89,
           "column": 10,
           "version": "14.16.4"
         }
@@ -5051,148 +7300,134 @@
           "version": "14.16.4"
         },
         {
-          "filePath": "src/components/GradesTab/EditModal/OverrideTable/AdjustedGradeInput.jsx",
+          "filePath": "src/components/GradesView/EditModal/OverrideTable/AdjustedGradeInput.jsx",
           "line": 29,
           "column": 8,
           "version": "14.16.4"
         },
         {
-          "filePath": "src/components/GradesTab/EditModal/OverrideTable/ReasonInput.jsx",
+          "filePath": "src/components/GradesView/EditModal/OverrideTable/ReasonInput.jsx",
           "line": 31,
           "column": 6,
           "version": "14.16.4"
         }
       ],
-      "StatefulButton": [
-        {
-          "filePath": "src/components/GradesTab/BulkManagementControls.jsx",
-          "line": 65,
-          "column": 8,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/components/GradesTab/BulkManagementControls.jsx",
-          "line": 69,
-          "column": 8,
-          "version": "14.16.4"
-        }
-      ],
       "Modal": [
         {
-          "filePath": "src/components/GradesTab/EditModal/index.jsx",
-          "line": 47,
+          "filePath": "src/components/GradesView/EditModal/index.jsx",
+          "line": 49,
           "column": 6,
           "version": "14.16.4"
         }
       ],
       "StatusAlert": [
         {
-          "filePath": "src/components/GradesTab/EditModal/index.jsx",
-          "line": 54,
+          "filePath": "src/components/GradesView/EditModal/index.jsx",
+          "line": 56,
           "column": 12,
           "version": "14.16.4"
         },
         {
-          "filePath": "src/components/GradesTab/StatusAlerts.jsx",
-          "line": 35,
+          "filePath": "src/components/GradesView/StatusAlerts.jsx",
+          "line": 43,
           "column": 8,
           "version": "14.16.4"
         },
         {
-          "filePath": "src/components/GradesTab/StatusAlerts.jsx",
-          "line": 41,
+          "filePath": "src/components/GradesView/StatusAlerts.jsx",
+          "line": 49,
           "column": 8,
           "version": "14.16.4"
         }
       ],
       "OverlayTrigger": [
         {
-          "filePath": "src/components/GradesTab/GradebookTable/LabelReplacements.jsx",
-          "line": 22,
+          "filePath": "src/components/GradesView/GradebookTable/LabelReplacements.jsx",
+          "line": 23,
           "column": 4,
           "version": "14.16.4"
         }
       ],
       "Tooltip": [
         {
-          "filePath": "src/components/GradesTab/GradebookTable/LabelReplacements.jsx",
-          "line": 26,
-          "column": 16,
+          "filePath": "src/components/GradesView/GradebookTable/LabelReplacements.jsx",
+          "line": 28,
+          "column": 8,
+          "version": "14.16.4"
+        }
+      ],
+      "Form": [
+        {
+          "filePath": "src/components/GradesView/ImportGradesButton.jsx",
+          "line": 62,
+          "column": 8,
+          "version": "14.16.4"
+        }
+      ],
+      "FormGroup": [
+        {
+          "filePath": "src/components/GradesView/ImportGradesButton.jsx",
+          "line": 63,
+          "column": 10,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/GradesView/ScoreViewInput.jsx",
+          "line": 17,
+          "column": 2,
+          "version": "14.16.4"
+        }
+      ],
+      "FormControl": [
+        {
+          "filePath": "src/components/GradesView/ImportGradesButton.jsx",
+          "line": 64,
+          "column": 12,
+          "version": "14.16.4"
+        },
+        {
+          "filePath": "src/components/GradesView/ScoreViewInput.jsx",
+          "line": 19,
+          "column": 4,
+          "version": "14.16.4"
+        }
+      ],
+      "Toast": [
+        {
+          "filePath": "src/components/GradesView/ImportSuccessToast.jsx",
+          "line": 40,
+          "column": 6,
           "version": "14.16.4"
         }
       ],
       "FormLabel": [
         {
-          "filePath": "src/components/GradesTab/ScoreViewInput.jsx",
-          "line": 16,
+          "filePath": "src/components/GradesView/ScoreViewInput.jsx",
+          "line": 18,
           "column": 4,
           "version": "14.16.4"
         }
       ],
       "SearchField": [
         {
-          "filePath": "src/components/GradesTab/SearchControls.jsx",
-          "line": 45,
-          "column": 12,
+          "filePath": "src/components/GradesView/SearchControls.jsx",
+          "line": 38,
+          "column": 8,
           "version": "14.16.4"
         }
       ],
-      "Tabs": [
+      "StatefulButton": [
         {
-          "filePath": "src/containers/GradebookPage/index.jsx",
-          "line": 54,
-          "column": 10,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/containers/GradebookPage/test.jsx",
-          "line": 100,
-          "column": 12,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/containers/GradebookPage/test.jsx",
-          "line": 111,
-          "column": 12,
-          "version": "14.16.4"
-        }
-      ],
-      "Tab": [
-        {
-          "filePath": "src/containers/GradebookPage/index.jsx",
-          "line": 55,
-          "column": 12,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/containers/GradebookPage/index.jsx",
-          "line": 59,
-          "column": 14,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/containers/GradebookPage/test.jsx",
-          "line": 101,
-          "column": 14,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/containers/GradebookPage/test.jsx",
-          "line": 112,
-          "column": 14,
-          "version": "14.16.4"
-        },
-        {
-          "filePath": "src/containers/GradebookPage/test.jsx",
-          "line": 115,
-          "column": 14,
+          "filePath": "src/components/NetworkButton/index.jsx",
+          "line": 53,
+          "column": 6,
           "version": "14.16.4"
         }
       ]
     }
   },
   {
-    "version": "14.6.1",
+    "version": "16.3.1",
     "name": "frontend-app-learner-portal-enterprise",
     "repository": {
       "type": "git",
@@ -5202,126 +7437,168 @@
     "usages": {
       "Container": [
         {
-          "filePath": "src/components/course/Course.jsx",
-          "line": 67,
+          "filePath": "src/components/app/LoginRefresh.jsx",
+          "line": 29,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/course/Course.jsx",
-          "line": 85,
+          "line": 75,
+          "column": 6,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/course/Course.jsx",
+          "line": 93,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/course/CourseEnrollmentFailedAlert.jsx",
+          "line": 59,
+          "column": 4,
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/course/CourseHeader.jsx",
-          "line": 43,
+          "line": 42,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
-          "filePath": "src/components/course/CourseHeader.jsx",
-          "line": 64,
+          "filePath": "src/components/dashboard/Dashboard.jsx",
+          "line": 44,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/Dashboard.jsx",
           "line": 47,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/enterprise-banner/EnterpriseBanner.jsx",
-          "line": 11,
+          "line": 14,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/enterprise-page/EnterprisePage.jsx",
           "line": 27,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/enterprise-user-subsidy/ActivateLicenseAlert.jsx",
+          "line": 16,
+          "column": 4,
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/enterprise-user-subsidy/UserSubsidy.jsx",
-          "line": 63,
+          "line": 73,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/license-activation/LicenseActivation.jsx",
           "line": 37,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/license-activation/LicenseActivation.jsx",
-          "line": 58,
+          "line": 51,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/NotFoundPage/index.jsx",
           "line": 15,
           "column": 4,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/search/SearchResults.jsx",
           "line": 60,
           "column": 4,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/site-header/SiteHeader.jsx",
           "line": 45,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SkillsQuiz.jsx",
+          "line": 22,
+          "column": 6,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SkillsQuizStepper.jsx",
+          "line": 132,
+          "column": 10,
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/system-wide-banner/SystemWideWarningBanner.jsx",
           "line": 13,
           "column": 4,
-          "version": "14.6.1"
+          "version": "16.3.1"
         }
       ],
       "Row": [
         {
           "filePath": "src/components/course/Course.jsx",
-          "line": 86,
+          "line": 94,
           "column": 10,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/course/CourseHeader.jsx",
+          "line": 43,
+          "column": 8,
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/course/CourseSidebarListItem.jsx",
           "line": 12,
           "column": 4,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/Dashboard.jsx",
-          "line": 49,
+          "line": 48,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx",
           "line": 162,
           "column": 12,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/search/SearchResults.jsx",
           "line": 81,
           "column": 12,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SkillsQuiz.jsx",
+          "line": 23,
+          "column": 8,
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/system-wide-banner/SystemWideWarningBanner.jsx",
           "line": 14,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
         }
       ],
       "Hyperlink": [
@@ -5329,119 +7606,133 @@
           "filePath": "src/components/course/CourseAssociatedPrograms.jsx",
           "line": 32,
           "column": 14,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/course/CourseMainContent.jsx",
           "line": 77,
           "column": 16,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/course/CourseSidebar.jsx",
           "line": 71,
           "column": 16,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/course/CourseSidebar.jsx",
           "line": 91,
           "column": 14,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/course/CreatedBy.jsx",
           "line": 38,
           "column": 14,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/course/CreatedBy.jsx",
           "line": 56,
           "column": 16,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/layout/Layout.jsx",
           "line": 36,
           "column": 12,
-          "version": "14.6.1"
+          "version": "16.3.1"
         }
       ],
-      "StatusAlert": [
+      "Alert": [
         {
-          "filePath": "src/components/course/CourseHeader.jsx",
-          "line": 44,
-          "column": 8,
-          "version": "14.6.1"
+          "filePath": "src/components/course/CourseEnrollmentFailedAlert.jsx",
+          "line": 60,
+          "column": 6,
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/Dashboard.jsx",
-          "line": 28,
-          "column": 8,
-          "version": "14.6.1"
+          "line": 35,
+          "column": 4,
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/EmailSettingsModal.jsx",
-          "line": 124,
+          "line": 120,
           "column": 14,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/ModalError.jsx",
-          "line": 11,
+          "line": 10,
           "column": 4,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/move-to-in-progress-modal/ModalError.jsx",
-          "line": 11,
+          "line": 10,
           "column": 4,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
-          "filePath": "src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx",
-          "line": 65,
-          "column": 4,
-          "version": "14.6.1"
-        },
-        {
-          "filePath": "src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx",
-          "line": 85,
+          "filePath": "src/components/enterprise-user-subsidy/ActivateLicenseAlert.jsx",
+          "line": 17,
           "column": 6,
-          "version": "14.6.1"
-        },
-        {
-          "filePath": "src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx",
-          "line": 108,
-          "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/license-activation/LicenseActivation.jsx",
           "line": 38,
           "column": 10,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
-          "filePath": "src/components/search/SearchError.jsx",
-          "line": 24,
-          "column": 4,
-          "version": "14.6.1"
+          "filePath": "src/components/system-wide-banner/SystemWideWarningBanner.jsx",
+          "line": 9,
+          "column": 2,
+          "version": "16.3.1"
+        }
+      ],
+      "Col": [
+        {
+          "filePath": "src/components/course/CourseHeader.jsx",
+          "line": 44,
+          "column": 10,
+          "version": "16.3.1"
         },
         {
-          "filePath": "src/components/search/SearchNoResults.jsx",
-          "line": 27,
+          "filePath": "src/components/course/CourseHeader.jsx",
+          "line": 110,
+          "column": 12,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/course/CourseSidebarListItem.jsx",
+          "line": 13,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/course/CourseSidebarListItem.jsx",
+          "line": 17,
+          "column": 6,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/system-wide-banner/SystemWideWarningBanner.jsx",
+          "line": 15,
+          "column": 8,
+          "version": "16.3.1"
         }
       ],
       "Breadcrumb": [
         {
           "filePath": "src/components/course/CourseHeader.jsx",
-          "line": 69,
+          "line": 47,
           "column": 16,
-          "version": "14.6.1"
+          "version": "16.3.1"
         }
       ],
       "Button": [
@@ -5449,43 +7740,79 @@
           "filePath": "src/components/course/CourseRunSelector.jsx",
           "line": 27,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/course/CourseRunSelector.jsx",
           "line": 54,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/course/CourseSkills.jsx",
           "line": 59,
           "column": 10,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/UpcomingCourseCard.jsx",
           "line": 10,
           "column": 4,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/main-content/DashboardMainContent.jsx",
           "line": 20,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/enterprise-banner/EnterpriseBanner.jsx",
+          "line": 21,
+          "column": 12,
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/integration-warning-modal/IntegrationWarningModal.jsx",
           "line": 38,
           "column": 10,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/preview-expand/PreviewExpand.jsx",
           "line": 21,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SkillsQuizStepper.jsx",
+          "line": 112,
+          "column": 16,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SkillsQuizStepper.jsx",
+          "line": 116,
+          "column": 16,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SkillsQuizStepper.jsx",
+          "line": 123,
+          "column": 16,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SkillsQuizStepper.jsx",
+          "line": 127,
+          "column": 16,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SkillsQuizStepper.jsx",
+          "line": 195,
+          "column": 16,
+          "version": "16.3.1"
         }
       ],
       "Input": [
@@ -5493,33 +7820,13 @@
           "filePath": "src/components/course/CourseRunSelector.jsx",
           "line": 38,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/EmailSettingsModal.jsx",
-          "line": 141,
+          "line": 125,
           "column": 14,
-          "version": "14.6.1"
-        }
-      ],
-      "Col": [
-        {
-          "filePath": "src/components/course/CourseSidebarListItem.jsx",
-          "line": 13,
-          "column": 6,
-          "version": "14.6.1"
-        },
-        {
-          "filePath": "src/components/course/CourseSidebarListItem.jsx",
-          "line": 17,
-          "column": 6,
-          "version": "14.6.1"
-        },
-        {
-          "filePath": "src/components/system-wide-banner/SystemWideWarningBanner.jsx",
-          "line": 15,
-          "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         }
       ],
       "OverlayTrigger": [
@@ -5527,7 +7834,7 @@
           "filePath": "src/components/course/CourseSkills.jsx",
           "line": 28,
           "column": 10,
-          "version": "14.6.1"
+          "version": "16.3.1"
         }
       ],
       "Popover": [
@@ -5535,7 +7842,7 @@
           "filePath": "src/components/course/CourseSkills.jsx",
           "line": 33,
           "column": 14,
-          "version": "14.6.1"
+          "version": "16.3.1"
         }
       ],
       "Popover.Title": [
@@ -5543,7 +7850,7 @@
           "filePath": "src/components/course/CourseSkills.jsx",
           "line": 34,
           "column": 16,
-          "version": "14.6.1"
+          "version": "16.3.1"
         }
       ],
       "Popover.Content": [
@@ -5551,7 +7858,7 @@
           "filePath": "src/components/course/CourseSkills.jsx",
           "line": 35,
           "column": 16,
-          "version": "14.6.1"
+          "version": "16.3.1"
         }
       ],
       "Badge": [
@@ -5559,57 +7866,63 @@
           "filePath": "src/components/course/CourseSkills.jsx",
           "line": 46,
           "column": 12,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/sidebar/SubscriptionSummaryCard.jsx",
           "line": 38,
           "column": 10,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SearchCourseCard.jsx",
+          "line": 198,
+          "column": 28,
+          "version": "16.3.1"
         }
       ],
       "Modal": [
         {
           "filePath": "src/components/course/EnrollModal.jsx",
-          "line": 37,
+          "line": 43,
           "column": 4,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/EmailSettingsModal.jsx",
-          "line": 119,
+          "line": 115,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/MarkCompleteModal.jsx",
           "line": 76,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/move-to-in-progress-modal/MoveToInProgressModal.jsx",
           "line": 67,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/SubscriptionExpirationModal.jsx",
-          "line": 103,
+          "line": 104,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/SubscriptionExpirationModal.jsx",
-          "line": 129,
+          "line": 139,
           "column": 4,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/integration-warning-modal/IntegrationWarningModal.jsx",
           "line": 29,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
         }
       ],
       "Dropdown": [
@@ -5617,13 +7930,19 @@
           "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx",
           "line": 146,
           "column": 10,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/site-header/AvatarDropdown.jsx",
           "line": 14,
           "column": 4,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/GoalDropdown.jsx",
+          "line": 20,
+          "column": 4,
+          "version": "16.3.1"
         }
       ],
       "Dropdown.Toggle": [
@@ -5631,13 +7950,19 @@
           "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx",
           "line": 147,
           "column": 12,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/site-header/AvatarDropdown.jsx",
           "line": 15,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/GoalDropdown.jsx",
+          "line": 21,
+          "column": 6,
+          "version": "16.3.1"
         }
       ],
       "Dropdown.Menu": [
@@ -5645,13 +7970,19 @@
           "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx",
           "line": 153,
           "column": 12,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/site-header/AvatarDropdown.jsx",
           "line": 18,
           "column": 6,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/GoalDropdown.jsx",
+          "line": 24,
+          "column": 6,
+          "version": "16.3.1"
         }
       ],
       "Dropdown.Item": [
@@ -5659,63 +7990,121 @@
           "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx",
           "line": 155,
           "column": 16,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/site-header/AvatarDropdown.jsx",
           "line": 23,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/site-header/AvatarDropdown.jsx",
           "line": 25,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/site-header/AvatarDropdown.jsx",
           "line": 37,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/site-header/AvatarDropdown.jsx",
           "line": 38,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/site-header/AvatarDropdown.jsx",
           "line": 39,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/site-header/AvatarDropdown.jsx",
           "line": 41,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/GoalDropdown.jsx",
+          "line": 26,
+          "column": 10,
+          "version": "16.3.1"
         }
       ],
       "StatefulButton": [
         {
           "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/EmailSettingsModal.jsx",
-          "line": 158,
+          "line": 142,
           "column": 10,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/MarkCompleteModal.jsx",
           "line": 80,
           "column": 10,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/move-to-in-progress-modal/MoveToInProgressModal.jsx",
           "line": 71,
           "column": 10,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        }
+      ],
+      "Alert.Link": [
+        {
+          "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/ModalError.jsx",
+          "line": 11,
+          "column": 21,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/dashboard/main-content/course-enrollments/course-cards/move-to-in-progress-modal/ModalError.jsx",
+          "line": 11,
+          "column": 42,
+          "version": "16.3.1"
+        }
+      ],
+      "StatusAlert": [
+        {
+          "filePath": "src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx",
+          "line": 65,
+          "column": 4,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx",
+          "line": 85,
+          "column": 6,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx",
+          "line": 108,
+          "column": 6,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/search/SearchError.jsx",
+          "line": 24,
+          "column": 4,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/search/SearchNoResults.jsx",
+          "line": 27,
+          "column": 6,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SearchCourseCard.jsx",
+          "line": 218,
+          "column": 10,
+          "version": "16.3.1"
         }
       ],
       "Collapsible": [
@@ -5723,7 +8112,7 @@
           "filePath": "src/components/dashboard/main-content/course-enrollments/CourseSection.jsx",
           "line": 94,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         }
       ],
       "MailtoLink": [
@@ -5731,13 +8120,13 @@
           "filePath": "src/components/dashboard/sidebar/DashboardSidebar.jsx",
           "line": 36,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/dashboard/SubscriptionExpirationModal.jsx",
-          "line": 43,
+          "line": 44,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         }
       ],
       "Card": [
@@ -5745,13 +8134,31 @@
           "filePath": "src/components/dashboard/sidebar/SidebarCard.jsx",
           "line": 11,
           "column": 2,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/search/SearchCourseCard.jsx",
-          "line": 56,
+          "line": 66,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/JobCardComponent.jsx",
+          "line": 17,
+          "column": 8,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SearchCourseCard.jsx",
+          "line": 137,
+          "column": 14,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SelectJobCard.jsx",
+          "line": 41,
+          "column": 14,
+          "version": "16.3.1"
         }
       ],
       "Card.Body": [
@@ -5759,13 +8166,31 @@
           "filePath": "src/components/dashboard/sidebar/SidebarCard.jsx",
           "line": 12,
           "column": 4,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/search/SearchCourseCard.jsx",
-          "line": 86,
+          "line": 96,
           "column": 10,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/JobCardComponent.jsx",
+          "line": 18,
+          "column": 10,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SearchCourseCard.jsx",
+          "line": 168,
+          "column": 16,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SelectJobCard.jsx",
+          "line": 42,
+          "column": 16,
+          "version": "16.3.1"
         }
       ],
       "Card.Title": [
@@ -5773,35 +8198,65 @@
           "filePath": "src/components/dashboard/sidebar/SidebarCard.jsx",
           "line": 13,
           "column": 16,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/search/SearchCourseCard.jsx",
-          "line": 87,
+          "line": 97,
           "column": 12,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/JobCardComponent.jsx",
+          "line": 19,
+          "column": 12,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SearchCourseCard.jsx",
+          "line": 169,
+          "column": 18,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SelectJobCard.jsx",
+          "line": 43,
+          "column": 18,
+          "version": "16.3.1"
         }
       ],
       "Card.Img": [
         {
           "filePath": "src/components/search/SearchCourseCard.jsx",
-          "line": 58,
+          "line": 68,
           "column": 12,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/search/SearchCourseCard.jsx",
-          "line": 66,
+          "line": 76,
           "column": 12,
-          "version": "14.6.1"
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SearchCourseCard.jsx",
+          "line": 139,
+          "column": 18,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SearchCourseCard.jsx",
+          "line": 147,
+          "column": 18,
+          "version": "16.3.1"
         }
       ],
       "Card.Footer": [
         {
           "filePath": "src/components/search/SearchCourseCard.jsx",
-          "line": 110,
+          "line": 120,
           "column": 10,
-          "version": "14.6.1"
+          "version": "16.3.1"
         }
       ],
       "Dropdown.Header": [
@@ -5809,7 +8264,7 @@
           "filePath": "src/components/site-header/AvatarDropdown.jsx",
           "line": 22,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         }
       ],
       "Dropdown.Divider": [
@@ -5817,21 +8272,89 @@
           "filePath": "src/components/site-header/AvatarDropdown.jsx",
           "line": 36,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         },
         {
           "filePath": "src/components/site-header/AvatarDropdown.jsx",
           "line": 40,
           "column": 8,
-          "version": "14.6.1"
+          "version": "16.3.1"
         }
       ],
-      "Alert": [
+      "Form.Group": [
         {
-          "filePath": "src/components/system-wide-banner/SystemWideWarningBanner.jsx",
-          "line": 9,
-          "column": 2,
-          "version": "14.6.1"
+          "filePath": "src/components/skills-quiz/SelectJobCard.jsx",
+          "line": 26,
+          "column": 6,
+          "version": "16.3.1"
+        }
+      ],
+      "Form.RadioSet": [
+        {
+          "filePath": "src/components/skills-quiz/SelectJobCard.jsx",
+          "line": 27,
+          "column": 8,
+          "version": "16.3.1"
+        }
+      ],
+      "Form.Radio": [
+        {
+          "filePath": "src/components/skills-quiz/SelectJobCard.jsx",
+          "line": 48,
+          "column": 20,
+          "version": "16.3.1"
+        }
+      ],
+      "Stepper": [
+        {
+          "filePath": "src/components/skills-quiz/SkillsQuizStepper.jsx",
+          "line": 102,
+          "column": 6,
+          "version": "16.3.1"
+        }
+      ],
+      "FullscreenModal": [
+        {
+          "filePath": "src/components/skills-quiz/SkillsQuizStepper.jsx",
+          "line": 103,
+          "column": 8,
+          "version": "16.3.1"
+        }
+      ],
+      "Stepper.Header": [
+        {
+          "filePath": "src/components/skills-quiz/SkillsQuizStepper.jsx",
+          "line": 108,
+          "column": 26,
+          "version": "16.3.1"
+        }
+      ],
+      "Stepper.ActionRow": [
+        {
+          "filePath": "src/components/skills-quiz/SkillsQuizStepper.jsx",
+          "line": 111,
+          "column": 14,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SkillsQuizStepper.jsx",
+          "line": 122,
+          "column": 14,
+          "version": "16.3.1"
+        }
+      ],
+      "Stepper.Step": [
+        {
+          "filePath": "src/components/skills-quiz/SkillsQuizStepper.jsx",
+          "line": 133,
+          "column": 12,
+          "version": "16.3.1"
+        },
+        {
+          "filePath": "src/components/skills-quiz/SkillsQuizStepper.jsx",
+          "line": 183,
+          "column": 12,
+          "version": "16.3.1"
         }
       ],
       "Icon": [
@@ -5839,7 +8362,7 @@
           "filePath": "src/components/system-wide-banner/SystemWideWarningBanner.jsx",
           "line": 21,
           "column": 10,
-          "version": "14.6.1"
+          "version": "16.3.1"
         }
       ]
     }
@@ -5890,13 +8413,13 @@
         },
         {
           "filePath": "src/components/program/ProgramPage.jsx",
-          "line": 55,
+          "line": 57,
           "column": 6,
           "version": "12.4.0"
         },
         {
           "filePath": "src/components/programs-list/ProgramListPage.jsx",
-          "line": 76,
+          "line": 78,
           "column": 4,
           "version": "12.4.0"
         }
@@ -5942,7 +8465,54 @@
     }
   },
   {
-    "version": "15.2.2",
+    "version": "13.17.5",
+    "name": "@edx/frontend-app-learner-record",
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/edx/frontend-app-learner-record.git"
+    },
+    "folderName": "frontend-app-learner-record",
+    "usages": {
+      "Hyperlink": [
+        {
+          "filePath": "src/components/ProgramRecordsList.jsx",
+          "line": 45,
+          "column": 6,
+          "version": "13.17.5"
+        },
+        {
+          "filePath": "src/components/ProgramRecordsList.jsx",
+          "line": 111,
+          "column": 14,
+          "version": "13.17.5"
+        },
+        {
+          "filePath": "src/components/ProgramRecordsList.jsx",
+          "line": 157,
+          "column": 6,
+          "version": "13.17.5"
+        }
+      ],
+      "Alert": [
+        {
+          "filePath": "src/components/ProgramRecordsList.jsx",
+          "line": 61,
+          "column": 6,
+          "version": "13.17.5"
+        }
+      ],
+      "Button": [
+        {
+          "filePath": "src/components/ProgramRecordsList.jsx",
+          "line": 115,
+          "column": 16,
+          "version": "13.17.5"
+        }
+      ]
+    }
+  },
+  {
+    "version": "16.13.3",
     "name": "@edx/frontend-app-learning",
     "repository": {
       "type": "git",
@@ -5953,377 +8523,555 @@
       "Hyperlink": [
         {
           "filePath": "src/alerts/access-expiration-alert/AccessExpirationAlert.jsx",
-          "line": 90,
+          "line": 82,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/alerts/access-expiration-alert/AccessExpirationAlertMMP2P.jsx",
           "line": 43,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/alerts/logistration-alert/LogistrationAlert.jsx",
           "line": 12,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/alerts/logistration-alert/LogistrationAlert.jsx",
           "line": 23,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
-          "filePath": "src/alerts/offer-alert/OfferAlert.jsx",
-          "line": 75,
-          "column": 6,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/course-home/outline-tab/alerts/private-course-alert/PrivateCourseAlert.jsx",
-          "line": 48,
-          "column": 4,
-          "version": "15.2.2"
+          "filePath": "src/course-home/goal-unsubscribe/ResultPage.jsx",
+          "line": 16,
+          "column": 10,
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/alerts/private-course-alert/PrivateCourseAlert.jsx",
-          "line": 57,
+          "line": 49,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/outline-tab/alerts/private-course-alert/PrivateCourseAlert.jsx",
+          "line": 58,
+          "column": 4,
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/SequenceLink.jsx",
-          "line": 50,
+          "line": 48,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/detailed-grades/DetailedGrades.jsx",
-          "line": 39,
+          "line": 41,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/related-links/RelatedLinks.jsx",
           "line": 36,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/related-links/RelatedLinks.jsx",
           "line": 42,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/CatalogSuggestion.jsx",
           "line": 25,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/CourseCelebration.jsx",
-          "line": 204,
+          "line": 205,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/CourseRecommendations.jsx",
           "line": 81,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/CourseRecommendations.jsx",
           "line": 196,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/DashboardFootnote.jsx",
           "line": 25,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/ProgramCompletion.jsx",
           "line": 34,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/ProgramCompletion.jsx",
-          "line": 57,
+          "line": 58,
+          "column": 16,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/course-exit/ProgramCompletion.jsx",
+          "line": 75,
           "column": 14,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/courseware/course/course-exit/ProgramCompletion.jsx",
-          "line": 74,
-          "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/UpgradeFootnote.jsx",
           "line": 23,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/sequence/hidden-after-due/HiddenAfterDue.jsx",
+          "line": 16,
+          "column": 4,
+          "version": "16.13.3"
         },
         {
           "filePath": "src/shared/links.jsx",
           "line": 11,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/shared/links.jsx",
           "line": 30,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/shared/links.jsx",
           "line": 48,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
+        }
+      ],
+      "Alert": [
+        {
+          "filePath": "src/alerts/access-expiration-alert/AccessExpirationAlert.jsx",
+          "line": 95,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/alerts/access-expiration-alert/AccessExpirationAlertMMP2P.jsx",
+          "line": 55,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/alerts/course-start-alert/CourseStartAlert.jsx",
+          "line": 39,
+          "column": 6,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/alerts/course-start-alert/CourseStartAlert.jsx",
+          "line": 64,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/alerts/enrollment-alert/EnrollmentAlert.jsx",
+          "line": 50,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/alerts/logistration-alert/LogistrationAlert.jsx",
+          "line": 32,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/outline-tab/alerts/certificate-status-alert/CertificateStatusAlert.jsx",
+          "line": 171,
+          "column": 8,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/outline-tab/alerts/course-end-alert/CourseEndAlert.jsx",
+          "line": 81,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/outline-tab/alerts/private-course-alert/PrivateCourseAlert.jsx",
+          "line": 67,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/outline-tab/alerts/scheduled-content-alert/ScheduledCotentAlert.jsx",
+          "line": 12,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/outline-tab/widgets/WelcomeMessage.jsx",
+          "line": 30,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/suggested-schedule-messaging/ShiftDatesAlert.jsx",
+          "line": 39,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/suggested-schedule-messaging/UpgradeToCompleteAlert.jsx",
+          "line": 36,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/suggested-schedule-messaging/UpgradeToShiftDatesAlert.jsx",
+          "line": 38,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/course-exit/CourseCelebration.jsx",
+          "line": 289,
+          "column": 10,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/course-exit/CourseInProgress.jsx",
+          "line": 37,
+          "column": 8,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/course-exit/CourseNonPassing.jsx",
+          "line": 37,
+          "column": 8,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/course-exit/ProgramCompletion.jsx",
+          "line": 44,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/sequence/hidden-after-due/HiddenAfterDue.jsx",
+          "line": 26,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/sequence/honor-code/HonorCode.jsx",
+          "line": 23,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/sequence/lock-paywall/LockPaywall.jsx",
+          "line": 86,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/generic/user-messages/Alert.jsx",
+          "line": 36,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/shared/streak-celebration/StreakCelebrationModal.jsx",
+          "line": 137,
+          "column": 10,
+          "version": "16.13.3"
+        }
+      ],
+      "PageBanner": [
+        {
+          "filePath": "src/alerts/access-expiration-alert/AccessExpirationMasqueradeBanner.jsx",
+          "line": 15,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/alerts/course-start-alert/CourseStartMasqueradeBanner.jsx",
+          "line": 21,
+          "column": 4,
+          "version": "16.13.3"
         }
       ],
       "Button": [
         {
           "filePath": "src/alerts/enrollment-alert/EnrollmentAlert.jsx",
-          "line": 42,
+          "line": 44,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/alerts/logistration-alert/AccountActivationAlert.jsx",
           "line": 49,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-header/AnonymousUserMenu.jsx",
           "line": 13,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-header/AnonymousUserMenu.jsx",
           "line": 20,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/goal-unsubscribe/ResultPage.jsx",
+          "line": 40,
+          "column": 6,
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/alerts/certificate-status-alert/CertificateStatusAlert.jsx",
-          "line": 122,
+          "line": 180,
           "column": 16,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/alerts/private-course-alert/PrivateCourseAlert.jsx",
           "line": 36,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/alerts/scheduled-content-alert/ScheduledCotentAlert.jsx",
           "line": 28,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/OutlineTab.jsx",
-          "line": 128,
+          "line": 137,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/OutlineTab.jsx",
-          "line": 181,
+          "line": 189,
           "column": 18,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/widgets/CourseGoalCard.jsx",
           "line": 44,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/widgets/CourseGoalCard.jsx",
           "line": 64,
           "column": 18,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx",
-          "line": 134,
-          "column": 18,
-          "version": "15.2.2"
+          "line": 105,
+          "column": 6,
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx",
-          "line": 148,
-          "column": 18,
-          "version": "15.2.2"
+          "line": 120,
+          "column": 6,
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx",
-          "line": 163,
+          "line": 127,
+          "column": 8,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx",
+          "line": 133,
+          "column": 8,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx",
+          "line": 175,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/widgets/WelcomeMessage.jsx",
-          "line": 43,
-          "column": 14,
-          "version": "15.2.2"
+          "line": 41,
+          "column": 8,
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/certificate-status/CertificateStatus.jsx",
-          "line": 209,
+          "line": 233,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/course-grade/CourseGradeHeader.jsx",
-          "line": 55,
+          "line": 77,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/ProgressHeader.jsx",
           "line": 33,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/suggested-schedule-messaging/ShiftDatesAlert.jsx",
           "line": 46,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/suggested-schedule-messaging/UpgradeToCompleteAlert.jsx",
           "line": 43,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/suggested-schedule-messaging/UpgradeToShiftDatesAlert.jsx",
           "line": 45,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/CourseCelebration.jsx",
-          "line": 107,
+          "line": 108,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/CourseCelebration.jsx",
-          "line": 150,
+          "line": 151,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/CourseCelebration.jsx",
-          "line": 295,
-          "column": 18,
-          "version": "15.2.2"
+          "line": 297,
+          "column": 20,
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/CourseExit.jsx",
           "line": 49,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/CourseInProgress.jsx",
           "line": 41,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/CourseNonPassing.jsx",
           "line": 41,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/ProgramCompletion.jsx",
-          "line": 65,
-          "column": 12,
-          "version": "15.2.2"
+          "line": 66,
+          "column": 14,
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/sequence/content-lock/ContentLock.jsx",
           "line": 32,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/sequence/honor-code/HonorCode.jsx",
           "line": 42,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/sequence/honor-code/HonorCode.jsx",
           "line": 45,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx",
-          "line": 72,
+          "line": 78,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx",
-          "line": 80,
+          "line": 88,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/sequence/sequence-navigation/UnitButton.jsx",
           "line": 28,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/sequence/sequence-navigation/UnitNavigation.jsx",
-          "line": 32,
+          "line": 35,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/sequence/sequence-navigation/UnitNavigation.jsx",
-          "line": 48,
+          "line": 52,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/experiments/mm-p2p/BlockModalContent.jsx",
           "line": 64,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/generic/upgrade-button/UpgradeButton.jsx",
           "line": 22,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/generic/upgrade-button/UpgradeNowButton.jsx",
           "line": 22,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Icon": [
@@ -6331,67 +9079,91 @@
           "filePath": "src/alerts/logistration-alert/AccountActivationAlert.jsx",
           "line": 62,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/alerts/logistration-alert/AccountActivationAlert.jsx",
           "line": 112,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/course-grade/CourseGradeFooter.jsx",
           "line": 60,
           "column": 27,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/course-grade/CourseGradeFooter.jsx",
           "line": 61,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/course-grade/CourseGradeHeader.jsx",
-          "line": 37,
+          "line": 58,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/progress-tab/grades/detailed-grades/DetailedGrades.jsx",
+          "line": 56,
+          "column": 10,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx",
+          "line": 51,
+          "column": 42,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx",
+          "line": 52,
+          "column": 40,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx",
+          "line": 57,
+          "column": 14,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/progress-tab/grades/grade-summary/AssignmentTypeCell.jsx",
+          "line": 21,
+          "column": 30,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.jsx",
+          "line": 51,
+          "column": 10,
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/NotificationIcon.jsx",
-          "line": 14,
+          "line": 13,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/NotificationTray.jsx",
-          "line": 39,
+          "line": 42,
           "column": 10,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/courseware/course/NotificationTray.jsx",
-          "line": 47,
-          "column": 12,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/courseware/course/sequence/lock-paywall/LockPaywall.jsx",
-          "line": 48,
-          "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/shared/streak-celebration/StreakCelebrationModal.jsx",
           "line": 130,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/shared/streak-celebration/StreakCelebrationModal.jsx",
-          "line": 138,
-          "column": 12,
-          "version": "15.2.2"
+          "line": 139,
+          "column": 14,
+          "version": "16.13.3"
         }
       ],
       "Spinner": [
@@ -6399,7 +9171,13 @@
           "filePath": "src/alerts/logistration-alert/AccountActivationAlert.jsx",
           "line": 99,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/generic/PageLoading.jsx",
+          "line": 28,
+          "column": 10,
+          "version": "16.13.3"
         }
       ],
       "AlertModal": [
@@ -6407,7 +9185,7 @@
           "filePath": "src/alerts/logistration-alert/AccountActivationAlert.jsx",
           "line": 124,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Dropdown.Item": [
@@ -6415,151 +9193,151 @@
           "filePath": "src/course-header/AuthenticatedUserDropdown.jsx",
           "line": 15,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-header/AuthenticatedUserDropdown.jsx",
           "line": 21,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-header/AuthenticatedUserDropdown.jsx",
-          "line": 40,
+          "line": 38,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-header/AuthenticatedUserDropdown.jsx",
-          "line": 43,
+          "line": 41,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-header/AuthenticatedUserDropdown.jsx",
-          "line": 51,
+          "line": 49,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-header/AuthenticatedUserDropdown.jsx",
-          "line": 55,
+          "line": 53,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/widgets/UpdateGoalSelector.jsx",
           "line": 53,
           "column": 18,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/sequence/sequence-navigation/SequenceNavigationDropdown.jsx",
           "line": 29,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/instructor-toolbar/masquerade-widget/MasqueradeWidgetOption.jsx",
           "line": 70,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Dropdown": [
         {
           "filePath": "src/course-header/AuthenticatedUserDropdown.jsx",
-          "line": 31,
+          "line": 29,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/widgets/UpdateGoalSelector.jsx",
           "line": 47,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/sequence/sequence-navigation/SequenceNavigationDropdown.jsx",
           "line": 15,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/generic/tabs/Tabs.jsx",
           "line": 39,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/instructor-toolbar/masquerade-widget/MasqueradeWidget.jsx",
           "line": 124,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Dropdown.Toggle": [
         {
           "filePath": "src/course-header/AuthenticatedUserDropdown.jsx",
-          "line": 32,
+          "line": 30,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/widgets/UpdateGoalSelector.jsx",
           "line": 48,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/sequence/sequence-navigation/SequenceNavigationDropdown.jsx",
           "line": 16,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/generic/tabs/Tabs.jsx",
           "line": 40,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/instructor-toolbar/masquerade-widget/MasqueradeWidget.jsx",
           "line": 125,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Dropdown.Menu": [
         {
           "filePath": "src/course-header/AuthenticatedUserDropdown.jsx",
-          "line": 38,
+          "line": 36,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/widgets/UpdateGoalSelector.jsx",
           "line": 51,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/sequence/sequence-navigation/SequenceNavigationDropdown.jsx",
           "line": 27,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/generic/tabs/Tabs.jsx",
           "line": 47,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/instructor-toolbar/masquerade-widget/MasqueradeWidget.jsx",
           "line": 128,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Badge": [
@@ -6567,7 +9345,7 @@
           "filePath": "src/course-home/dates-tab/timeline/badgelist.jsx",
           "line": 99,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "OverlayTrigger": [
@@ -6575,49 +9353,49 @@
           "filePath": "src/course-home/dates-tab/timeline/Day.jsx",
           "line": 100,
           "column": 18,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/course-completion/CompleteDonutSegment.jsx",
           "line": 32,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/course-completion/IncompleteDonutSegment.jsx",
           "line": 36,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/course-completion/LockedDonutSegment.jsx",
           "line": 35,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/course-grade/CurrentGradeTooltip.jsx",
           "line": 28,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/course-grade/GradeRangeTooltip.jsx",
           "line": 33,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/course-grade/PassingGradeTooltip.jsx",
           "line": 12,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.jsx",
-          "line": 20,
+          "line": 26,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Tooltip": [
@@ -6625,155 +9403,81 @@
           "filePath": "src/course-home/dates-tab/timeline/Day.jsx",
           "line": 103,
           "column": 22,
-          "version": "15.2.2"
-        }
-      ],
-      "Alert": [
-        {
-          "filePath": "src/course-home/outline-tab/alerts/certificate-status-alert/CertificateStatusAlert.jsx",
-          "line": 113,
-          "column": 8,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/course-home/outline-tab/alerts/scheduled-content-alert/ScheduledCotentAlert.jsx",
-          "line": 12,
-          "column": 4,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/course-home/suggested-schedule-messaging/ShiftDatesAlert.jsx",
-          "line": 39,
-          "column": 4,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/course-home/suggested-schedule-messaging/UpgradeToCompleteAlert.jsx",
-          "line": 36,
-          "column": 4,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/course-home/suggested-schedule-messaging/UpgradeToShiftDatesAlert.jsx",
-          "line": 38,
-          "column": 4,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/courseware/course/course-exit/CourseCelebration.jsx",
-          "line": 288,
-          "column": 10,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/courseware/course/course-exit/CourseInProgress.jsx",
-          "line": 37,
-          "column": 8,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/courseware/course/course-exit/CourseNonPassing.jsx",
-          "line": 37,
-          "column": 8,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/courseware/course/course-exit/ProgramCompletion.jsx",
-          "line": 44,
-          "column": 4,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/courseware/course/sequence/honor-code/HonorCode.jsx",
-          "line": 23,
-          "column": 4,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/courseware/course/sequence/lock-paywall/LockPaywall.jsx",
-          "line": 82,
-          "column": 4,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/shared/streak-celebration/StreakCelebrationModal.jsx",
-          "line": 137,
-          "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Alert.Heading": [
         {
           "filePath": "src/course-home/outline-tab/alerts/certificate-status-alert/CertificateStatusAlert.jsx",
-          "line": 117,
+          "line": 175,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/alerts/scheduled-content-alert/ScheduledCotentAlert.jsx",
           "line": 15,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/suggested-schedule-messaging/UpgradeToCompleteAlert.jsx",
           "line": 39,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Toast": [
         {
           "filePath": "src/course-home/outline-tab/OutlineTab.jsx",
-          "line": 115,
+          "line": 124,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/tab-page/TabPage.jsx",
-          "line": 41,
+          "line": 65,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Collapsible": [
         {
           "filePath": "src/course-home/outline-tab/Section.jsx",
-          "line": 77,
+          "line": 75,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "IconButton": [
         {
           "filePath": "src/course-home/outline-tab/Section.jsx",
-          "line": 84,
+          "line": 82,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/outline-tab/Section.jsx",
-          "line": 92,
+          "line": 90,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/course-grade/GradeRangeTooltip.jsx",
           "line": 63,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.jsx",
-          "line": 32,
+          "line": 38,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
-          "filePath": "src/generic/user-messages/Alert.jsx",
-          "line": 69,
-          "column": 12,
-          "version": "15.2.2"
+          "filePath": "src/courseware/course/NotificationTray.jsx",
+          "line": 52,
+          "column": 14,
+          "version": "16.13.3"
         }
       ],
       "Card": [
@@ -6781,19 +9485,19 @@
           "filePath": "src/course-home/outline-tab/widgets/CourseGoalCard.jsx",
           "line": 37,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/certificate-status/CertificateStatus.jsx",
-          "line": 200,
+          "line": 224,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/CourseRecommendations.jsx",
           "line": 86,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Card.Body": [
@@ -6801,19 +9505,19 @@
           "filePath": "src/course-home/outline-tab/widgets/CourseGoalCard.jsx",
           "line": 38,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/certificate-status/CertificateStatus.jsx",
-          "line": 201,
+          "line": 225,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/CourseRecommendations.jsx",
           "line": 88,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Card.Text": [
@@ -6821,35 +9525,35 @@
           "filePath": "src/course-home/outline-tab/widgets/CourseGoalCard.jsx",
           "line": 57,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/certificate-status/CertificateStatus.jsx",
-          "line": 205,
+          "line": 229,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "TransitionReplace": [
         {
           "filePath": "src/course-home/outline-tab/widgets/WelcomeMessage.jsx",
-          "line": 55,
-          "column": 8,
-          "version": "15.2.2"
+          "line": 50,
+          "column": 6,
+          "version": "16.13.3"
         }
       ],
       "Card.Title": [
         {
           "filePath": "src/course-home/progress-tab/certificate-status/CertificateStatus.jsx",
-          "line": 202,
+          "line": 226,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/CourseRecommendations.jsx",
           "line": 89,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Popover": [
@@ -6857,43 +9561,43 @@
           "filePath": "src/course-home/progress-tab/course-completion/CompleteDonutSegment.jsx",
           "line": 36,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/course-completion/IncompleteDonutSegment.jsx",
           "line": 40,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/course-completion/LockedDonutSegment.jsx",
           "line": 39,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/course-grade/CurrentGradeTooltip.jsx",
           "line": 32,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/course-grade/GradeRangeTooltip.jsx",
           "line": 38,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/course-grade/PassingGradeTooltip.jsx",
           "line": 16,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.jsx",
-          "line": 25,
+          "line": 31,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Popover.Content": [
@@ -6901,77 +9605,201 @@
           "filePath": "src/course-home/progress-tab/course-completion/CompleteDonutSegment.jsx",
           "line": 37,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/course-completion/IncompleteDonutSegment.jsx",
           "line": 41,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/course-completion/LockedDonutSegment.jsx",
           "line": 40,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/course-grade/CurrentGradeTooltip.jsx",
           "line": 33,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/course-grade/GradeRangeTooltip.jsx",
           "line": 39,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/course-grade/PassingGradeTooltip.jsx",
           "line": 17,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.jsx",
-          "line": 26,
+          "line": 32,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "DataTable": [
         {
           "filePath": "src/course-home/progress-tab/grades/detailed-grades/DetailedGradesTable.jsx",
-          "line": 64,
+          "line": 40,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/grade-summary/GradeSummaryTable.jsx",
-          "line": 57,
+          "line": 81,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/course-exit/CourseRecommendations.jsx",
           "line": 183,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "DataTable.Table": [
         {
           "filePath": "src/course-home/progress-tab/grades/detailed-grades/DetailedGradesTable.jsx",
-          "line": 82,
+          "line": 58,
           "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/progress-tab/grades/grade-summary/GradeSummaryTable.jsx",
-          "line": 94,
+          "line": 131,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
+        }
+      ],
+      "Collapsible.Advanced": [
+        {
+          "filePath": "src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx",
+          "line": 44,
+          "column": 4,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
+          "line": 42,
+          "column": 6,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
+          "line": 82,
+          "column": 10,
+          "version": "16.13.3"
+        }
+      ],
+      "Row": [
+        {
+          "filePath": "src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx",
+          "line": 45,
+          "column": 6,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/suggested-schedule-messaging/ShiftDatesAlert.jsx",
+          "line": 40,
+          "column": 6,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/suggested-schedule-messaging/UpgradeToCompleteAlert.jsx",
+          "line": 37,
+          "column": 6,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/suggested-schedule-messaging/UpgradeToShiftDatesAlert.jsx",
+          "line": 39,
+          "column": 6,
+          "version": "16.13.3"
+        }
+      ],
+      "Collapsible.Trigger": [
+        {
+          "filePath": "src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx",
+          "line": 46,
+          "column": 8,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
+          "line": 44,
+          "column": 10,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
+          "line": 84,
+          "column": 14,
+          "version": "16.13.3"
+        }
+      ],
+      "Collapsible.Visible": [
+        {
+          "filePath": "src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx",
+          "line": 51,
+          "column": 10,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx",
+          "line": 52,
+          "column": 10,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
+          "line": 45,
+          "column": 12,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
+          "line": 48,
+          "column": 12,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
+          "line": 85,
+          "column": 16,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
+          "line": 88,
+          "column": 16,
+          "version": "16.13.3"
+        }
+      ],
+      "Collapsible.Body": [
+        {
+          "filePath": "src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx",
+          "line": 81,
+          "column": 6,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
+          "line": 54,
+          "column": 8,
+          "version": "16.13.3"
+        },
+        {
+          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
+          "line": 97,
+          "column": 12,
+          "version": "16.13.3"
         }
       ],
       "DataTable.TableFooter": [
@@ -6979,27 +9807,7 @@
           "filePath": "src/course-home/progress-tab/grades/grade-summary/GradeSummaryTableFooter.jsx",
           "line": 26,
           "column": 4,
-          "version": "15.2.2"
-        }
-      ],
-      "Row": [
-        {
-          "filePath": "src/course-home/suggested-schedule-messaging/ShiftDatesAlert.jsx",
-          "line": 40,
-          "column": 6,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/course-home/suggested-schedule-messaging/UpgradeToCompleteAlert.jsx",
-          "line": 37,
-          "column": 6,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/course-home/suggested-schedule-messaging/UpgradeToShiftDatesAlert.jsx",
-          "line": 39,
-          "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Col": [
@@ -7007,37 +9815,37 @@
           "filePath": "src/course-home/suggested-schedule-messaging/ShiftDatesAlert.jsx",
           "line": 41,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/suggested-schedule-messaging/ShiftDatesAlert.jsx",
           "line": 45,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/suggested-schedule-messaging/UpgradeToCompleteAlert.jsx",
           "line": 38,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/suggested-schedule-messaging/UpgradeToCompleteAlert.jsx",
           "line": 42,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/suggested-schedule-messaging/UpgradeToShiftDatesAlert.jsx",
           "line": 40,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/course-home/suggested-schedule-messaging/UpgradeToShiftDatesAlert.jsx",
           "line": 44,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "StatefulButton": [
@@ -7045,7 +9853,7 @@
           "filePath": "src/courseware/course/bookmark/BookmarkButton.jsx",
           "line": 42,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Modal": [
@@ -7053,81 +9861,13 @@
           "filePath": "src/courseware/course/celebration/CelebrationModal.jsx",
           "line": 34,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/courseware/course/sequence/Unit.jsx",
-          "line": 199,
+          "line": 200,
           "column": 8,
-          "version": "15.2.2"
-        }
-      ],
-      "Collapsible.Advanced": [
-        {
-          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
-          "line": 42,
-          "column": 6,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
-          "line": 82,
-          "column": 10,
-          "version": "15.2.2"
-        }
-      ],
-      "Collapsible.Trigger": [
-        {
-          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
-          "line": 44,
-          "column": 10,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
-          "line": 84,
-          "column": 14,
-          "version": "15.2.2"
-        }
-      ],
-      "Collapsible.Visible": [
-        {
-          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
-          "line": 45,
-          "column": 12,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
-          "line": 48,
-          "column": 12,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
-          "line": 85,
-          "column": 16,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
-          "line": 88,
-          "column": 16,
-          "version": "15.2.2"
-        }
-      ],
-      "Collapsible.Body": [
-        {
-          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
-          "line": 54,
-          "column": 8,
-          "version": "15.2.2"
-        },
-        {
-          "filePath": "src/courseware/course/content-tools/calculator/Calculator.jsx",
-          "line": 97,
-          "column": 12,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Card.Img": [
@@ -7135,7 +9875,7 @@
           "filePath": "src/courseware/course/course-exit/CourseRecommendations.jsx",
           "line": 87,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "CardView": [
@@ -7143,7 +9883,23 @@
           "filePath": "src/courseware/course/course-exit/CourseRecommendations.jsx",
           "line": 193,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
+        }
+      ],
+      "SelectMenu": [
+        {
+          "filePath": "src/courseware/course/CourseBreadcrumbs.jsx",
+          "line": 53,
+          "column": 12,
+          "version": "16.13.3"
+        }
+      ],
+      "MenuItem": [
+        {
+          "filePath": "src/courseware/course/CourseBreadcrumbs.jsx",
+          "line": 55,
+          "column": 16,
+          "version": "16.13.3"
         }
       ],
       "ActionRow": [
@@ -7151,7 +9907,7 @@
           "filePath": "src/courseware/course/sequence/honor-code/HonorCode.jsx",
           "line": 40,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "ActionRow.Spacer": [
@@ -7159,15 +9915,15 @@
           "filePath": "src/courseware/course/sequence/honor-code/HonorCode.jsx",
           "line": 41,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Alert.Link": [
         {
           "filePath": "src/courseware/course/sequence/lock-paywall/LockPaywall.jsx",
-          "line": 56,
+          "line": 60,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "ModalLayer": [
@@ -7175,13 +9931,13 @@
           "filePath": "src/experiments/mm-p2p/BlockModal.jsx",
           "line": 10,
           "column": 2,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/experiments/mm-p2p/BlockModalContent.jsx",
           "line": 35,
           "column": 2,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "Input": [
@@ -7189,7 +9945,7 @@
           "filePath": "src/instructor-toolbar/masquerade-widget/MasqueradeUserNameInput.jsx",
           "line": 49,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "ModalDialog": [
@@ -7197,7 +9953,7 @@
           "filePath": "src/shared/streak-celebration/StreakCelebrationModal.jsx",
           "line": 102,
           "column": 4,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "ModalDialog.Header": [
@@ -7205,7 +9961,7 @@
           "filePath": "src/shared/streak-celebration/StreakCelebrationModal.jsx",
           "line": 113,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "ModalDialog.Title": [
@@ -7213,7 +9969,7 @@
           "filePath": "src/shared/streak-celebration/StreakCelebrationModal.jsx",
           "line": 114,
           "column": 8,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "ModalDialog.Body": [
@@ -7221,35 +9977,35 @@
           "filePath": "src/shared/streak-celebration/StreakCelebrationModal.jsx",
           "line": 118,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "ModalDialog.Footer": [
         {
           "filePath": "src/shared/streak-celebration/StreakCelebrationModal.jsx",
-          "line": 153,
+          "line": 155,
           "column": 6,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ],
       "ModalDialog.CloseButton": [
         {
           "filePath": "src/shared/streak-celebration/StreakCelebrationModal.jsx",
-          "line": 164,
+          "line": 166,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/shared/streak-celebration/StreakCelebrationModal.jsx",
-          "line": 175,
+          "line": 177,
           "column": 14,
-          "version": "15.2.2"
+          "version": "16.13.3"
         },
         {
           "filePath": "src/shared/streak-celebration/StreakCelebrationModal.jsx",
-          "line": 182,
+          "line": 184,
           "column": 10,
-          "version": "15.2.2"
+          "version": "16.13.3"
         }
       ]
     }
@@ -7272,86 +10028,62 @@
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 295,
+          "line": 332,
           "column": 6,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 300,
+          "line": 336,
           "column": 6,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 309,
+          "line": 347,
           "column": 6,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 312,
+          "line": 350,
           "column": 6,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 318,
+          "line": 356,
           "column": 18,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 326,
+          "line": 364,
           "column": 18,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 337,
+          "line": 375,
           "column": 14,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 352,
+          "line": 390,
           "column": 18,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 362,
+          "line": 402,
+          "column": 18,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
+          "line": 414,
           "column": 14,
-          "version": "10.0.1"
-        },
-        {
-          "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 377,
-          "column": 20,
-          "version": "10.0.1"
-        },
-        {
-          "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 380,
-          "column": 20,
-          "version": "10.0.1"
-        },
-        {
-          "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 415,
-          "column": 6,
-          "version": "10.0.1"
-        },
-        {
-          "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 418,
-          "column": 12,
-          "version": "10.0.1"
-        },
-        {
-          "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 425,
-          "column": 12,
           "version": "10.0.1"
         },
         {
@@ -7362,13 +10094,43 @@
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 434,
+          "line": 432,
           "column": 20,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 439,
+          "line": 467,
+          "column": 6,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
+          "line": 470,
+          "column": 12,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
+          "line": 477,
+          "column": 12,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
+          "line": 481,
+          "column": 20,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
+          "line": 486,
+          "column": 20,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
+          "line": 491,
           "column": 20,
           "version": "10.0.1"
         },
@@ -7472,6 +10234,30 @@
           "filePath": "src/library-authoring/common/LicenseField.jsx",
           "line": 148,
           "column": 6,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/common/SuccessAlert.jsx",
+          "line": 10,
+          "column": 4,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportListItem.jsx",
+          "line": 50,
+          "column": 8,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportListItem.jsx",
+          "line": 53,
+          "column": 8,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportTaskListItem.jsx",
+          "line": 33,
+          "column": 8,
           "version": "10.0.1"
         },
         {
@@ -7550,7 +10336,7 @@
       "Navbar": [
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 69,
+          "line": 79,
           "column": 4,
           "version": "10.0.1"
         }
@@ -7558,7 +10344,7 @@
       "Navbar.Brand": [
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 70,
+          "line": 80,
           "column": 6,
           "version": "10.0.1"
         }
@@ -7566,7 +10352,7 @@
       "Navbar.Collapse": [
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 71,
+          "line": 81,
           "column": 6,
           "version": "10.0.1"
         }
@@ -7574,67 +10360,73 @@
       "Button": [
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 73,
+          "line": 84,
+          "column": 12,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
+          "line": 91,
           "column": 10,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 79,
+          "line": 97,
           "column": 8,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 100,
+          "line": 118,
           "column": 8,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 227,
+          "line": 263,
           "column": 4,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 231,
+          "line": 267,
           "column": 4,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 364,
+          "line": 416,
           "column": 16,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 398,
+          "line": 450,
           "column": 22,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 401,
+          "line": 453,
           "column": 22,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 404,
+          "line": 456,
           "column": 22,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 435,
+          "line": 487,
           "column": 22,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 440,
+          "line": 492,
           "column": 22,
           "version": "10.0.1"
         },
@@ -7654,6 +10446,18 @@
           "filePath": "src/library-authoring/configure-library/LibraryConfigurePage.jsx",
           "line": 317,
           "column": 18,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportPage.jsx",
+          "line": 49,
+          "column": 14,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportPage.jsx",
+          "line": 203,
+          "column": 16,
           "version": "10.0.1"
         },
         {
@@ -7688,25 +10492,25 @@
         },
         {
           "filePath": "src/library-authoring/edit-block/LibraryBlockPage.jsx",
-          "line": 212,
+          "line": 213,
           "column": 14,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/edit-block/LibraryBlockPage.jsx",
-          "line": 330,
+          "line": 331,
           "column": 24,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/edit-block/LibraryBlockPage.jsx",
-          "line": 341,
+          "line": 342,
           "column": 24,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/edit-block/LibraryBlockPage.jsx",
-          "line": 352,
+          "line": 353,
           "column": 24,
           "version": "10.0.1"
         },
@@ -7772,13 +10576,13 @@
         },
         {
           "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
-          "line": 139,
+          "line": 186,
           "column": 18,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
-          "line": 195,
+          "line": 254,
           "column": 24,
           "version": "10.0.1"
         }
@@ -7786,7 +10590,7 @@
       "Modal": [
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 88,
+          "line": 106,
           "column": 4,
           "version": "10.0.1"
         },
@@ -7806,19 +10610,19 @@
       "Card": [
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 108,
+          "line": 126,
           "column": 6,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 313,
+          "line": 351,
           "column": 8,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 426,
+          "line": 478,
           "column": 14,
           "version": "10.0.1"
         },
@@ -7844,19 +10648,19 @@
       "Card.Body": [
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 109,
+          "line": 127,
           "column": 8,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 314,
+          "line": 352,
           "column": 10,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 427,
+          "line": 479,
           "column": 16,
           "version": "10.0.1"
         },
@@ -7882,7 +10686,7 @@
       "Container": [
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 293,
+          "line": 330,
           "column": 2,
           "version": "10.0.1"
         }
@@ -7890,31 +10694,31 @@
       "Row": [
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 294,
+          "line": 331,
           "column": 4,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 315,
+          "line": 353,
           "column": 12,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 376,
+          "line": 428,
           "column": 18,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 417,
+          "line": 469,
           "column": 10,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 428,
+          "line": 480,
           "column": 18,
           "version": "10.0.1"
         },
@@ -7955,6 +10759,18 @@
           "version": "10.0.1"
         },
         {
+          "filePath": "src/library-authoring/course-import/CourseImportListItem.jsx",
+          "line": 49,
+          "column": 6,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportTaskListItem.jsx",
+          "line": 32,
+          "column": 6,
+          "version": "10.0.1"
+        },
+        {
           "filePath": "src/library-authoring/library-access/LibraryAccessForm.jsx",
           "line": 29,
           "column": 4,
@@ -7988,7 +10804,7 @@
       "SearchField": [
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 319,
+          "line": 357,
           "column": 20,
           "version": "10.0.1"
         }
@@ -7996,7 +10812,7 @@
       "Input": [
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 327,
+          "line": 365,
           "column": 20,
           "version": "10.0.1"
         },
@@ -8043,6 +10859,12 @@
           "version": "10.0.1"
         },
         {
+          "filePath": "src/library-authoring/course-import/CourseImportPage.jsx",
+          "line": 218,
+          "column": 14,
+          "version": "10.0.1"
+        },
+        {
           "filePath": "src/library-authoring/create-library/LibraryCreateForm.jsx",
           "line": 163,
           "column": 16,
@@ -8074,21 +10896,47 @@
         },
         {
           "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
-          "line": 210,
+          "line": 269,
           "column": 22,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
-          "line": 224,
+          "line": 283,
           "column": 22,
+          "version": "10.0.1"
+        }
+      ],
+      "Pagination": [
+        {
+          "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
+          "line": 403,
+          "column": 20,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportPage.jsx",
+          "line": 118,
+          "column": 12,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportPage.jsx",
+          "line": 282,
+          "column": 12,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
+          "line": 213,
+          "column": 18,
           "version": "10.0.1"
         }
       ],
       "Dropdown": [
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 382,
+          "line": 434,
           "column": 24,
           "version": "10.0.1"
         },
@@ -8100,7 +10948,7 @@
         },
         {
           "filePath": "src/library-authoring/studio-header/StudioHeader.jsx",
-          "line": 79,
+          "line": 80,
           "column": 16,
           "version": "10.0.1"
         }
@@ -8108,7 +10956,7 @@
       "Dropdown.Toggle": [
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 383,
+          "line": 435,
           "column": 26,
           "version": "10.0.1"
         },
@@ -8120,7 +10968,7 @@
         },
         {
           "filePath": "src/library-authoring/studio-header/StudioHeader.jsx",
-          "line": 80,
+          "line": 81,
           "column": 18,
           "version": "10.0.1"
         }
@@ -8128,7 +10976,7 @@
       "Dropdown.Menu": [
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 386,
+          "line": 438,
           "column": 26,
           "version": "10.0.1"
         },
@@ -8140,7 +10988,7 @@
         },
         {
           "filePath": "src/library-authoring/studio-header/StudioHeader.jsx",
-          "line": 84,
+          "line": 85,
           "column": 18,
           "version": "10.0.1"
         }
@@ -8148,7 +10996,7 @@
       "Dropdown.Item": [
         {
           "filePath": "src/library-authoring/author-library/LibraryAuthoringPage.jsx",
-          "line": 388,
+          "line": 440,
           "column": 30,
           "version": "10.0.1"
         },
@@ -8166,8 +11014,8 @@
         },
         {
           "filePath": "src/library-authoring/studio-header/StudioHeader.jsx",
-          "line": 85,
-          "column": 20,
+          "line": 54,
+          "column": 22,
           "version": "10.0.1"
         },
         {
@@ -8181,6 +11029,12 @@
           "line": 87,
           "column": 20,
           "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/studio-header/StudioHeader.jsx",
+          "line": 88,
+          "column": 20,
+          "version": "10.0.1"
         }
       ],
       "Alert": [
@@ -8191,9 +11045,21 @@
           "version": "10.0.1"
         },
         {
+          "filePath": "src/library-authoring/common/SuccessAlert.jsx",
+          "line": 11,
+          "column": 6,
+          "version": "10.0.1"
+        },
+        {
           "filePath": "src/library-authoring/configure-library/LibraryConfigurePage.jsx",
           "line": 194,
           "column": 14,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportPage.jsx",
+          "line": 367,
+          "column": 18,
           "version": "10.0.1"
         },
         {
@@ -8204,7 +11070,7 @@
         },
         {
           "filePath": "src/library-authoring/edit-block/LibraryBlockPage.jsx",
-          "line": 226,
+          "line": 227,
           "column": 14,
           "version": "10.0.1"
         },
@@ -8223,8 +11089,14 @@
           "version": "10.0.1"
         },
         {
+          "filePath": "src/library-authoring/course-import/CourseImportPage.jsx",
+          "line": 191,
+          "column": 8,
+          "version": "10.0.1"
+        },
+        {
           "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
-          "line": 182,
+          "line": 241,
           "column": 16,
           "version": "10.0.1"
         }
@@ -8287,20 +11159,32 @@
           "version": "10.0.1"
         },
         {
+          "filePath": "src/library-authoring/course-import/CourseImportPage.jsx",
+          "line": 193,
+          "column": 12,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportPage.jsx",
+          "line": 214,
+          "column": 12,
+          "version": "10.0.1"
+        },
+        {
           "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
-          "line": 184,
+          "line": 243,
           "column": 20,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
-          "line": 206,
+          "line": 265,
           "column": 20,
           "version": "10.0.1"
         },
         {
           "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
-          "line": 220,
+          "line": 279,
           "column": 20,
           "version": "10.0.1"
         }
@@ -8324,6 +11208,12 @@
           "filePath": "src/library-authoring/configure-library/LibraryConfigurePage.jsx",
           "line": 302,
           "column": 18,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportListItem.jsx",
+          "line": 54,
+          "column": 10,
           "version": "10.0.1"
         },
         {
@@ -8366,15 +11256,107 @@
         },
         {
           "filePath": "src/library-authoring/studio-header/StudioHeader.jsx",
-          "line": 82,
+          "line": 83,
           "column": 20,
+          "version": "10.0.1"
+        }
+      ],
+      "Form.Row": [
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportPage.jsx",
+          "line": 192,
+          "column": 10,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportPage.jsx",
+          "line": 213,
+          "column": 10,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
+          "line": 242,
+          "column": 18,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
+          "line": 264,
+          "column": 18,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
+          "line": 278,
+          "column": 18,
+          "version": "10.0.1"
+        }
+      ],
+      "Form.Label": [
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportPage.jsx",
+          "line": 194,
+          "column": 14,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportPage.jsx",
+          "line": 215,
+          "column": 14,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
+          "line": 244,
+          "column": 22,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
+          "line": 266,
+          "column": 22,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
+          "line": 280,
+          "column": 22,
+          "version": "10.0.1"
+        }
+      ],
+      "Form.Control": [
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportPage.jsx",
+          "line": 198,
+          "column": 16,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
+          "line": 248,
+          "column": 24,
+          "version": "10.0.1"
+        }
+      ],
+      "Badge": [
+        {
+          "filePath": "src/library-authoring/course-import/CourseImportTaskListItem.jsx",
+          "line": 41,
+          "column": 12,
+          "version": "10.0.1"
+        },
+        {
+          "filePath": "src/library-authoring/library-access/UserAccessWidget.jsx",
+          "line": 29,
+          "column": 8,
           "version": "10.0.1"
         }
       ],
       "Spinner": [
         {
           "filePath": "src/library-authoring/edit-block/LibraryBlockPage.jsx",
-          "line": 262,
+          "line": 263,
           "column": 22,
           "version": "10.0.1"
         }
@@ -8384,62 +11366,6 @@
           "filePath": "src/library-authoring/library-access/LibraryAccessForm.jsx",
           "line": 34,
           "column": 14,
-          "version": "10.0.1"
-        }
-      ],
-      "Badge": [
-        {
-          "filePath": "src/library-authoring/library-access/UserAccessWidget.jsx",
-          "line": 29,
-          "column": 8,
-          "version": "10.0.1"
-        }
-      ],
-      "Form.Row": [
-        {
-          "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
-          "line": 183,
-          "column": 18,
-          "version": "10.0.1"
-        },
-        {
-          "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
-          "line": 205,
-          "column": 18,
-          "version": "10.0.1"
-        },
-        {
-          "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
-          "line": 219,
-          "column": 18,
-          "version": "10.0.1"
-        }
-      ],
-      "Form.Label": [
-        {
-          "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
-          "line": 185,
-          "column": 22,
-          "version": "10.0.1"
-        },
-        {
-          "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
-          "line": 207,
-          "column": 22,
-          "version": "10.0.1"
-        },
-        {
-          "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
-          "line": 221,
-          "column": 22,
-          "version": "10.0.1"
-        }
-      ],
-      "Form.Control": [
-        {
-          "filePath": "src/library-authoring/list-libraries/LibraryListPage.jsx",
-          "line": 189,
-          "column": 24,
           "version": "10.0.1"
         }
       ]
@@ -8555,7 +11481,7 @@
     }
   },
   {
-    "version": "16.0.1",
+    "version": "16.6.1",
     "name": "@edx/frontend-app-profile",
     "repository": {
       "type": "git",
@@ -8568,19 +11494,19 @@
           "filePath": "src/profile/AgeMessage.jsx",
           "line": 8,
           "column": 4,
-          "version": "16.0.1"
+          "version": "16.6.1"
         },
         {
           "filePath": "src/profile/forms/SocialLinks.jsx",
           "line": 168,
           "column": 36,
-          "version": "16.0.1"
+          "version": "16.6.1"
         },
         {
           "filePath": "src/profile/ProfilePage.jsx",
-          "line": 135,
+          "line": 149,
           "column": 10,
-          "version": "16.0.1"
+          "version": "16.6.1"
         }
       ],
       "ValidationFormGroup": [
@@ -8588,25 +11514,25 @@
           "filePath": "src/profile/forms/Bio.jsx",
           "line": 59,
           "column": 16,
-          "version": "16.0.1"
+          "version": "16.6.1"
         },
         {
           "filePath": "src/profile/forms/Country.jsx",
           "line": 70,
           "column": 16,
-          "version": "16.0.1"
+          "version": "16.6.1"
         },
         {
           "filePath": "src/profile/forms/Education.jsx",
           "line": 66,
           "column": 16,
-          "version": "16.0.1"
+          "version": "16.6.1"
         },
         {
           "filePath": "src/profile/forms/PreferredLanguage.jsx",
           "line": 80,
           "column": 16,
-          "version": "16.0.1"
+          "version": "16.6.1"
         }
       ],
       "Hyperlink": [
@@ -8614,13 +11540,13 @@
           "filePath": "src/profile/forms/Certificates.jsx",
           "line": 106,
           "column": 14,
-          "version": "16.0.1"
+          "version": "16.6.1"
         },
         {
           "filePath": "src/profile/ProfilePage.jsx",
-          "line": 104,
+          "line": 118,
           "column": 6,
-          "version": "16.0.1"
+          "version": "16.6.1"
         }
       ],
       "Button": [
@@ -8628,19 +11554,19 @@
           "filePath": "src/profile/forms/elements/EditButton.jsx",
           "line": 14,
           "column": 4,
-          "version": "16.0.1"
+          "version": "16.6.1"
         },
         {
           "filePath": "src/profile/forms/elements/FormControls.jsx",
           "line": 54,
           "column": 8,
-          "version": "16.0.1"
+          "version": "16.6.1"
         },
         {
           "filePath": "src/profile/forms/ProfileAvatar.jsx",
           "line": 59,
           "column": 8,
-          "version": "16.0.1"
+          "version": "16.6.1"
         }
       ],
       "StatefulButton": [
@@ -8648,7 +11574,7 @@
           "filePath": "src/profile/forms/elements/FormControls.jsx",
           "line": 32,
           "column": 8,
-          "version": "16.0.1"
+          "version": "16.6.1"
         }
       ],
       "TransitionReplace": [
@@ -8656,7 +11582,7 @@
           "filePath": "src/profile/forms/elements/SwitchContent.jsx",
           "line": 44,
           "column": 4,
-          "version": "16.0.1"
+          "version": "16.6.1"
         }
       ],
       "Dropdown": [
@@ -8664,7 +11590,7 @@
           "filePath": "src/profile/forms/ProfileAvatar.jsx",
           "line": 75,
           "column": 6,
-          "version": "16.0.1"
+          "version": "16.6.1"
         }
       ],
       "Dropdown.Toggle": [
@@ -8672,7 +11598,7 @@
           "filePath": "src/profile/forms/ProfileAvatar.jsx",
           "line": 76,
           "column": 8,
-          "version": "16.0.1"
+          "version": "16.6.1"
         }
       ],
       "Dropdown.Menu": [
@@ -8680,7 +11606,7 @@
           "filePath": "src/profile/forms/ProfileAvatar.jsx",
           "line": 79,
           "column": 8,
-          "version": "16.0.1"
+          "version": "16.6.1"
         }
       ],
       "Dropdown.Item": [
@@ -8688,13 +11614,13 @@
           "filePath": "src/profile/forms/ProfileAvatar.jsx",
           "line": 80,
           "column": 10,
-          "version": "16.0.1"
+          "version": "16.6.1"
         },
         {
           "filePath": "src/profile/forms/ProfileAvatar.jsx",
           "line": 87,
           "column": 10,
-          "version": "16.0.1"
+          "version": "16.6.1"
         }
       ]
     }
@@ -9033,295 +11959,127 @@
     },
     "folderName": "frontend-app-support-tools",
     "usages": {
-      "Dropdown": [
+      "Row": [
         {
-          "filePath": "src/supportHeader/DesktopHeader.jsx",
-          "line": 54,
-          "column": 6,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/supportHeader/MobileHeader.jsx",
-          "line": 56,
-          "column": 6,
-          "version": "12.8.0"
-        }
-      ],
-      "Dropdown.Toggle": [
-        {
-          "filePath": "src/supportHeader/DesktopHeader.jsx",
-          "line": 55,
-          "column": 8,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/supportHeader/MobileHeader.jsx",
-          "line": 57,
-          "column": 8,
-          "version": "12.8.0"
-        }
-      ],
-      "Dropdown.Menu": [
-        {
-          "filePath": "src/supportHeader/DesktopHeader.jsx",
-          "line": 59,
-          "column": 8,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/supportHeader/MobileHeader.jsx",
-          "line": 61,
-          "column": 8,
-          "version": "12.8.0"
-        }
-      ],
-      "Dropdown.Item": [
-        {
-          "filePath": "src/supportHeader/DesktopHeader.jsx",
-          "line": 70,
-          "column": 6,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/supportHeader/DesktopHeader.jsx",
-          "line": 78,
-          "column": 6,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/supportHeader/MobileHeader.jsx",
-          "line": 72,
-          "column": 6,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/supportHeader/MobileHeader.jsx",
-          "line": 80,
-          "column": 6,
-          "version": "12.8.0"
-        }
-      ],
-      "Button": [
-        {
-          "filePath": "src/Table.jsx",
-          "line": 69,
-          "column": 8,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/userMessages/Alert.jsx",
-          "line": 49,
-          "column": 22,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/enrollments/Certificates.jsx",
-          "line": 62,
-          "column": 8,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/enrollments/Certificates.jsx",
-          "line": 156,
-          "column": 24,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/enrollments/Certificates.jsx",
-          "line": 166,
-          "column": 24,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/enrollments/ChangeEnrollmentForm.jsx",
-          "line": 99,
-          "column": 10,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/enrollments/ChangeEnrollmentForm.jsx",
-          "line": 107,
-          "column": 10,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/enrollments/CreateEnrollmentForm.jsx",
-          "line": 97,
-          "column": 10,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/enrollments/CreateEnrollmentForm.jsx",
-          "line": 105,
-          "column": 10,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/enrollments/Enrollments.jsx",
-          "line": 109,
-          "column": 12,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/enrollments/Enrollments.jsx",
-          "line": 120,
-          "column": 12,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/enrollments/Enrollments.jsx",
-          "line": 130,
-          "column": 12,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/enrollments/Enrollments.jsx",
-          "line": 200,
-          "column": 10,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/entitlements/CreateEntitlementForm.jsx",
-          "line": 92,
-          "column": 10,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/entitlements/CreateEntitlementForm.jsx",
-          "line": 103,
-          "column": 10,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/entitlements/Entitlements.jsx",
-          "line": 104,
-          "column": 10,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/entitlements/Entitlements.jsx",
-          "line": 160,
-          "column": 12,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/entitlements/Entitlements.jsx",
-          "line": 170,
-          "column": 12,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/entitlements/Entitlements.jsx",
-          "line": 183,
-          "column": 12,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/entitlements/Entitlements.jsx",
-          "line": 262,
-          "column": 10,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/entitlements/ExpireEntitlementForm.jsx",
-          "line": 86,
-          "column": 10,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/entitlements/ExpireEntitlementForm.jsx",
-          "line": 97,
-          "column": 10,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/entitlements/ReissueEntitlementForm.jsx",
-          "line": 84,
-          "column": 10,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/entitlements/ReissueEntitlementForm.jsx",
-          "line": 95,
-          "column": 10,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/IdentityVerificationStatus.jsx",
-          "line": 97,
-          "column": 10,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/SingleSignOnRecords.jsx",
-          "line": 82,
-          "column": 10,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/UserSearch.jsx",
-          "line": 22,
-          "column": 8,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/UserSummary.jsx",
-          "line": 148,
+          "filePath": "src/FeatureBasedEnrollments/FeatureBasedEnrollment.jsx",
+          "line": 45,
           "column": 16,
           "version": "12.8.0"
         },
         {
-          "filePath": "src/users/UserSummary.jsx",
-          "line": 155,
-          "column": 16,
+          "filePath": "src/users/v2/SingleSignOnRecordCard.jsx",
+          "line": 43,
+          "column": 10,
           "version": "12.8.0"
-        },
+        }
+      ],
+      "Col": [
         {
-          "filePath": "src/users/UserSummary.jsx",
-          "line": 162,
+          "filePath": "src/FeatureBasedEnrollments/FeatureBasedEnrollment.jsx",
+          "line": 46,
           "column": 18,
           "version": "12.8.0"
         },
         {
-          "filePath": "src/users/UserSummary.jsx",
-          "line": 197,
+          "filePath": "src/FeatureBasedEnrollments/FeatureBasedEnrollment.jsx",
+          "line": 49,
+          "column": 18,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/v2/SingleSignOnRecordCard.jsx",
+          "line": 44,
           "column": 12,
           "version": "12.8.0"
         },
         {
-          "filePath": "src/users/UserSummary.jsx",
-          "line": 222,
+          "filePath": "src/users/v2/SingleSignOnRecordCard.jsx",
+          "line": 49,
           "column": 12,
           "version": "12.8.0"
         }
       ],
-      "InputSelect": [
+      "Card": [
         {
-          "filePath": "src/users/enrollments/ChangeEnrollmentForm.jsx",
-          "line": 66,
+          "filePath": "src/FeatureBasedEnrollments/FeatureBasedEnrollmentCard.jsx",
+          "line": 10,
+          "column": 4,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/v2/SingleSignOnRecordCard.jsx",
+          "line": 38,
+          "column": 6,
+          "version": "12.8.0"
+        }
+      ],
+      "Card.Body": [
+        {
+          "filePath": "src/FeatureBasedEnrollments/FeatureBasedEnrollmentCard.jsx",
+          "line": 11,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/v2/SingleSignOnRecordCard.jsx",
+          "line": 39,
+          "column": 8,
+          "version": "12.8.0"
+        }
+      ],
+      "Card.Title": [
+        {
+          "filePath": "src/FeatureBasedEnrollments/FeatureBasedEnrollmentCard.jsx",
+          "line": 12,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/v2/SingleSignOnRecordCard.jsx",
+          "line": 40,
           "column": 10,
           "version": "12.8.0"
         },
         {
-          "filePath": "src/users/enrollments/ChangeEnrollmentForm.jsx",
-          "line": 77,
+          "filePath": "src/users/v2/SingleSignOnRecordCard.jsx",
+          "line": 56,
           "column": 10,
+          "version": "12.8.0"
+        }
+      ],
+      "Badge": [
+        {
+          "filePath": "src/FeatureBasedEnrollments/FeatureBasedEnrollmentCard.jsx",
+          "line": 13,
+          "column": 38,
           "version": "12.8.0"
         },
         {
-          "filePath": "src/users/enrollments/CreateEnrollmentForm.jsx",
-          "line": 65,
-          "column": 10,
+          "filePath": "src/FeatureBasedEnrollments/FeatureBasedEnrollmentCard.jsx",
+          "line": 13,
+          "column": 81,
           "version": "12.8.0"
         },
         {
-          "filePath": "src/users/enrollments/CreateEnrollmentForm.jsx",
-          "line": 75,
-          "column": 10,
+          "filePath": "src/users/licenses/Licenses.jsx",
+          "line": 108,
+          "column": 16,
           "version": "12.8.0"
         }
       ],
       "Input": [
+        {
+          "filePath": "src/FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage.jsx",
+          "line": 96,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/account-actions/TogglePasswordStatus.jsx",
+          "line": 48,
+          "column": 12,
+          "version": "12.8.0"
+        },
         {
           "filePath": "src/users/enrollments/ChangeEnrollmentForm.jsx",
           "line": 89,
@@ -9338,6 +12096,24 @@
           "filePath": "src/users/enrollments/CreateEnrollmentForm.jsx",
           "line": 87,
           "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/ChangeEnrollmentForm.jsx",
+          "line": 121,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/CreateEnrollmentForm.jsx",
+          "line": 54,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/CreateEnrollmentForm.jsx",
+          "line": 80,
+          "column": 8,
           "version": "12.8.0"
         },
         {
@@ -9395,15 +12171,535 @@
           "version": "12.8.0"
         },
         {
+          "filePath": "src/users/entitlements/v2/CreateEntitlementForm.jsx",
+          "line": 63,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/CreateEntitlementForm.jsx",
+          "line": 73,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/CreateEntitlementForm.jsx",
+          "line": 87,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/ExpireEntitlementForm.jsx",
+          "line": 77,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/ReissueEntitlementForm.jsx",
+          "line": 75,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
           "filePath": "src/users/UserSearch.jsx",
           "line": 21,
           "column": 8,
           "version": "12.8.0"
+        }
+      ],
+      "Button": [
+        {
+          "filePath": "src/FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage.jsx",
+          "line": 97,
+          "column": 10,
+          "version": "12.8.0"
         },
         {
-          "filePath": "src/users/UserSummary.jsx",
-          "line": 209,
-          "column": 14,
+          "filePath": "src/Table.jsx",
+          "line": 69,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/userMessages/Alert.jsx",
+          "line": 49,
+          "column": 22,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/account-actions/PasswordHistory.jsx",
+          "line": 46,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/account-actions/ResetPassword.jsx",
+          "line": 19,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/account-actions/ResetPassword.jsx",
+          "line": 30,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/account-actions/TogglePasswordStatus.jsx",
+          "line": 25,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/account-actions/TogglePasswordStatus.jsx",
+          "line": 36,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/Certificates.jsx",
+          "line": 66,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/Certificates.jsx",
+          "line": 160,
+          "column": 24,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/Certificates.jsx",
+          "line": 170,
+          "column": 24,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/ChangeEnrollmentForm.jsx",
+          "line": 99,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/ChangeEnrollmentForm.jsx",
+          "line": 107,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/CreateEnrollmentForm.jsx",
+          "line": 97,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/CreateEnrollmentForm.jsx",
+          "line": 105,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/Enrollments.jsx",
+          "line": 109,
+          "column": 12,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/Enrollments.jsx",
+          "line": 120,
+          "column": 12,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/Enrollments.jsx",
+          "line": 130,
+          "column": 12,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/Enrollments.jsx",
+          "line": 200,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/ChangeEnrollmentForm.jsx",
+          "line": 150,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/CreateEnrollmentForm.jsx",
+          "line": 107,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/Enrollments.jsx",
+          "line": 210,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/CreateEntitlementForm.jsx",
+          "line": 92,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/CreateEntitlementForm.jsx",
+          "line": 103,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/Entitlements.jsx",
+          "line": 76,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/Entitlements.jsx",
+          "line": 131,
+          "column": 12,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/Entitlements.jsx",
+          "line": 141,
+          "column": 12,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/Entitlements.jsx",
+          "line": 154,
+          "column": 12,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/Entitlements.jsx",
+          "line": 233,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/ExpireEntitlementForm.jsx",
+          "line": 86,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/ExpireEntitlementForm.jsx",
+          "line": 97,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/ReissueEntitlementForm.jsx",
+          "line": 84,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/ReissueEntitlementForm.jsx",
+          "line": 95,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/CreateEntitlementForm.jsx",
+          "line": 113,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/Entitlements.jsx",
+          "line": 244,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/ExpireEntitlementForm.jsx",
+          "line": 105,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/ReissueEntitlementForm.jsx",
+          "line": 103,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/IdentityVerificationStatus.jsx",
+          "line": 97,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/SingleSignOnRecords.jsx",
+          "line": 82,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/UserSearch.jsx",
+          "line": 22,
+          "column": 8,
+          "version": "12.8.0"
+        }
+      ],
+      "Dropdown": [
+        {
+          "filePath": "src/supportHeader/DesktopHeader.jsx",
+          "line": 54,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/supportHeader/MobileHeader.jsx",
+          "line": 56,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/Enrollments.jsx",
+          "line": 75,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/Entitlements.jsx",
+          "line": 100,
+          "column": 8,
+          "version": "12.8.0"
+        }
+      ],
+      "Dropdown.Toggle": [
+        {
+          "filePath": "src/supportHeader/DesktopHeader.jsx",
+          "line": 55,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/supportHeader/MobileHeader.jsx",
+          "line": 57,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/Enrollments.jsx",
+          "line": 76,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/Entitlements.jsx",
+          "line": 101,
+          "column": 10,
+          "version": "12.8.0"
+        }
+      ],
+      "Dropdown.Menu": [
+        {
+          "filePath": "src/supportHeader/DesktopHeader.jsx",
+          "line": 59,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/supportHeader/MobileHeader.jsx",
+          "line": 61,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/Enrollments.jsx",
+          "line": 79,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/Entitlements.jsx",
+          "line": 104,
+          "column": 10,
+          "version": "12.8.0"
+        }
+      ],
+      "Dropdown.Item": [
+        {
+          "filePath": "src/supportHeader/DesktopHeader.jsx",
+          "line": 70,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/supportHeader/DesktopHeader.jsx",
+          "line": 78,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/supportHeader/MobileHeader.jsx",
+          "line": 72,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/supportHeader/MobileHeader.jsx",
+          "line": 80,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/Enrollments.jsx",
+          "line": 80,
+          "column": 12,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/Enrollments.jsx",
+          "line": 89,
+          "column": 12,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/Entitlements.jsx",
+          "line": 105,
+          "column": 12,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/Entitlements.jsx",
+          "line": 116,
+          "column": 12,
+          "version": "12.8.0"
+        }
+      ],
+      "Modal": [
+        {
+          "filePath": "src/users/account-actions/PasswordHistory.jsx",
+          "line": 55,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/account-actions/ResetPassword.jsx",
+          "line": 26,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/account-actions/TogglePasswordStatus.jsx",
+          "line": 32,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/ChangeEnrollmentForm.jsx",
+          "line": 136,
+          "column": 4,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/CreateEnrollmentForm.jsx",
+          "line": 93,
+          "column": 4,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/Entitlements.jsx",
+          "line": 273,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/CreateEntitlementForm.jsx",
+          "line": 99,
+          "column": 4,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/ExpireEntitlementForm.jsx",
+          "line": 91,
+          "column": 4,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/ReissueEntitlementForm.jsx",
+          "line": 89,
+          "column": 4,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/IdentityVerificationStatus.jsx",
+          "line": 113,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/SingleSignOnRecords.jsx",
+          "line": 97,
+          "column": 6,
+          "version": "12.8.0"
+        }
+      ],
+      "Table": [
+        {
+          "filePath": "src/users/account-actions/PasswordHistory.jsx",
+          "line": 61,
+          "column": 10,
+          "version": "12.8.0"
+        }
+      ],
+      "InputSelect": [
+        {
+          "filePath": "src/users/enrollments/ChangeEnrollmentForm.jsx",
+          "line": 66,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/ChangeEnrollmentForm.jsx",
+          "line": 77,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/CreateEnrollmentForm.jsx",
+          "line": 65,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/CreateEnrollmentForm.jsx",
+          "line": 75,
+          "column": 10,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/ChangeEnrollmentForm.jsx",
+          "line": 101,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/ChangeEnrollmentForm.jsx",
+          "line": 111,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/CreateEnrollmentForm.jsx",
+          "line": 62,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/CreateEnrollmentForm.jsx",
+          "line": 71,
+          "column": 8,
           "version": "12.8.0"
         }
       ],
@@ -9427,14 +12723,38 @@
           "version": "12.8.0"
         },
         {
-          "filePath": "src/users/entitlements/Entitlements.jsx",
-          "line": 276,
+          "filePath": "src/users/enrollments/v2/Enrollments.jsx",
+          "line": 235,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/enrollments/v2/Enrollments.jsx",
+          "line": 249,
           "column": 6,
           "version": "12.8.0"
         },
         {
           "filePath": "src/users/entitlements/Entitlements.jsx",
-          "line": 290,
+          "line": 247,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/Entitlements.jsx",
+          "line": 261,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/Entitlements.jsx",
+          "line": 271,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/entitlements/v2/Entitlements.jsx",
+          "line": 285,
           "column": 6,
           "version": "12.8.0"
         }
@@ -9448,7 +12768,7 @@
         },
         {
           "filePath": "src/users/entitlements/Entitlements.jsx",
-          "line": 316,
+          "line": 285,
           "column": 6,
           "version": "12.8.0"
         },
@@ -9459,49 +12779,65 @@
           "version": "12.8.0"
         }
       ],
-      "Modal": [
+      "Hyperlink": [
         {
-          "filePath": "src/users/entitlements/Entitlements.jsx",
-          "line": 304,
-          "column": 6,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/IdentityVerificationStatus.jsx",
-          "line": 113,
-          "column": 6,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/SingleSignOnRecords.jsx",
-          "line": 97,
-          "column": 6,
-          "version": "12.8.0"
-        },
-        {
-          "filePath": "src/users/UserSummary.jsx",
-          "line": 181,
+          "filePath": "src/users/entitlements/v2/Entitlements.jsx",
+          "line": 64,
           "column": 8,
           "version": "12.8.0"
         },
         {
-          "filePath": "src/users/UserSummary.jsx",
-          "line": 193,
+          "filePath": "src/users/v2/CopyShowHyperLinks.jsx",
+          "line": 10,
+          "column": 6,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/v2/CopyShowHyperLinks.jsx",
+          "line": 23,
+          "column": 6,
+          "version": "12.8.0"
+        }
+      ],
+      "Tabs": [
+        {
+          "filePath": "src/users/v2/LearnerInformation.jsx",
+          "line": 16,
+          "column": 6,
+          "version": "12.8.0"
+        }
+      ],
+      "Tab": [
+        {
+          "filePath": "src/users/v2/LearnerInformation.jsx",
+          "line": 20,
           "column": 8,
           "version": "12.8.0"
         },
         {
-          "filePath": "src/users/UserSummary.jsx",
-          "line": 218,
+          "filePath": "src/users/v2/LearnerInformation.jsx",
+          "line": 28,
+          "column": 8,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/v2/LearnerInformation.jsx",
+          "line": 38,
           "column": 8,
           "version": "12.8.0"
         }
       ],
-      "Badge": [
+      "Card.Subtitle": [
         {
-          "filePath": "src/users/licenses/Licenses.jsx",
-          "line": 108,
-          "column": 16,
+          "filePath": "src/users/v2/SingleSignOnRecordCard.jsx",
+          "line": 45,
+          "column": 14,
+          "version": "12.8.0"
+        },
+        {
+          "filePath": "src/users/v2/SingleSignOnRecordCard.jsx",
+          "line": 50,
+          "column": 14,
           "version": "12.8.0"
         }
       ]
@@ -9607,7 +12943,7 @@
         },
         {
           "filePath": "src/CurrentRefinements.jsx",
-          "line": 96,
+          "line": 94,
           "column": 10,
           "version": false
         },
@@ -9633,13 +12969,13 @@
       "Badge": [
         {
           "filePath": "src/CurrentRefinements.jsx",
-          "line": 71,
+          "line": 69,
           "column": 10,
           "version": false
         },
         {
           "filePath": "src/CurrentRefinements.jsx",
-          "line": 84,
+          "line": 82,
           "column": 10,
           "version": false
         },
@@ -9731,7 +13067,7 @@
       "Container": [
         {
           "filePath": "src/SearchHeader.jsx",
-          "line": 22,
+          "line": 21,
           "column": 6,
           "version": false
         }
@@ -9739,7 +13075,7 @@
       "Row": [
         {
           "filePath": "src/SearchHeader.jsx",
-          "line": 23,
+          "line": 22,
           "column": 8,
           "version": false
         }
@@ -9747,13 +13083,13 @@
       "Col": [
         {
           "filePath": "src/SearchHeader.jsx",
-          "line": 24,
+          "line": 23,
           "column": 10,
           "version": false
         },
         {
           "filePath": "src/SearchHeader.jsx",
-          "line": 36,
+          "line": 35,
           "column": 10,
           "version": false
         }
@@ -9877,16 +13213,28 @@
       "Spinner": [
         {
           "filePath": "src/exam/Exam.jsx",
-          "line": 45,
+          "line": 70,
           "column": 8,
           "version": "13.17.0"
         }
       ],
       "Alert": [
         {
+          "filePath": "src/exam/Exam.jsx",
+          "line": 80,
+          "column": 8,
+          "version": "13.17.0"
+        },
+        {
           "filePath": "src/exam/ExamAPIError.jsx",
           "line": 37,
           "column": 4,
+          "version": "13.17.0"
+        },
+        {
+          "filePath": "src/instructions/UnknownAttemptStatusError.jsx",
+          "line": 6,
+          "column": 2,
           "version": "13.17.0"
         },
         {
@@ -9921,6 +13269,12 @@
           "filePath": "src/exam/ExamAPIError.jsx",
           "line": 39,
           "column": 6,
+          "version": "13.17.0"
+        },
+        {
+          "filePath": "src/instructions/UnknownAttemptStatusError.jsx",
+          "line": 7,
+          "column": 4,
           "version": "13.17.0"
         }
       ],
@@ -10301,7 +13655,7 @@
     }
   },
   {
-    "version": "14.16.10",
+    "version": "16.14.2",
     "name": "@edx/frontend-platform",
     "repository": {
       "type": "git",
@@ -10314,7 +13668,7 @@
           "filePath": "src/react/ErrorPage.jsx",
           "line": 25,
           "column": 6,
-          "version": "14.16.10"
+          "version": "16.14.2"
         }
       ],
       "Row": [
@@ -10322,7 +13676,7 @@
           "filePath": "src/react/ErrorPage.jsx",
           "line": 26,
           "column": 8,
-          "version": "14.16.10"
+          "version": "16.14.2"
         }
       ],
       "Col": [
@@ -10330,7 +13684,7 @@
           "filePath": "src/react/ErrorPage.jsx",
           "line": 27,
           "column": 10,
-          "version": "14.16.10"
+          "version": "16.14.2"
         }
       ],
       "Button": [
@@ -10338,13 +13692,13 @@
           "filePath": "src/react/ErrorPage.jsx",
           "line": 40,
           "column": 12,
-          "version": "14.16.10"
+          "version": "16.14.2"
         }
       ]
     }
   },
   {
-    "version": "13.17.5",
+    "version": "16.3.2",
     "name": "@edx/frontend-template-application",
     "repository": {
       "type": "git",
@@ -10354,7 +13708,7 @@
     "usages": {}
   },
   {
-    "version": "15.2.1",
+    "version": "16.14.0",
     "name": "@edx/gatsby-react-app",
     "repository": {
       "type": "git",
@@ -10365,75 +13719,215 @@
       "Button": [
         {
           "filePath": "src/components/Card/index.jsx",
-          "line": 142,
+          "line": 139,
           "column": 12,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Card/index.jsx",
-          "line": 182,
+          "line": 180,
           "column": 16,
-          "version": "15.2.1"
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Careers/JobList.jsx",
+          "line": 75,
+          "column": 16,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseHeader.jsx",
+          "line": 53,
+          "column": 10,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseHeaderExp.jsx",
+          "line": 76,
+          "column": 10,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseHeaderExp.jsx",
+          "line": 166,
+          "column": 26,
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Course/CourseRunSelector.jsx",
-          "line": 91,
-          "column": 8,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Course/Redesign/CourseHeader.jsx",
-          "line": 52,
+          "line": 213,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Course/Redesign/CourseRunSelector.jsx",
-          "line": 205,
+          "filePath": "src/components/Course/CourseRunSelectorExp.jsx",
+          "line": 231,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Course/Redesign/EnrollButtonLink.jsx",
-          "line": 296,
-          "column": 18,
-          "version": "15.2.1"
+          "filePath": "src/components/Course/EnrollButtonLink.jsx",
+          "line": 320,
+          "column": 20,
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Course/Redesign/Instructors.jsx",
+          "filePath": "src/components/Course/Instructors.jsx",
           "line": 56,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/EdX/ParagonCollapsible.jsx",
           "line": 94,
           "column": 10,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/EnrollButton/index.jsx",
-          "line": 409,
-          "column": 24,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Home/HomeSearchBar.jsx",
-          "line": 71,
+          "line": 72,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Search/SearchBox/AutoComplete.jsx",
-          "line": 457,
-          "column": 14,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Search/Test/ManagedAutoComplete.jsx",
-          "line": 260,
+          "filePath": "src/components/Search/ManagedAutoComplete.jsx",
+          "line": 261,
           "column": 12,
-          "version": "15.2.1"
+          "version": "16.14.0"
+        }
+      ],
+      "Icon": [
+        {
+          "filePath": "src/components/Card/index.jsx",
+          "line": 171,
+          "column": 32,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Card/index.jsx",
+          "line": 172,
+          "column": 31,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Card/index.jsx",
+          "line": 185,
+          "column": 18,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Carousel/index.jsx",
+          "line": 191,
+          "column": 10,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Carousel/index.jsx",
+          "line": 207,
+          "column": 10,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Collapsible/CollapsibleLink.jsx",
+          "line": 44,
+          "column": 12,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseHeader.jsx",
+          "line": 111,
+          "column": 10,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseHeaderExp.jsx",
+          "line": 135,
+          "column": 10,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseModes.jsx",
+          "line": 297,
+          "column": 50,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseModes.jsx",
+          "line": 306,
+          "column": 50,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseModesExp.jsx",
+          "line": 295,
+          "column": 50,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseModesExp.jsx",
+          "line": 304,
+          "column": 50,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseSnapshot.jsx",
+          "line": 72,
+          "column": 20,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseSnapshot.jsx",
+          "line": 101,
+          "column": 22,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseSnapshot.jsx",
+          "line": 137,
+          "column": 24,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseSnapshotExp.jsx",
+          "line": 57,
+          "column": 14,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseSnapshotExp.jsx",
+          "line": 122,
+          "column": 12,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseSnapshotExp.jsx",
+          "line": 142,
+          "column": 12,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/InstructorCard.jsx",
+          "line": 57,
+          "column": 22,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/DiscoveryCard/DiscoveryProgramCard.jsx",
+          "line": 208,
+          "column": 18,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Search/Pagination/index.jsx",
+          "line": 17,
+          "column": 19,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Search/Pagination/index.jsx",
+          "line": 18,
+          "column": 20,
+          "version": "16.14.0"
         }
       ],
       "Container": [
@@ -10441,569 +13935,551 @@
           "filePath": "src/components/CardPanels/CardListPanel.jsx",
           "line": 183,
           "column": 6,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Course/CourseMain.jsx",
-          "line": 152,
-          "column": 8,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Course/CourseMain.jsx",
-          "line": 173,
-          "column": 8,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Course/CourseMain.jsx",
-          "line": 210,
-          "column": 10,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Course/CourseMain.jsx",
-          "line": 234,
-          "column": 10,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Course/CourseMain.jsx",
-          "line": 277,
-          "column": 10,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Course/CourseMain.jsx",
-          "line": 295,
-          "column": 10,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Course/CourseMain.jsx",
-          "line": 308,
-          "column": 10,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Course/CourseMain.jsx",
-          "line": 324,
-          "column": 10,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Course/CourseMain.jsx",
-          "line": 350,
-          "column": 10,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Course/CourseMain.jsx",
-          "line": 379,
-          "column": 10,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Course/Redesign/BusinessBlock.jsx",
-          "line": 52,
-          "column": 4,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Course/Redesign/CourseHeader.jsx",
-          "line": 105,
+          "filePath": "src/components/Careers/Benefits.jsx",
+          "line": 123,
           "column": 6,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Course/Redesign/CourseMain.jsx",
-          "line": 93,
+          "filePath": "src/components/Careers/Hero.jsx",
+          "line": 38,
           "column": 4,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Course/Redesign/CourseModes.jsx",
-          "line": 147,
+          "filePath": "src/components/Careers/JobList.jsx",
+          "line": 48,
           "column": 4,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Course/Redesign/CourseRunSelector.jsx",
-          "line": 114,
+          "filePath": "src/components/Course/BusinessBlock.jsx",
+          "line": 49,
           "column": 4,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Course/Redesign/CourseSnapshot.jsx",
-          "line": 57,
-          "column": 12,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Course/Redesign/FAQ.jsx",
-          "line": 39,
+          "filePath": "src/components/Course/BusinessBlockExp.jsx",
+          "line": 49,
           "column": 4,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Course/Redesign/Navbar.jsx",
+          "filePath": "src/components/Course/CourseHeader.jsx",
+          "line": 106,
+          "column": 6,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseHeaderExp.jsx",
+          "line": 130,
+          "column": 6,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseMain.jsx",
+          "line": 95,
+          "column": 4,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseMainExp.jsx",
+          "line": 30,
+          "column": 2,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseModes.jsx",
+          "line": 154,
+          "column": 4,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseModesExp.jsx",
+          "line": 155,
+          "column": 4,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseRecommendationsExp.jsx",
+          "line": 17,
+          "column": 2,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseRunSelector.jsx",
+          "line": 123,
+          "column": 4,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseRunSelectorExp.jsx",
           "line": 129,
+          "column": 4,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseSnapshot.jsx",
+          "line": 58,
           "column": 12,
-          "version": "15.2.1"
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/FAQ.jsx",
+          "line": 40,
+          "column": 4,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/FAQExp.jsx",
+          "line": 34,
+          "column": 4,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/StickyNav.jsx",
+          "line": 146,
+          "column": 12,
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/EdX/AboutEdx.jsx",
           "line": 7,
           "column": 2,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/EdX/AboutEdx.jsx",
           "line": 8,
           "column": 4,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/EdX/EdxForBusiness.jsx",
-          "line": 44,
-          "column": 8,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/EdX/EdxStatistics.jsx",
           "line": 12,
           "column": 2,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/EdX/EdxStatistics.jsx",
           "line": 13,
           "column": 4,
-          "version": "15.2.1"
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Hero/Hero.exp.jsx",
+          "line": 22,
+          "column": 4,
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Home/Audiences.jsx",
-          "line": 16,
+          "line": 18,
           "column": 6,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Home/EdxVision.jsx",
           "line": 8,
           "column": 4,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Home/Hero.jsx",
-          "line": 57,
-          "column": 8,
-          "version": "15.2.1"
+          "line": 12,
+          "column": 6,
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Home/MarketingTakeover.jsx",
           "line": 20,
           "column": 4,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Home/MarketingTakeover.jsx",
           "line": 49,
           "column": 4,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Home/SubjectList.jsx",
-          "line": 16,
+          "line": 17,
           "column": 6,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Home/Trustbar.jsx",
           "line": 10,
           "column": 2,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Home/UniversalDesignOfLearning.jsx",
           "line": 6,
           "column": 2,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Program/ProgramDataBar.jsx",
           "line": 121,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Program/ProgramMain.jsx",
-          "line": 400,
+          "line": 394,
           "column": 8,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Program/ProgramMain.jsx",
-          "line": 401,
+          "line": 395,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Program/ProgramMain.jsx",
-          "line": 402,
+          "line": 396,
           "column": 12,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Program/ProgramMain.jsx",
-          "line": 634,
+          "line": 630,
           "column": 12,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Program/ProgramMain.jsx",
-          "line": 642,
+          "line": 638,
           "column": 12,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Program/ProgramMain.jsx",
-          "line": 661,
+          "line": 657,
           "column": 8,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Program/ProgramMain.jsx",
-          "line": 834,
+          "line": 842,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Program/ProgramMain.jsx",
-          "line": 835,
+          "line": 843,
           "column": 12,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Search/Test/Results/FullProductHits.jsx",
+          "filePath": "src/components/Search/Results/FullProductHits.jsx",
           "line": 31,
-          "column": 4,
-          "version": "15.2.1"
+          "column": 2,
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Search/Test/Results/OverviewProductHits.jsx",
+          "filePath": "src/components/Search/Results/OverviewProductHits.jsx",
           "line": 28,
           "column": 4,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Search/Test/Results/TabbedResults.jsx",
-          "line": 63,
-          "column": 8,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/SitewideBanner/index.jsx",
-          "line": 72,
+          "line": 69,
           "column": 8,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/SplitView/index.jsx",
           "line": 32,
           "column": 4,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/SubjectTopics/index.jsx",
-          "line": 56,
+          "line": 58,
           "column": 8,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/SubjectTopics/index.jsx",
-          "line": 66,
+          "line": 68,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/templates/aboutEdX.jsx",
-          "line": 372,
+          "line": 367,
           "column": 12,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/templates/aboutEdX.jsx",
-          "line": 396,
+          "line": 391,
           "column": 12,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/templates/allTopics.jsx",
-          "line": 69,
+          "line": 72,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/templates/allTopics.jsx",
-          "line": 80,
+          "line": 83,
           "column": 8,
-          "version": "15.2.1"
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/templates/careers.jsx",
+          "line": 82,
+          "column": 12,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/templates/careers.jsx",
+          "line": 99,
+          "column": 12,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/templates/mastersLandingPage.jsx",
+          "line": 111,
+          "column": 10,
+          "version": "16.14.0"
         },
         {
           "filePath": "src/templates/searchPageNew.jsx",
-          "line": 295,
-          "column": 10,
-          "version": "15.2.1"
+          "line": 335,
+          "column": 12,
+          "version": "16.14.0"
         }
       ],
       "Breadcrumb": [
         {
           "filePath": "src/components/Course/CourseHeader.jsx",
-          "line": 80,
-          "column": 14,
-          "version": "15.2.1"
+          "line": 108,
+          "column": 10,
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Course/Redesign/CourseHeader.jsx",
-          "line": 107,
+          "filePath": "src/components/Course/CourseHeader.jsx",
+          "line": 112,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Course/Redesign/CourseHeader.jsx",
-          "line": 111,
+          "filePath": "src/components/Course/CourseHeaderExp.jsx",
+          "line": 132,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseHeaderExp.jsx",
+          "line": 136,
+          "column": 10,
+          "version": "16.14.0"
         }
       ],
       "OverlayTrigger": [
         {
-          "filePath": "src/components/Course/CourseSidebar.jsx",
-          "line": 112,
-          "column": 14,
-          "version": "15.2.1"
+          "filePath": "src/components/Course/CourseModes.jsx",
+          "line": 231,
+          "column": 26,
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Course/Redesign/CourseModes.jsx",
-          "line": 216,
+          "filePath": "src/components/Course/CourseModes.jsx",
+          "line": 248,
           "column": 26,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Course/Redesign/CourseModes.jsx",
-          "line": 233,
+          "filePath": "src/components/Course/CourseModesExp.jsx",
+          "line": 229,
           "column": 26,
-          "version": "15.2.1"
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseModesExp.jsx",
+          "line": 246,
+          "column": 26,
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/ProgramPathway/ProgramPathwayCourse.jsx",
-          "line": 64,
+          "line": 61,
           "column": 6,
-          "version": "15.2.1"
-        }
-      ],
-      "Popover": [
-        {
-          "filePath": "src/components/Course/CourseSidebar.jsx",
-          "line": 117,
-          "column": 18,
-          "version": "15.2.1"
-        }
-      ],
-      "Popover.Content": [
-        {
-          "filePath": "src/components/Course/CourseSidebar.jsx",
-          "line": 118,
-          "column": 20,
-          "version": "15.2.1"
-        }
-      ],
-      "Icon": [
-        {
-          "filePath": "src/components/Course/CourseSidebar.jsx",
-          "line": 128,
-          "column": 16,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Course/Redesign/CourseSnapshot.jsx",
-          "line": 71,
-          "column": 20,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Course/Redesign/CourseSnapshot.jsx",
-          "line": 100,
-          "column": 22,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Course/Redesign/CourseSnapshot.jsx",
-          "line": 136,
-          "column": 24,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/DiscoveryCard/DiscoveryProgramCard.jsx",
-          "line": 180,
-          "column": 18,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Search/Test/Pagination/index.jsx",
-          "line": 16,
-          "column": 19,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Search/Test/Pagination/index.jsx",
-          "line": 17,
-          "column": 20,
-          "version": "15.2.1"
+          "version": "16.14.0"
         }
       ],
       "Tooltip": [
         {
-          "filePath": "src/components/Course/Redesign/CourseModes.jsx",
-          "line": 219,
+          "filePath": "src/components/Course/CourseModes.jsx",
+          "line": 234,
           "column": 30,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Course/Redesign/CourseModes.jsx",
-          "line": 236,
+          "filePath": "src/components/Course/CourseModes.jsx",
+          "line": 251,
           "column": 30,
-          "version": "15.2.1"
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseModesExp.jsx",
+          "line": 232,
+          "column": 30,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseModesExp.jsx",
+          "line": 249,
+          "column": 30,
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/ProgramPathway/ProgramPathwayCourse.jsx",
-          "line": 70,
+          "line": 67,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
         }
       ],
       "Card": [
         {
-          "filePath": "src/components/Course/Redesign/CourseRunSelectionTile.jsx",
-          "line": 49,
+          "filePath": "src/components/Course/CourseRunSelectionTile.jsx",
+          "line": 52,
           "column": 4,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/templates/allTopics.jsx",
-          "line": 85,
+          "line": 88,
           "column": 12,
-          "version": "15.2.1"
+          "version": "16.14.0"
         }
       ],
       "Card.Body": [
         {
-          "filePath": "src/components/Course/Redesign/CourseRunSelectionTile.jsx",
-          "line": 50,
+          "filePath": "src/components/Course/CourseRunSelectionTile.jsx",
+          "line": 53,
           "column": 6,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/templates/allTopics.jsx",
-          "line": 86,
+          "line": 89,
           "column": 14,
-          "version": "15.2.1"
+          "version": "16.14.0"
         }
       ],
       "Badge": [
         {
-          "filePath": "src/components/Course/Redesign/CourseRunSelectionTile.jsx",
-          "line": 54,
+          "filePath": "src/components/Course/CourseRunSelectionTile.jsx",
+          "line": 57,
           "column": 12,
-          "version": "15.2.1"
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/DiscoveryCard/DiscoveryCourseCard.jsx",
+          "line": 98,
+          "column": 14,
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/DiscoveryCard/DiscoveryProgramCard.jsx",
-          "line": 172,
+          "line": 130,
+          "column": 18,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/DiscoveryCard/DiscoveryProgramCard.jsx",
+          "line": 200,
           "column": 16,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/DiscoveryCard/experiment/OldCourseWithTag.jsx",
-          "line": 112,
-          "column": 16,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Search/Test/ManagedAutoComplete.jsx",
-          "line": 193,
+          "filePath": "src/components/Search/ManagedAutoComplete.jsx",
+          "line": 194,
           "column": 30,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Search/Test/ManagedAutoComplete.jsx",
-          "line": 247,
+          "filePath": "src/components/Search/ManagedAutoComplete.jsx",
+          "line": 248,
           "column": 30,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Search/Test/Refinements/FacetList.jsx",
-          "line": 185,
+          "filePath": "src/components/Search/Refinements/FacetList.jsx",
+          "line": 187,
           "column": 33,
-          "version": "15.2.1"
+          "version": "16.14.0"
         }
       ],
       "CardGrid": [
         {
-          "filePath": "src/components/Course/Redesign/CourseRunSelector.jsx",
-          "line": 177,
+          "filePath": "src/components/Course/CourseRunSelector.jsx",
+          "line": 184,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/components/Course/CourseRunSelectorExp.jsx",
+          "line": 202,
+          "column": 10,
+          "version": "16.14.0"
         }
       ],
       "Avatar": [
         {
-          "filePath": "src/components/Course/Redesign/InstructorCard.jsx",
-          "line": 50,
+          "filePath": "src/components/Course/InstructorCard.jsx",
+          "line": 49,
           "column": 20,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/MemberList/index.jsx",
           "line": 123,
           "column": 8,
-          "version": "15.2.1"
-        }
-      ],
-      "DropdownButton": [
-        {
-          "filePath": "src/components/Course/Redesign/Navbar.jsx",
-          "line": 131,
-          "column": 16,
-          "version": "15.2.1"
-        }
-      ],
-      "Dropdown.Item": [
-        {
-          "filePath": "src/components/Course/Redesign/Navbar.jsx",
-          "line": 143,
-          "column": 20,
-          "version": "15.2.1"
+          "version": "16.14.0"
         }
       ],
       "Alert": [
         {
-          "filePath": "src/components/Course/Redesign/RetirementBanner.jsx",
+          "filePath": "src/components/Course/RetirementBanner.jsx",
           "line": 7,
           "column": 2,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Program/ProgramMain.jsx",
-          "line": 407,
+          "line": 401,
           "column": 20,
-          "version": "15.2.1"
-        },
+          "version": "16.14.0"
+        }
+      ],
+      "DropdownButton": [
         {
-          "filePath": "src/templates/courseDetail.jsx",
-          "line": 194,
-          "column": 18,
-          "version": "15.2.1"
+          "filePath": "src/components/Course/StickyNav.jsx",
+          "line": 155,
+          "column": 16,
+          "version": "16.14.0"
+        }
+      ],
+      "Dropdown.Item": [
+        {
+          "filePath": "src/components/Course/StickyNav.jsx",
+          "line": 167,
+          "column": 20,
+          "version": "16.14.0"
         }
       ],
       "Input": [
@@ -11011,31 +14487,31 @@
           "filePath": "src/components/Footer/index.jsx",
           "line": 421,
           "column": 20,
-          "version": "15.2.1"
+          "version": "16.14.0"
         }
       ],
       "Dropdown": [
         {
           "filePath": "src/components/Header/UserMenu.jsx",
-          "line": 136,
+          "line": 138,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
         }
       ],
       "Dropdown.Toggle": [
         {
           "filePath": "src/components/Header/UserMenu.jsx",
-          "line": 137,
+          "line": 139,
           "column": 12,
-          "version": "15.2.1"
+          "version": "16.14.0"
         }
       ],
       "Dropdown.Menu": [
         {
           "filePath": "src/components/Header/UserMenu.jsx",
-          "line": 151,
+          "line": 153,
           "column": 12,
-          "version": "15.2.1"
+          "version": "16.14.0"
         }
       ],
       "Modal": [
@@ -11043,13 +14519,13 @@
           "filePath": "src/components/MemberList/index.jsx",
           "line": 163,
           "column": 8,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/Program/ProgramTrackModal.jsx",
           "line": 111,
           "column": 6,
-          "version": "15.2.1"
+          "version": "16.14.0"
         }
       ],
       "AvatarButton": [
@@ -11057,155 +14533,59 @@
           "filePath": "src/components/MemberList/MemberListItem.jsx",
           "line": 52,
           "column": 8,
-          "version": "15.2.1"
+          "version": "16.14.0"
         }
       ],
       "StatusAlert": [
         {
-          "filePath": "src/components/Search/DiscoveryCardList/noResultsBlurb.jsx",
-          "line": 41,
+          "filePath": "src/components/Search/ConnectedDiscoveryCardList/noResultsBlurb.jsx",
+          "line": 43,
           "column": 6,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
-          "filePath": "src/components/Search/Test/Results/NoResultsBlurb.jsx",
-          "line": 13,
+          "filePath": "src/components/Search/Results/NoResultsBlurb.jsx",
+          "line": 15,
           "column": 2,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/templates/appUpgrade.jsx",
-          "line": 73,
+          "line": 77,
           "column": 8,
-          "version": "15.2.1"
+          "version": "16.14.0"
         }
       ],
       "Pagination": [
         {
           "filePath": "src/components/Search/Pagination/index.jsx",
-          "line": 100,
-          "column": 8,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Search/Pagination/index.jsx",
-          "line": 113,
-          "column": 6,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Search/Test/Pagination/index.jsx",
-          "line": 32,
+          "line": 33,
           "column": 4,
-          "version": "15.2.1"
+          "version": "16.14.0"
         }
       ],
       "DataTable": [
         {
-          "filePath": "src/components/Search/Test/Results/FullProductHits.jsx",
+          "filePath": "src/components/Search/Results/FullProductHits.jsx",
           "line": 39,
-          "column": 6,
-          "version": "15.2.1"
+          "column": 4,
+          "version": "16.14.0"
         }
       ],
       "CardView": [
         {
-          "filePath": "src/components/Search/Test/Results/FullProductHits.jsx",
+          "filePath": "src/components/Search/Results/FullProductHits.jsx",
           "line": 74,
-          "column": 8,
-          "version": "15.2.1"
+          "column": 6,
+          "version": "16.14.0"
         }
       ],
       "DataTable.TableFooter": [
         {
-          "filePath": "src/components/Search/Test/Results/FullProductHits.jsx",
+          "filePath": "src/components/Search/Results/FullProductHits.jsx",
           "line": 79,
-          "column": 8,
-          "version": "15.2.1"
-        }
-      ],
-      "Tab.Container": [
-        {
-          "filePath": "src/components/Search/Test/Results/TabbedResults.jsx",
-          "line": 52,
-          "column": 4,
-          "version": "15.2.1"
-        }
-      ],
-      "Nav": [
-        {
-          "filePath": "src/components/Search/Test/Results/TabbedResults.jsx",
-          "line": 64,
-          "column": 10,
-          "version": "15.2.1"
-        }
-      ],
-      "Nav.Item": [
-        {
-          "filePath": "src/components/Search/Test/Results/TabbedResults.jsx",
-          "line": 65,
-          "column": 12,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Search/Test/Results/TabbedResults.jsx",
-          "line": 70,
-          "column": 12,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Search/Test/Results/TabbedResults.jsx",
-          "line": 75,
-          "column": 12,
-          "version": "15.2.1"
-        }
-      ],
-      "Nav.Link": [
-        {
-          "filePath": "src/components/Search/Test/Results/TabbedResults.jsx",
-          "line": 66,
-          "column": 14,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Search/Test/Results/TabbedResults.jsx",
-          "line": 71,
-          "column": 14,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Search/Test/Results/TabbedResults.jsx",
-          "line": 76,
-          "column": 14,
-          "version": "15.2.1"
-        }
-      ],
-      "Tab.Content": [
-        {
-          "filePath": "src/components/Search/Test/Results/TabbedResults.jsx",
-          "line": 95,
           "column": 6,
-          "version": "15.2.1"
-        }
-      ],
-      "Tab.Pane": [
-        {
-          "filePath": "src/components/Search/Test/Results/TabbedResults.jsx",
-          "line": 96,
-          "column": 8,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Search/Test/Results/TabbedResults.jsx",
-          "line": 132,
-          "column": 8,
-          "version": "15.2.1"
-        },
-        {
-          "filePath": "src/components/Search/Test/Results/TabbedResults.jsx",
-          "line": 144,
-          "column": 8,
-          "version": "15.2.1"
+          "version": "16.14.0"
         }
       ],
       "Row": [
@@ -11213,13 +14593,13 @@
           "filePath": "src/components/SplitView/index.jsx",
           "line": 34,
           "column": 8,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/SplitView/index.jsx",
           "line": 40,
           "column": 6,
-          "version": "15.2.1"
+          "version": "16.14.0"
         }
       ],
       "Col": [
@@ -11227,19 +14607,69 @@
           "filePath": "src/components/SplitView/index.jsx",
           "line": 35,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/SplitView/index.jsx",
           "line": 42,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
         },
         {
           "filePath": "src/components/SplitView/index.jsx",
           "line": 45,
           "column": 10,
-          "version": "15.2.1"
+          "version": "16.14.0"
+        }
+      ],
+      "Collapsible": [
+        {
+          "filePath": "src/templates/courseDetailMobileExp.jsx",
+          "line": 294,
+          "column": 12,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/templates/courseDetailMobileExp.jsx",
+          "line": 309,
+          "column": 14,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/templates/courseDetailMobileExp.jsx",
+          "line": 315,
+          "column": 12,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/templates/courseDetailMobileExp.jsx",
+          "line": 326,
+          "column": 14,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/templates/courseDetailMobileExp.jsx",
+          "line": 337,
+          "column": 14,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/templates/courseDetailMobileExp.jsx",
+          "line": 348,
+          "column": 14,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/templates/courseDetailMobileExp.jsx",
+          "line": 357,
+          "column": 14,
+          "version": "16.14.0"
+        },
+        {
+          "filePath": "src/templates/courseDetailMobileExp.jsx",
+          "line": 367,
+          "column": 14,
+          "version": "16.14.0"
         }
       ]
     }


### PR DESCRIPTION
* Pulls new data for Paragon usage insights, adding in a few other repos that have Paragon installed as a dependency.
* Adds a "Summary" tab to include a table of how many times each component has been used across all projects.

![image](https://user-images.githubusercontent.com/2828721/134991451-ebbf4c7b-e425-4e9d-a2b5-16df07a49ebf.png)
