### PR TITLE
[BD-46] docs: add info message to empty PropsTables

### DIFF
--- a/www/src/components/PropsTable.jsx
+++ b/www/src/components/PropsTable.jsx
@@ -69,9 +69,11 @@ const PropsTable = ({ props: componentProps, displayName, content }) => (
       <Card.Title as="h3">{displayName} Props API</Card.Title>
       {content && <div className="small mb-3">{content}</div>}
     </Card.Body>
-    <ul className="list-unstyled">
-      {componentProps.map(metadata => <Prop key={metadata.name} {...metadata} />)}
-    </ul>
+    {componentProps.length > 0 ? (
+      <ul className="list-unstyled">
+        {componentProps.map(metadata => <Prop key={metadata.name} {...metadata} />)}
+      </ul>
+    ) : <div className="pb-3 pl-4">This component does not receive any props.</div>}
   </Card>
 );
 


### PR DESCRIPTION
Improve `PropsTable` component to add info message in case when component does not have any props.

Previously for components without props the table would be rendered as follows:
![image](https://user-images.githubusercontent.com/52399399/144383676-cdf3f672-52c8-4f8d-a75b-598c5bda50f7.png)


this PR changes it to:
![image](https://user-images.githubusercontent.com/52399399/144383568-474fdb7f-a591-4507-9dba-f1af31354a22.png)
