### PR TITLE
fix: update iconAfter prop type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
     "testPathIgnorePatterns": [
       "/node_modules/",
       "/www/",
-      "/dist/"
+      "/dist/",
+      "/dependent-usage-analyzer/"
     ],
     "transformIgnorePatterns": [
       "/node_modules/(?!(@edx/paragon)/).*/"

--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -30,11 +30,11 @@ WrappedButton.propTypes = {
   /** Docstring for className... A class name to append to the button */
   className: PropTypes.string,
   /** An icon component to render.
-   * Example import of a Paragon icon component: `import { Check } from '@edx/paragon/dist/icon';` */
+   * Example import of a Paragon icon component: `import { Check } from '@edx/paragon/icons';` */
   iconBefore: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   /** An icon component to render.
-   * Example import of a Paragon icon component: `import { Check } from '@edx/paragon/dist/icon';` */
-  iconAfter: PropTypes.instanceOf([PropTypes.func, PropTypes.node]),
+   * Example import of a Paragon icon component: `import { Check } from '@edx/paragon/icons';` */
+  iconAfter: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
 };
 
 WrappedButton.defaultProps = {


### PR DESCRIPTION
Changes the `Button` component's `iconAfter` prop type to `PropTypes.oneOfType` instead of `PropTypes.instanceOf` to match the `iconBefore` prop. Also, generally it doesn't seem `PropTypes.instanceOf` actually supports passing an array to it for multiple types per its implementation:

https://github.com/facebook/prop-types/blob/4de0644a10a554d0a556daa39f029369bc007ea5/factoryWithTypeCheckers.js#L297-L307

Also, configures Jest to ignore tests in the `dependent-usage-analyzer` directory (which may include Git checkouts of 30+ projects). Running tests with these projects checked out resulted in Jest attempting to run tests in all projects.