### PR TITLE
[BD-46] docs: improve local development information

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,29 @@ JSX code blocks in the markdown file can be made interactive with the live attri
 
 Visit the documentation at [http://localhost:8000](http://localhost:8000) and navigate to see your README.md powered page and workbench. Changes to the README.md file will auto refesh the page.
 
+### Developing locally against MFE
+
+If you want to test the changes with local MFE setup, you need to create a "module.config.js" file in your MFE's directory containing local module overrides. After that the webpack build for your application will automatically pick your local version of Paragon and use it. The example of module.config.js file looks like this (for more details about module.config.js, refer to the [frontend-build documentation](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).):
+
+```javascript
+module.exports = {
+  /*
+  Modules you want to use from local source code. Adding a module here means that when 
+  your MFE runs its build, it'll resolve the source from peer directories of the app.
+
+  moduleName: the name you use to import code from the module.
+  dir: The relative path to the module's source code.
+  dist: The sub-directory of the source code where it puts its build artifact. Often "dist".
+  */
+  localModules: [
+    { moduleName: '@edx/paragon/scss/core', dir: '../src/paragon', dist: 'scss/core' },
+    { moduleName: '@edx/paragon/icons', dir: '../src/paragon', dist: 'icons' },
+    { moduleName: '@edx/paragon', dir: '../src/paragon', dist: 'dist' },
+  ],
+};
+```
+
+Then, when importing Paragon's core SCSS in your MFE the import needs to begin with a tilde `~` so that path to your local Paragon repository gets resolved correctly: `@import "~@edx/paragon/scss/core";`
 
 ### ESLint
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ module.exports = {
   localModules: [
     { moduleName: '@edx/paragon/scss/core', dir: '../src/paragon', dist: 'scss/core' },
     { moduleName: '@edx/paragon/icons', dir: '../src/paragon', dist: 'icons' },
+    // Note that using dist: 'dist' will require you to run 'npm build' in Paragon
+    // to add local changes to the 'dist' directory, so that they can be picked up by the MFE.
+    // To avoid doing that you can use dist: 'src' to get any local changes hot reloaded on save in the MFE.
     { moduleName: '@edx/paragon', dir: '../src/paragon', dist: 'dist' },
   ],
 };

--- a/www/src/pages/guides/installation-and-usage.mdx
+++ b/www/src/pages/guides/installation-and-usage.mdx
@@ -28,6 +28,8 @@ Usage with no theme:
 
 Usage with a theme:
 
+When working with a theme the order of imports is important: if you need to override Paragon's variables you must import theme's variables before Paragon core (that's because all variables in Paragon use `!default` flag which allows you to override them before importing, you can read more [here](https://sass-lang.com/documentation/variables#default-values)), while to override Paragon's styles, the theme's style overrides must be imported after.
+
 ```scss
 @import "@my-brand/fonts.scss";
 @import "@my-brand/variables.scss";


### PR DESCRIPTION
Update installation docs to explain order of imports when working with a theme and update README with local development guide

JIRA:
- [PAR-117](https://openedx.atlassian.net/browse/PAR-117)
- [PAR-259](https://openedx.atlassian.net/browse/PAR-259)