### PR TITLE
feat: update form switch per figma

### DIFF
--- a/scss/core/_variables.scss
+++ b/scss/core/_variables.scss
@@ -547,6 +547,7 @@ $font-family-base:            $font-family-sans-serif !default;
 $font-size-base:              1.125rem !default; // Assumes the browser default, typically `16px`
 $font-size-lg:                $font-size-base * 1.25 !default;
 $font-size-sm:                0.875rem !default;
+$font-size-xs:                0.75rem !default;
 
 $font-weight-lighter:         lighter !default;
 $font-weight-light:           300 !default;

--- a/src/Form/FormCheckbox.jsx
+++ b/src/Form/FormCheckbox.jsx
@@ -51,6 +51,7 @@ const FormCheckbox = React.forwardRef(({
   isInvalid,
   isValid,
   controlAs,
+  floatLabelLeft,
   ...props
 }, ref) => {
   const { getCheckboxControlProps, hasCheckboxSetProvider } = useCheckboxSetContext();
@@ -77,6 +78,7 @@ const FormCheckbox = React.forwardRef(({
           'pgn__form-control-valid': isValid,
           'pgn__form-control-invalid': isInvalid,
           'pgn__form-control-disabled': checkboxInputProps.disabled,
+          'pgn__form-control-label-left': !!floatLabelLeft,
         })}
         {...groupProps}
       >
@@ -105,6 +107,7 @@ FormCheckbox.propTypes = {
   isInvalid: PropTypes.bool,
   isValid: PropTypes.bool,
   controlAs: PropTypes.elementType,
+  floatLabelLeft: PropTypes.bool,
 };
 
 FormCheckbox.defaultProps = {
@@ -115,6 +118,7 @@ FormCheckbox.defaultProps = {
   isInvalid: false,
   isValid: false,
   controlAs: CheckboxControl,
+  floatLabelLeft: false,
 };
 
 export { CheckboxControl };

--- a/src/Form/FormSwitch.jsx
+++ b/src/Form/FormSwitch.jsx
@@ -47,27 +47,44 @@ SwitchControl.defaultProps = {
 const FormSwitch = React.forwardRef(({
   children,
   className,
+  helperText,
   ...props
 }, ref) => (
-
-  <FormCheckbox
-    className={classNames('pgn__form-switch', className)}
-    {...props}
-    role="switch"
-    controlAs={SwitchControl}
-    ref={ref}
-  >
-    {children}
-  </FormCheckbox>
+  <div className="d-inline-flex flex-column">
+    <FormCheckbox
+      className={classNames('pgn__form-switch', className)}
+      {...props}
+      role="switch"
+      ref={ref}
+      controlAs={SwitchControl}
+      // ignore the following props for form switch
+      isValid={null}
+      isInvalid={null}
+      description={null}
+    >
+      {children}
+    </FormCheckbox>
+    {helperText && (
+      <div className="pgn__form-switch-helper-text">
+        {helperText}
+      </div>
+    )}
+  </div>
 ));
 
 FormSwitch.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
+  labelClassName: PropTypes.string,
+  helperText: PropTypes.node,
+  floatLabelLeft: PropTypes.bool,
 };
 
 FormSwitch.defaultProps = {
   className: undefined,
+  labelClassName: undefined,
+  helperText: undefined,
+  floatLabelLeft: false,
 };
 
 export { SwitchControl };

--- a/src/Form/_Form.scss
+++ b/src/Form/_Form.scss
@@ -320,13 +320,19 @@ $select-icon-padding: .5625rem !default;
   transition: background 150ms ease;
   &:checked {
     background-position: right center;
-    background-color: $custom-control-indicator-checked-bg;
+    background-color: $custom-switch-indicator-checked-bg;
     background-image: escape-svg($custom-switch-indicator-icon-on);
   }
   &:indeterminate {
     background-position: center;
     background-image: escape-svg($custom-switch-indicator-icon-off);
   }
+}
+
+.pgn__form-switch-helper-text {
+  color: $gray-500;
+  font-size: $font-size-xs;
+  margin-top: 0.25rem;
 }
 
 .pgn__form-radio-input {
@@ -358,5 +364,15 @@ $select-icon-padding: .5625rem !default;
   }
   &.pgn__form-control-valid input {
     border-color: $form-feedback-valid-color;
+  }
+  &.pgn__form-control-label-left {
+    .pgn__form-label {
+      order: 1;
+      margin-right: $custom-control-gutter;
+    }
+
+    input {
+      order: 2;
+    }
   }
 }

--- a/src/Form/_variables.scss
+++ b/src/Form/_variables.scss
@@ -116,6 +116,7 @@ $custom-switch-indicator-icon-on:               str-replace(url("data:image/svg+
 $custom-switch-width:                           $custom-control-indicator-size * 1.75 !default;
 $custom-switch-indicator-border-radius:         $custom-control-indicator-size / 2 !default;
 $custom-switch-indicator-size:                  calc(#{$custom-control-indicator-size} - #{$custom-control-indicator-border-width * 4}) !default;
+$custom-switch-indicator-checked-bg:            theme-color("success") !default;
 
 $custom-select-padding-y:           $input-padding-y !default;
 $custom-select-padding-x:           $input-padding-x !default;

--- a/src/Form/form-checkbox.mdx
+++ b/src/Form/form-checkbox.mdx
@@ -223,3 +223,16 @@ underlying `input` node. See MDN for documentation on available
   </Form.CheckboxSet>
 </Form.Group>
 ```
+
+### Label Position
+
+The label is positioned to the right of the checkbox control by default. The label can be rendered on the left instead
+by passing the `floatLabelLeft` prop.
+
+```jsx live
+<Form.Group>
+  <Form.CheckboxSet>
+    <Form.Checkbox value="red" floatLabelLeft>Red</Form.Checkbox>
+  </Form.CheckboxSet>
+</Form.Group>
+```

--- a/src/Form/form-switch.mdx
+++ b/src/Form/form-switch.mdx
@@ -3,11 +3,7 @@ title: 'Form.Switch'
 type: 'component'
 components:
 - FormSwitch
-- FormCheckbox
 - SwitchControl
-- CheckboxControl
-- FormCheckboxSet
-- FormSwitchSet
 categories:
 - Forms
 status: 'New'
@@ -172,59 +168,42 @@ underlying `input` node. See MDN for documentation on available
 </Form.Group>
 ```
 
-### Validation
+### Label Position
 
-#### Group Level Validation
-
-```jsx live
-<Form.Group isInvalid>
-  <Form.Label>Which Color?</Form.Label>
-  <Form.SwitchSet
-    name="color-five"
-    onChange={(e) => console.log(e.target.value)}
-  >
-    <Form.Switch value="red">Red</Form.Switch>
-    <Form.Switch value="green">Green</Form.Switch>
-    <Form.Switch value="blue">Blue</Form.Switch>
-    <Form.Switch value="cyan" disabled>Cyan</Form.Switch>
-  </Form.SwitchSet>
-  <Form.Control.Feedback>
-    Please choose an option.
-  </Form.Control.Feedback>
-</Form.Group>
-```
-
-#### Individual option validation
+The label is positioned to the right of the switch control by default. The label can be rendered on the left instead
+by passing the `floatLabelLeft` prop.
 
 ```jsx live
 <Form.Group>
-  <Form.Label>Which Color?</Form.Label>
-  <Form.SwitchSet name="color-four">
+  <Form.SwitchSet>
+    <Form.Switch value="red">Red</Form.Switch>
+    <Form.Switch value="blue" floatLabelLeft>Blue</Form.Switch>
+  </Form.SwitchSet>
+</Form.Group>
+```
+
+### Helper Text
+
+A helper text component can be passed in to be rendered below the switch control.
+
+```jsx live
+<Form.Group>
+  <Form.SwitchSet>
     <Form.Switch
       value="red"
-      description="Red's cool"
+      helperText={
+        <span>Helper text for red switch</span>
+      }
     >
       Red
     </Form.Switch>
     <Form.Switch
-      value="green"
-      description="Excellent choice"
-      isValid
-    >
-      Green
-    </Form.Switch>
-    <Form.Switch
       value="blue"
-      description="Poor choice"
-      isInvalid
+      helperText={
+        <span>Helper text for blue switch</span>
+      }
     >
       Blue
-    </Form.Switch>
-    <Form.Switch
-      value="cyan"
-      disabled
-    >
-      Cyan
     </Form.Switch>
   </Form.SwitchSet>
 </Form.Group>

--- a/src/Form/tests/FormSwitch.test.jsx
+++ b/src/Form/tests/FormSwitch.test.jsx
@@ -6,14 +6,19 @@ import FormSwitch from '../FormSwitch';
 
 describe('FormSwitch', () => {
   const wrapper = mount((
-    <FormSwitch name="color" value="green" description="Describe green">
+    <FormSwitch
+      name="color"
+      value="green"
+      helperText="Describe green"
+    >
       Green
     </FormSwitch>
   ));
   const inputNode = wrapper.find('input[value="green"]').first();
 
   it('renders an input with a name and value and role=switch', () => {
-    wrapper.exists('input[value="green"]');
+    expect(wrapper.exists('input[value="green"]')).toBe(true);
+    expect(wrapper.exists('.pgn__form-switch-helper-text')).toBe(true);
     expect(inputNode.props().name).toBe('color');
     expect(inputNode.props().role).toBe('switch');
   });


### PR DESCRIPTION
- Support label on the left for form.switch
- Change background color for form switch (we only need to support success variant)
- Add support for helper text below the switch
- Remove outline color variations 