### PR TITLE
feat: forward isBlocking to Alert and Marketing modals

### DIFF
--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -6,7 +6,7 @@ import { useTable } from 'react-table';
 
 import Table from './Table';
 import getVisibleColumns from './utils/getVisibleColumns';
-import { requiredWhen } from './utils/propTypesUtils';
+import { requiredWhen } from '../utils/propTypesUtils';
 import getTableArgs from './utils/getTableArgs';
 import TableControlBar from './TableControlBar';
 import EmptyTableContent from './EmptyTable';

--- a/src/DataTable/utils/propTypesUtils.js
+++ b/src/DataTable/utils/propTypesUtils.js
@@ -1,8 +1,0 @@
-/* eslint-disable import/prefer-default-export */
-
-export const requiredWhen = (propType, dependentOnProp) => (props, propName, componentName, ...rest) => {
-  if (props[dependentOnProp] === true && props[propName] === undefined) {
-    return new Error(`${componentName}: ${propName} is required when ${dependentOnProp} is set to true.`);
-  }
-  return propType(props, propName, componentName, ...rest);
-};

--- a/src/Modal/AlertModal.jsx
+++ b/src/Modal/AlertModal.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+
+import { requiredWhenNot } from '../utils/propTypesUtils';
 import ModalDialog from './ModalDialog';
 
