### PR TITLE
[BD-46] feat: implement new searchfield component design

### DIFF
--- a/src/SearchField/README.md
+++ b/src/SearchField/README.md
@@ -152,3 +152,20 @@ For needs that deviate from the basic usage above, use `<SearchField.Advanced />
   <SearchField.Input />
 </SearchField.Advanced>
 ```
+
+### Advanced usage with the submit button outside the input
+
+Use class `pgn__searchfield_wrapper` to group input elements apart from the submit button.
+
+```jsx live
+<SearchField.Advanced
+  onSubmit={value => console.log(`search submitted: ${value}`)}
+  submitButtonLocation="external"
+>
+  <div className="pgn__searchfield_wrapper">
+    <SearchField.Label/>
+    <SearchField.Input/>
+  </div>
+  <SearchField.SubmitButton submitButtonLocation="external" />
+</SearchField.Advanced>
+```

--- a/src/SearchField/README.md
+++ b/src/SearchField/README.md
@@ -77,6 +77,15 @@ notes:
 />
 ```
 
+### With the submit button outside the input
+
+```jsx live
+<SearchField
+  submitButtonLocation="external"
+  onSubmit={value => console.log(`search submitted: ${value}`)}
+/>
+```
+
 ### Advanced Usage
 
 For needs that deviate from the basic usage above, use `<SearchField.Advanced />`. The `children` elements must contain the `SearchField.Label` and `SearchField.Input` components at a minimum.

--- a/src/SearchField/SearchField.scss
+++ b/src/SearchField/SearchField.scss
@@ -4,6 +4,7 @@
     transition: $input-transition;
     border: $search-border-width solid $search-border-color;
 
+    &.disabled,
     &:disabled {
         opacity: $search-disabled-opacity;
         pointer-events: none;
@@ -23,8 +24,8 @@
     }
 
     .form-control {
-        @extend .border-0;
-        border-radius: $search-border-radius !important;
+        border: none;
+        border-radius: $search-border-radius;
         height: $input-height-search;
 
         &:focus {
@@ -61,15 +62,31 @@
     &.pgn__searchfield--external {
         border: none;
 
+        .btn-primary {
+            background: map-get($search-btn-variants, 'light');
+        }
+
+        .btn-brand {
+            background: map-get($search-btn-variants, 'dark');
+        }
+
         &.has-focus {
             box-shadow: none;
+
+            .btn-primary {
+                background: map-get($search-btn-variants, 'light');
+            }
+
+            .btn-brand {
+                background: map-get($search-btn-variants, 'dark');
+            }
         }
     }
 
     .pgn__searchfield_wrapper {
-        @extend .d-flex;
-        @extend .align-items-center;
-        @extend .w-100;
+        display: flex;
+        align-items: center;
+        width: 100%;
 
         border: $search-border-width solid $search-border-color;
 
@@ -83,10 +100,4 @@
 .pgn__searchfield__button.btn[type='submit'] {
     border-radius: 0;
     margin-left: $search-button-margin;
-
-    &:hover:before,
-    &:focus:before,
-    &:active:before {
-        border-radius: 0 !important;
-    }
 }

--- a/src/SearchField/SearchField.scss
+++ b/src/SearchField/SearchField.scss
@@ -1,14 +1,32 @@
-.pgn__searchfield {
-    @extend .border;
-    @extend .rounded;
-    transition: $input-transition;
+@import "variables";
 
-    &.has-focus {
-        box-shadow: $input-focus-box-shadow;
+.pgn__searchfield {
+    transition: $input-transition;
+    border: $search-border-width solid $search-border-color;
+
+    &.disabled,
+    &:disabled {
+        opacity: $search-disabled-opacity;
+        pointer-events: none;
     }
 
-    .form-control {
+    &.has-focus {
+        box-shadow: 0 0 0 $search-border-width $search-border-color-interaction;
+
+        .pgn__searchfield_wrapper {
+            box-shadow: 0 0 0 $search-border-width $search-border-color-interaction;
+        }
+    }
+
+    &:hover,
+    &:active {
+        border-color: $search-border-color-interaction;
+    }
+
+    & .form-control {
         @extend .border-0;
+        border-radius: $search-border-radius !important;
+        height: $input-height-search;
 
         &:focus {
             box-shadow: none;
@@ -29,14 +47,47 @@
         &::-webkit-search-results-decoration {
             display: none;
         }
+
+        & .form-control:hover,
+        & .form-control:focus,
+        & .form-control:active {
+            border: none;
+        }
     }
 
     label.has-label-text {
         padding-left: 0.75rem;
     }
 
-    .btn[type="submit"],
-    .btn[type="reset"] {
-        @extend .px-2;
+    &.pgn__searchfield--external {
+        border: none;
+
+        &.has-focus {
+            box-shadow: none;
+        }
+    }
+
+    .pgn__searchfield_wrapper {
+        @extend .d-flex;
+        @extend .align-items-center;
+        @extend .w-100;
+
+        border: $search-border-width solid $search-border-color;
+
+        &:hover,
+        &:active {
+            border-color: $search-border-color-interaction;
+        }
+    }
+}
+
+.pgn__searchfield__button.btn[type='submit'] {
+    border-radius: 0;
+    margin-left: $search-button-margin;
+
+    &:hover:before,
+    &:focus:before,
+    &:active:before {
+        border-radius: 0 !important;
     }
 }

--- a/src/SearchField/SearchField.scss
+++ b/src/SearchField/SearchField.scss
@@ -4,7 +4,6 @@
     transition: $input-transition;
     border: $search-border-width solid $search-border-color;
 
-    &.disabled,
     &:disabled {
         opacity: $search-disabled-opacity;
         pointer-events: none;
@@ -23,7 +22,7 @@
         border-color: $search-border-color-interaction;
     }
 
-    & .form-control {
+    .form-control {
         @extend .border-0;
         border-radius: $search-border-radius !important;
         height: $input-height-search;
@@ -48,9 +47,9 @@
             display: none;
         }
 
-        & .form-control:hover,
-        & .form-control:focus,
-        & .form-control:active {
+        .form-control:hover,
+        .form-control:focus,
+        .form-control:active {
             border: none;
         }
     }

--- a/src/SearchField/SearchField.test.jsx
+++ b/src/SearchField/SearchField.test.jsx
@@ -3,9 +3,13 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch, faTimes } from '@fortawesome/free-solid-svg-icons';
-import { BUTTON_LOCATION_VARIANTS } from './constants';
 
 import SearchField from './index';
+
+const BUTTON_LOCATION_VARIANTS = [
+  'internal',
+  'external',
+];
 
 const baseProps = {
   onSubmit: () => {},

--- a/src/SearchField/SearchField.test.jsx
+++ b/src/SearchField/SearchField.test.jsx
@@ -211,8 +211,8 @@ describe('<SearchField /> with basic usage', () => {
           <SearchField.SubmitButton {...buttonProps} variant="dark" />
         </SearchField.Advanced>,
       );
-      expect(wrapperDefault.find('button').hasClass('btn-dark')).toBe(true);
-      expect(wrapperDark.find('button').hasClass('btn-danger')).toBe(true);
+      expect(wrapperDefault.find('button').hasClass('btn-primary')).toBe(true);
+      expect(wrapperDark.find('button').hasClass('btn-brand')).toBe(true);
     });
   });
 });

--- a/src/SearchField/SearchField.test.jsx
+++ b/src/SearchField/SearchField.test.jsx
@@ -3,12 +3,9 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { BUTTON_LOCATION_VARIANTS } from './constants';
 
 import SearchField from './index';
-import SearchFieldLabel from './SearchFieldLabel';
-import SearchFieldInput from './SearchFieldInput';
-import SearchFieldClearButton from './SearchFieldClearButton';
-import SearchFieldSubmitButton from './SearchFieldSubmitButton';
 
 const baseProps = {
   onSubmit: () => {},
@@ -22,30 +19,27 @@ describe('<SearchField /> with basic usage', () => {
 
   it('should pass correct props to `SearchField.Advanced`', () => {
     const wrapper = shallow(<SearchField {...baseProps} />);
-    expect(wrapper.find(SearchField.Advanced).props()).toEqual({
-      children: [
-        <SearchFieldLabel />,
-        <SearchFieldInput />,
-        <SearchFieldClearButton />,
-        <SearchFieldSubmitButton />,
-      ],
-      className: undefined,
-      icons: {
-        clear: <FontAwesomeIcon icon={faTimes} />,
-        submit: <FontAwesomeIcon icon={faSearch} />,
-      },
-      onFocus: expect.any(Function),
-      onBlur: expect.any(Function),
-      onChange: expect.any(Function),
-      onSubmit: expect.any(Function),
-      onClear: expect.any(Function),
-      value: '',
-      screenReaderText: {
-        label: 'search',
-        clearButton: 'clear search',
-        submitButton: 'submit search',
-      },
+    const props = wrapper.find(SearchField.Advanced).props();
+    expect(props.children).toEqual(expect.any(Array));
+    expect(props.className).toEqual(undefined);
+    expect(props.icons).toEqual({
+      clear: <FontAwesomeIcon icon={faTimes} />,
+      submit: <FontAwesomeIcon icon={faSearch} />,
     });
+    expect(props.onFocus).toEqual(expect.any(Function));
+    expect(props.onBlur).toEqual(expect.any(Function));
+    expect(props.onChange).toEqual(expect.any(Function));
+    expect(props.onSubmit).toEqual(expect.any(Function));
+    expect(props.onClear).toEqual(expect.any(Function));
+    expect(props.value).toEqual(expect.any(String));
+    expect(props.screenReaderText).toEqual({
+      label: 'search',
+      clearButton: 'clear search',
+      submitButton: 'submit search',
+    });
+    expect(props.formAriaLabel).toEqual(undefined);
+    expect(props.className).toEqual(undefined);
+    expect(BUTTON_LOCATION_VARIANTS.includes(props.submitButtonLocation)).toEqual(true);
   });
   it('should pass correct props to `SearchField.Label`', () => {
     const label = 'foobar';
@@ -88,9 +82,17 @@ describe('<SearchField /> with basic usage', () => {
     };
     const props = { ...baseProps, screenReaderText };
     const wrapper = mount(<SearchField {...props} />);
+    const submitLabel = wrapper.find('button[type="submit"] .sr-only').text();
+    expect(submitLabel).toEqual(screenReaderText.submitButton);
     wrapper.find('input').simulate('change', { target: { value: 'foobar' } });
-    expect(wrapper.find('button[type="reset"] .sr-only').prop('children')).toEqual(screenReaderText.clearButton);
-    expect(wrapper.find('button[type="submit"] .sr-only').prop('children')).toEqual(screenReaderText.submitButton);
+    const resetLabel = wrapper.find('button[type="reset"] .sr-only').text();
+    expect(resetLabel).toEqual(screenReaderText.clearButton);
+  });
+  it('should add div if `submitButtonLocation` is passed', () => {
+    const wrapperDefault = mount(<SearchField {...baseProps} />);
+    const wrapperExternal = mount(<SearchField {...baseProps} submitButtonLocation="external" />);
+    expect(wrapperDefault.find('.pgn__searchfield_wrapper').length).toEqual(0);
+    expect(wrapperExternal.find('.pgn__searchfield_wrapper').length).toEqual(1);
   });
 
   describe('should fire', () => {
@@ -132,7 +134,7 @@ describe('<SearchField /> with basic usage', () => {
       const props = { ...baseProps, onSubmit: spy };
       const wrapper = mount(<SearchField {...props} />);
       wrapper.find('input').simulate('change', { target: { value: 'foobar' } });
-      wrapper.find('button[type="submit"]').simulate('submit');
+      wrapper.find('input').simulate('submit');
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith('foobar');
     });
@@ -178,13 +180,35 @@ describe('<SearchField /> with basic usage', () => {
       expect(wrapper.find('label').prop('variant')).toEqual(labelProps.variant);
     });
     it('should pass props to the submit button', () => {
-      const buttonProps = { variant: 'inline' };
+      const buttonText = 'Some test text';
+      const buttonProps = {
+        submitButtonLocation: 'external',
+        buttonText,
+      };
       const wrapper = mount(
         <SearchField.Advanced {...baseProps}>
           <SearchField.SubmitButton {...buttonProps} />
         </SearchField.Advanced>,
       );
-      expect(wrapper.find('button').prop('variant')).toEqual(buttonProps.variant);
+      expect(wrapper.find('button').hasClass('pgn__searchfield__button')).toBe(true);
+      expect(wrapper.find('button').text().includes(buttonText)).toBe(true);
+    });
+    it('should pass variant to the submit button', () => {
+      const buttonProps = {
+        submitButtonLocation: 'external',
+      };
+      const wrapperDefault = mount(
+        <SearchField.Advanced {...baseProps}>
+          <SearchField.SubmitButton {...buttonProps} />
+        </SearchField.Advanced>,
+      );
+      const wrapperDark = mount(
+        <SearchField.Advanced {...baseProps}>
+          <SearchField.SubmitButton {...buttonProps} variant="dark" />
+        </SearchField.Advanced>,
+      );
+      expect(wrapperDefault.find('button').hasClass('btn-dark')).toBe(true);
+      expect(wrapperDark.find('button').hasClass('btn-danger')).toBe(true);
     });
   });
 });

--- a/src/SearchField/SearchFieldAdvanced.jsx
+++ b/src/SearchField/SearchFieldAdvanced.jsx
@@ -8,9 +8,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch, faTimes } from '@fortawesome/free-solid-svg-icons';
 
 import newId from '../utils/newId';
-import { BUTTON_LOCATION_VARIANTS } from './constants';
 
 export const SearchFieldContext = createContext();
+
+const BUTTON_LOCATION_VARIANTS = [
+  'internal',
+  'external',
+];
 
 const SearchFieldAdvanced = (props) => {
   const {

--- a/src/SearchField/SearchFieldAdvanced.jsx
+++ b/src/SearchField/SearchFieldAdvanced.jsx
@@ -108,6 +108,7 @@ const SearchFieldAdvanced = (props) => {
             screenReaderText,
             icons,
             value,
+            disabled,
             handleFocus,
             handleBlur,
             handleChange,
@@ -169,7 +170,9 @@ SearchFieldAdvanced.propTypes = {
   }),
   /** specifies the aria-label attribute on the form element. This is useful if you use the `SearchField` component more than once on a page. */
   formAriaLabel: PropTypes.string,
+  /** Specifies whether the `SearchField` is disabled. */
   disabled: PropTypes.bool,
+  /** Controls whether the search button is internal as an icon or external as a button. */
   submitButtonLocation: PropTypes.oneOf(BUTTON_LOCATION_VARIANTS),
 };
 

--- a/src/SearchField/SearchFieldAdvanced.jsx
+++ b/src/SearchField/SearchFieldAdvanced.jsx
@@ -8,6 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch, faTimes } from '@fortawesome/free-solid-svg-icons';
 
 import newId from '../utils/newId';
+import { BUTTON_LOCATION_VARIANTS } from './constants';
 
 export const SearchFieldContext = createContext();
 
@@ -24,6 +25,8 @@ const SearchFieldAdvanced = (props) => {
     onFocus,
     value: initialValue,
     formAriaLabel,
+    disabled,
+    submitButtonLocation,
   } = props;
 
   const [hasFocus, setHasFocus] = useState(false);
@@ -80,7 +83,11 @@ const SearchFieldAdvanced = (props) => {
     <div
       className={classNames(
         'pgn__searchfield', 'd-flex',
-        { 'has-focus': hasFocus },
+        {
+          'has-focus': hasFocus,
+          disabled,
+          'pgn__searchfield--external': submitButtonLocation === 'external',
+        },
         className,
       )}
     >
@@ -158,6 +165,8 @@ SearchFieldAdvanced.propTypes = {
   }),
   /** specifies the aria-label attribute on the form element. This is useful if you use the `SearchField` component more than once on a page. */
   formAriaLabel: PropTypes.string,
+  disabled: PropTypes.bool,
+  submitButtonLocation: PropTypes.oneOf(BUTTON_LOCATION_VARIANTS),
 };
 
 SearchFieldAdvanced.defaultProps = {
@@ -177,6 +186,8 @@ SearchFieldAdvanced.defaultProps = {
   onChange: () => {},
   onFocus: () => {},
   onClear: () => {},
+  disabled: false,
+  submitButtonLocation: 'internal',
 };
 
 export default SearchFieldAdvanced;

--- a/src/SearchField/SearchFieldClearButton.jsx
+++ b/src/SearchField/SearchFieldClearButton.jsx
@@ -4,7 +4,7 @@ import { SearchFieldContext } from './SearchFieldAdvanced';
 
 const SearchFieldClearButton = (props) => {
   const {
-    screenReaderText, icons, value,
+    screenReaderText, icons, value, disabled,
   } = useContext(SearchFieldContext);
 
   if (!value) {
@@ -13,7 +13,7 @@ const SearchFieldClearButton = (props) => {
 
   return (
     // eslint-disable-next-line react/button-has-type
-    <button type="reset" className="btn" {...props}>
+    <button type="reset" className="btn" {...props} disabled={disabled}>
       {icons.clear}
       <span className="sr-only">{screenReaderText.clearButton}</span>
     </button>

--- a/src/SearchField/SearchFieldInput.jsx
+++ b/src/SearchField/SearchFieldInput.jsx
@@ -6,7 +6,7 @@ import { SearchFieldContext } from './SearchFieldAdvanced';
 
 const SearchFieldInput = (props) => {
   const {
-    inputId, value, handleChange, handleFocus, handleBlur, refs,
+    inputId, value, handleChange, handleFocus, handleBlur, refs, disabled,
   } = useContext(SearchFieldContext);
 
   return (
@@ -21,6 +21,7 @@ const SearchFieldInput = (props) => {
       onFocus={handleFocus}
       onBlur={handleBlur}
       onChange={handleChange}
+      options={{ disabled }}
     />
   );
 };

--- a/src/SearchField/SearchFieldSubmitButton.jsx
+++ b/src/SearchField/SearchFieldSubmitButton.jsx
@@ -1,21 +1,63 @@
 import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { BUTTON_LOCATION_VARIANTS, STYLE_VARIANTS } from './constants';
 
 import { SearchFieldContext } from './SearchFieldAdvanced';
+import { Button } from '../index';
 
 const SearchFieldSubmitButton = (props) => {
-  const { screenReaderText, icons, refs } = useContext(SearchFieldContext);
+  const {
+    variant, submitButtonLocation, buttonText, ...others
+  } = props;
+  const {
+    screenReaderText, icons, refs, value,
+  } = useContext(SearchFieldContext);
 
-  return (
+  if (submitButtonLocation === 'internal' && value.length) {
+    return null;
+  }
+
+  return submitButtonLocation === 'external' ? (
+    <Button
+      type="submit"
+      ref={refs.submitButton}
+      variant={variant === 'light' ? 'dark' : 'danger'}
+      className="pgn__searchfield__button"
+      {...others}
+    >
+      {buttonText}
+      <span className="sr-only">{screenReaderText.submitButton}</span>
+    </Button>
+  ) : (
     <button
       type="submit"
-      className="btn"
+      className={classNames('btn')}
       ref={refs.submitButton}
-      {...props}
+      {...others}
     >
       {icons.submit}
       <span className="sr-only">{screenReaderText.submitButton}</span>
     </button>
   );
+};
+
+SearchFieldSubmitButton.propTypes = {
+  /** The button style variant to use. */
+  variant: PropTypes.oneOf(STYLE_VARIANTS),
+  /** Controls whether the search button is internal as an icon or external as a button. */
+  submitButtonLocation: PropTypes.oneOf(BUTTON_LOCATION_VARIANTS),
+  /**
+   * Specifies a text that is displayed on the button.
+   * The `submitButtonLocation` prop should be set to `external`.
+   */
+  buttonText: PropTypes.string,
+};
+
+SearchFieldSubmitButton.defaultProps = {
+  variant: 'light',
+  submitButtonLocation: 'internal',
+  buttonText: 'Search',
 };
 
 export default SearchFieldSubmitButton;

--- a/src/SearchField/SearchFieldSubmitButton.jsx
+++ b/src/SearchField/SearchFieldSubmitButton.jsx
@@ -1,10 +1,19 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { BUTTON_LOCATION_VARIANTS, STYLE_VARIANTS } from './constants';
 
 import { SearchFieldContext } from './SearchFieldAdvanced';
 import { Button } from '../index';
+
+const STYLE_VARIANTS = [
+  'light',
+  'dark',
+];
+
+const BUTTON_LOCATION_VARIANTS = [
+  'internal',
+  'external',
+];
 
 const SearchFieldSubmitButton = (props) => {
   const {

--- a/src/SearchField/SearchFieldSubmitButton.jsx
+++ b/src/SearchField/SearchFieldSubmitButton.jsx
@@ -20,7 +20,7 @@ const SearchFieldSubmitButton = (props) => {
     variant, submitButtonLocation, buttonText, ...others
   } = props;
   const {
-    screenReaderText, icons, refs, value,
+    screenReaderText, icons, refs, value, disabled,
   } = useContext(SearchFieldContext);
 
   if (submitButtonLocation === 'internal' && value.length) {
@@ -31,8 +31,9 @@ const SearchFieldSubmitButton = (props) => {
     <Button
       type="submit"
       ref={refs.submitButton}
-      variant={variant === 'light' ? 'dark' : 'danger'}
+      variant={variant === 'light' ? 'primary' : 'brand'}
       className="pgn__searchfield__button"
+      disabled={disabled}
       {...others}
     >
       {buttonText}
@@ -43,6 +44,7 @@ const SearchFieldSubmitButton = (props) => {
       type="submit"
       className={classNames('btn')}
       ref={refs.submitButton}
+      disabled={disabled}
       {...others}
     >
       {icons.submit}

--- a/src/SearchField/_variables.scss
+++ b/src/SearchField/_variables.scss
@@ -1,0 +1,13 @@
+$search-btn-variants: (
+        "light":  $primary-500,
+        "dark":   $brand-500,
+);
+$search-border-radius:                0 !default;
+$search-line-height:                  1.5rem !default;
+$search-border-color:                 $gray-500 !default;
+$search-border-color-interaction:     $black !default;
+$search-border-width:                 .0625rem !default;
+$search-border-width-interaction:     .125rem !default;
+$search-disabled-opacity:             .3 !default;
+$search-button-margin:                .5rem !default;
+$input-height-search:                 calc(#{$input-line-height * 1em} + #{$input-padding-y * 2}) !default;

--- a/src/SearchField/constants.js
+++ b/src/SearchField/constants.js
@@ -1,9 +1,0 @@
-export const STYLE_VARIANTS = [
-  'light',
-  'dark',
-];
-
-export const BUTTON_LOCATION_VARIANTS = [
-  'internal',
-  'external',
-];

--- a/src/SearchField/constants.js
+++ b/src/SearchField/constants.js
@@ -1,0 +1,9 @@
+export const STYLE_VARIANTS = [
+  'light',
+  'dark',
+];
+
+export const BUTTON_LOCATION_VARIANTS = [
+  'internal',
+  'external',
+];

--- a/src/SearchField/index.jsx
+++ b/src/SearchField/index.jsx
@@ -9,7 +9,16 @@ import SearchFieldLabel from './SearchFieldLabel';
 import SearchFieldInput from './SearchFieldInput';
 import SearchFieldClearButton from './SearchFieldClearButton';
 import SearchFieldSubmitButton from './SearchFieldSubmitButton';
-import { BUTTON_LOCATION_VARIANTS, STYLE_VARIANTS } from './constants';
+
+const STYLE_VARIANTS = [
+  'light',
+  'dark',
+];
+
+const BUTTON_LOCATION_VARIANTS = [
+  'internal',
+  'external',
+];
 
 const SearchField = (props) => {
   const {

--- a/src/SearchField/index.jsx
+++ b/src/SearchField/index.jsx
@@ -9,22 +9,38 @@ import SearchFieldLabel from './SearchFieldLabel';
 import SearchFieldInput from './SearchFieldInput';
 import SearchFieldClearButton from './SearchFieldClearButton';
 import SearchFieldSubmitButton from './SearchFieldSubmitButton';
+import { BUTTON_LOCATION_VARIANTS, STYLE_VARIANTS } from './constants';
 
 const SearchField = (props) => {
   const {
     label,
     placeholder,
     inputProps,
+    variant,
+    submitButtonLocation,
+    buttonText,
     ...others
   } = props;
 
+  const Wrapper = (wrapperProps) => (submitButtonLocation === 'external'
+    ? <div className="pgn__searchfield_wrapper">{wrapperProps.children}</div>
+    : <>{wrapperProps.children}</>);
+
   return (
-    <SearchField.Advanced {...others}>
-      <SearchField.Label>{label}</SearchField.Label>
-      <SearchField.Input placeholder={placeholder} {...inputProps} />
-      <SearchField.ClearButton />
-      <SearchField.SubmitButton />
-    </SearchField.Advanced>
+    <>
+      <SearchField.Advanced {...others} submitButtonLocation={submitButtonLocation}>
+        <Wrapper>
+          <SearchField.Label>{label}</SearchField.Label>
+          <SearchField.Input placeholder={placeholder} {...inputProps} />
+          <SearchField.ClearButton />
+        </Wrapper>
+        <SearchField.SubmitButton
+          variant={variant}
+          submitButtonLocation={submitButtonLocation}
+          buttonText={buttonText}
+        />
+      </SearchField.Advanced>
+    </>
   );
 };
 
@@ -77,6 +93,17 @@ SearchField.propTypes = {
   formAriaLabel: PropTypes.string,
   /** Props to be passed to the form input */
   inputProps: PropTypes.shape({}),
+  /** The button style variant to use. */
+  variant: PropTypes.oneOf(STYLE_VARIANTS),
+  /** Specifies whether the `SearchField` is disabled. */
+  disabled: PropTypes.bool,
+  /** Controls whether the search button is internal as an icon or external as a button. */
+  submitButtonLocation: PropTypes.oneOf(BUTTON_LOCATION_VARIANTS),
+  /**
+   * Specifies a text that is displayed on the button.
+   * The `submitButtonLocation` prop should be set to `external`.
+   */
+  buttonText: PropTypes.string,
 };
 
 SearchField.defaultProps = {
@@ -99,6 +126,10 @@ SearchField.defaultProps = {
   onFocus: () => {},
   onClear: () => {},
   inputProps: {},
+  variant: 'light',
+  disabled: false,
+  submitButtonLocation: 'internal',
+  buttonText: 'Search',
 };
 
 SearchField.Advanced = SearchFieldAdvanced;

--- a/src/SearchField/index.jsx
+++ b/src/SearchField/index.jsx
@@ -40,7 +40,7 @@ const SearchField = (props) => {
       <SearchField.Advanced {...others} submitButtonLocation={submitButtonLocation}>
         <Wrapper>
           <SearchField.Label>{label}</SearchField.Label>
-          <SearchField.Input placeholder={placeholder} {...inputProps} />
+          <SearchField.Input placeholder={placeholder} {...inputProps} disabled={others.disabled} />
           <SearchField.ClearButton />
         </Wrapper>
         <SearchField.SubmitButton


### PR DESCRIPTION
- added constants for the `variant` and `submitButtonLocation` props
- added functionality for the new properties: `variant`, `disabled`, `buttonText`
- added styles according to the [Figma design](https://www.figma.com/file/eGmDp94FlqEr4iSqy1Uc1K/Paragon-Design-System?node-id=14061%3A21)
- implemented the `submitButtonLocation` feature
- updated and added tests
- added a small example in the `README.md`

JIRA: [PAR-281](https://openedx.atlassian.net/jira/software/projects/PAR/boards/654?selectedIssue=PAR-281)