### PR TITLE
Fixed Datatable ActionDisplay to support functions

### DIFF
--- a/src/DataTable/ActionDisplay.jsx
+++ b/src/DataTable/ActionDisplay.jsx
@@ -6,8 +6,8 @@ import DataTableContext from './DataTableContext';
 // handles display logic for actions
 const ActionDisplay = () => {
   const { bulkActions, tableActions, selectedFlatRows } = useContext(DataTableContext);
-  const noBulkActions = bulkActions?.length < 1;
-  const noTableActions = tableActions?.length < 1;
+  const noBulkActions = typeof bulkActions !== 'function' && bulkActions?.length < 1;
+  const noTableActions = typeof tableActions !== 'function' && tableActions?.length < 1;
   const noActionsAvailable = noBulkActions && noTableActions;
   const hasRowsSelected = selectedFlatRows?.length > 0;
 

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -110,7 +110,6 @@ function DataTable({
   }, [fetchData, JSON.stringify(tableStateWithoutSelections)]);
 
   const selectionActions = useSelectionActions(instance, controlledTableSelections);
-
   const enhancedInstance = {
     ...instance,
     itemCount,
@@ -245,7 +244,7 @@ DataTable.propTypes = {
           /** optional button variant; only relevant for the first two buttons */
           variant: PropTypes.string,
           /** disables button */
-          disabled: PropTypes.disabled,
+          disabled: PropTypes.bool,
         }),
         /** function passed selected items, should return action object */
         PropTypes.func,
@@ -268,7 +267,7 @@ DataTable.propTypes = {
           /** optional button variant; only relevant for the first two buttons */
           variant: PropTypes.string,
           /** disables button */
-          disabled: PropTypes.disabled,
+          disabled: PropTypes.bool,
         }),
         /** function passed table instance, should return action object */
         PropTypes.func,

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -110,6 +110,7 @@ function DataTable({
   }, [fetchData, JSON.stringify(tableStateWithoutSelections)]);
 
   const selectionActions = useSelectionActions(instance, controlledTableSelections);
+
   const enhancedInstance = {
     ...instance,
     itemCount,


### PR DESCRIPTION
This change makes sure that if we pass a function it is always rendered.

In `DataTable`, when passing a function through `tableActions` and `bulkActions`, with no parameters it would not render the component. This happened because we were (unintentianlly) counting the number of parameters in a function, if the function supplied took zero arguments the code would flag `noBulkActions` or `noTableActions` as true.