-const AlertModal = ({ children, footerNode, ...props }) => (
+const AlertModal = ({
+  children,
+  footerNode,
+  ...props
+}) => (
   <ModalDialog
     {...props}
     className={classNames('pgn__alert-modal', props.className)}
@@ -19,9 +25,10 @@ const AlertModal = ({ children, footerNode, ...props }) => (
 AlertModal.propTypes = {
   children: PropTypes.node.isRequired,
   title: PropTypes.string.isRequired,
-  onClose: PropTypes.func.isRequired,
   isOpen: PropTypes.bool,
+  isBlocking: PropTypes.bool,
   hasCloseButton: PropTypes.bool,
+  onClose: requiredWhenNot(PropTypes.func, 'isBlocking'),
   size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl', 'fullscreen']),
   variant: PropTypes.oneOf(['default', 'warning', 'danger', 'success', 'dark']),
   closeLabel: PropTypes.string,
@@ -32,7 +39,9 @@ AlertModal.propTypes = {
 
 AlertModal.defaultProps = {
   isOpen: false,
+  isBlocking: false,
   hasCloseButton: false,
+  onClose: () => {},
   size: 'md',
   variant: 'default',
   closeLabel: 'Close',

--- a/src/Modal/MarketingModal.jsx
+++ b/src/Modal/MarketingModal.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
+import { requiredWhenNot } from '../utils/propTypesUtils';
 import ModalDialog from './ModalDialog';
 
 const MarketingModal = ({
@@ -28,9 +30,10 @@ const MarketingModal = ({
 MarketingModal.propTypes = {
   children: PropTypes.node.isRequired,
   title: PropTypes.string.isRequired,
-  onClose: PropTypes.func.isRequired,
   isOpen: PropTypes.bool,
+  isBlocking: PropTypes.bool,
   hasCloseButton: PropTypes.bool,
+  onClose: requiredWhenNot(PropTypes.func, 'isBlocking'),
   size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl', 'fullscreen']),
   closeLabel: PropTypes.string,
   className: PropTypes.string,
@@ -44,7 +47,9 @@ MarketingModal.propTypes = {
 
 MarketingModal.defaultProps = {
   isOpen: false,
+  isBlocking: false,
   hasCloseButton: true,
+  onClose: () => {},
   size: 'md',
   closeLabel: 'Close',
   className: undefined,

--- a/src/Modal/ModalDialog.jsx
+++ b/src/Modal/ModalDialog.jsx
@@ -24,11 +24,12 @@ function ModalDialog({
   isFullscreenScroll,
   className,
   isFullscreenOnMobile,
+  isBlocking,
 }) {
   const isMobile = useMediaQuery({ query: '(max-width: 767.98px)' });
   const showFullScreen = (isFullscreenOnMobile && isMobile);
   return (
-    <ModalLayer isOpen={isOpen} onClose={onClose}>
+    <ModalLayer isOpen={isOpen} onClose={onClose} isBlocking={isBlocking}>
       <div
         role="dialog"
         aria-label={title}
@@ -100,6 +101,10 @@ ModalDialog.propTypes = {
    * to show full screen view on mobile screens
    * */
   isFullscreenOnMobile: PropTypes.bool,
+  /**
+   * Prevent clicking on the backdrop to close the modal
+   * */
+  isBlocking: PropTypes.bool,
 };
 
 ModalDialog.defaultProps = {
@@ -111,6 +116,7 @@ ModalDialog.defaultProps = {
   className: undefined,
   isFullscreenScroll: false,
   isFullscreenOnMobile: false,
+  isBlocking: false,
 };
 
 ModalDialog.Header = ModalDialogHeader;

--- a/src/utils/propTypesUtils.js
+++ b/src/utils/propTypesUtils.js
@@ -1,0 +1,57 @@
+/**
+ * Returns a the passed target PropType (targetType) if the conditionFn returns true
+ * when called with the props object.
+ * If the conditional is false and the associated prop is not included, raise an error,
+ * giving the provided filterString as the explanation for the failure.
+ * @param {func} targetType - target PropType method
+ * @param {func} isRequiredFn - function taking the props object and returning whether or
+ *   not the associated prop should be required
+ * @param {string} filterString - string explanation of the isRequiredFn condition for error
+ *   messages.
+ * @return {func} - PropType based on targetType that is required if conditionFn returns true
+ *   when called with the props object.
+ */
+export const customPropTypeRequirement = (targetType, conditionFn, filterString) => (
+  (props, propName, componentName, ...rest) => {
+    if (conditionFn(props) && props[propName] === undefined) {
+      return new Error(
+        `${componentName}: ${propName} is required when ${filterString}`,
+      );
+    }
+    return targetType(props, propName, componentName, ...rest);
+  }
+);
+
+/**
+ * Returns a PropType entry with the given propType that is required if dependentOnProp
+ * is set to true.
+ * @param {func} propType - target PropType
+ * @param {string} dependentOnProp - string name for prop that, if true, marks the
+ *   associated prop as required
+ * @return {func} - PropType based on propType that is required if dependentOnProp is
+ *   set to true.
+ */
+export const requiredWhen = (propType, dependentOnProp) => (
+  customPropTypeRequirement(
+    propType,
+    (props) => props[dependentOnProp] === true,
+    `${dependentOnProp} is set to true`,
+  )
+);
+
+/**
+ * Returns a PropType entry with the given propType that is required if dependentOnProp
+ * is false-y.
+ * @param {func} propType - target PropType
+ * @param {string} otherPropName - string name for prop that, if false-y, marks the
+ *   associated prop as required
+ * @return {func} - PropType based on propType that is required if dependentOnProp is
+*    false-y
+ */
+export const requiredWhenNot = (propType, otherPropName) => (
+  customPropTypeRequirement(
+    propType,
+    (props) => !props[otherPropName],
+    `not ${otherPropName}`,
+  )
+);

--- a/src/utils/propTypesUtils.js
+++ b/src/utils/propTypesUtils.js
@@ -1,5 +1,5 @@
 /**
- * Returns a the passed target PropType (targetType) if the conditionFn returns true
+ * Returns the passed target PropType (targetType) if the conditionFn returns true
  * when called with the props object.
  * If the conditional is false and the associated prop is not included, raise an error,
  * giving the provided filterString as the explanation for the failure.
@@ -23,29 +23,29 @@ export const customPropTypeRequirement = (targetType, conditionFn, filterString)
 );
 
 /**
- * Returns a PropType entry with the given propType that is required if dependentOnProp
- * is set to true.
+ * Returns a PropType entry with the given propType that is required if otherPropName
+ * is truthy.
  * @param {func} propType - target PropType
- * @param {string} dependentOnProp - string name for prop that, if true, marks the
+ * @param {string} otherPropName - string name for prop that, if true, marks the
  *   associated prop as required
- * @return {func} - PropType based on propType that is required if dependentOnProp is
+ * @return {func} - PropType based on propType that is required if otherPropName is
  *   set to true.
  */
-export const requiredWhen = (propType, dependentOnProp) => (
+export const requiredWhen = (propType, otherPropName) => (
   customPropTypeRequirement(
     propType,
-    (props) => props[dependentOnProp] === true,
-    `${dependentOnProp} is set to true`,
+    (props) => props[otherPropName] === true,
+    `${otherPropName} is truthy`,
   )
 );
 
 /**
- * Returns a PropType entry with the given propType that is required if dependentOnProp
+ * Returns a PropType entry with the given propType that is required if otherPropName
  * is false-y.
  * @param {func} propType - target PropType
  * @param {string} otherPropName - string name for prop that, if false-y, marks the
  *   associated prop as required
- * @return {func} - PropType based on propType that is required if dependentOnProp is
+ * @return {func} - PropType based on propType that is required if otherPropName is
 *    false-y
  */
 export const requiredWhenNot = (propType, otherPropName) => (


### PR DESCRIPTION
Move requiredWhen from DataTable/utils/propTypesUtils into a top-level utils dir, and generalize into `customPropTypeRequirement`
`requiredWhen` and new `requiredWhenNot` methods wrap `customPropTypeRequirement`.

ModalDialog now forwards the `isBlocking` prop to the ModalLayer, and thus its inheritors now have that prop notated.
for MarketingModal and AlertModal, the `onClose` method is marked as required only if `isBlocking` is false-y.