### PR TITLE
[BD-46] feat: allow using IconButton as a base element for Dropdown.Toggle

### DIFF
--- a/src/DataTable/CollapsibleButtonGroup.jsx
+++ b/src/DataTable/CollapsibleButtonGroup.jsx
@@ -5,25 +5,11 @@ import classNames from 'classnames';
 import DataTableContext from './DataTableContext';
 import { MoreVert } from '../../icons';
 import {
-  Button, Dropdown, useWindowSize, Icon, breakpoints,
+  Button, Dropdown, useWindowSize, Icon, IconButton, breakpoints,
 } from '..';
 
 export const DROPDOWN_BUTTON_TEXT = 'More actions';
 export const SMALL_SCREEN_DROPDOWN_BUTTON_TEXT = 'Actions';
-
-// eslint-disable-next-line react/prop-types
-const CustomDropdownToggle = React.forwardRef(({ children, onClick }, ref) => (
-  <Button
-    ref={ref}
-    variant="tertiary"
-    onClick={(e) => {
-      e.preventDefault();
-      onClick(e);
-    }}
-  >
-    {children}
-  </Button>
-));
 
 const CollapsibleButtonGroup = ({
   className,
@@ -74,13 +60,15 @@ const CollapsibleButtonGroup = ({
     <div className={className}>
       {dropdownActions.length > 0 && (
         <Dropdown>
-          <Dropdown.Toggle as={CustomDropdownToggle}>
-            <Icon
-              src={MoreVert}
-              screenReaderText={width > breakpoints.small.minWidth
-                ? DROPDOWN_BUTTON_TEXT : SMALL_SCREEN_DROPDOWN_BUTTON_TEXT}
-            />
-          </Dropdown.Toggle>
+          <Dropdown.Toggle
+            variant="secondary"
+            iconAs={Icon}
+            as={IconButton}
+            src={MoreVert}
+            screenReaderText={width > breakpoints.small.minWidth
+              ? DROPDOWN_BUTTON_TEXT : SMALL_SCREEN_DROPDOWN_BUTTON_TEXT}
+            id="actions-dropdown"
+          />
           <Dropdown.Menu alignRight>
             {dropdownActions.map((action) => (
               <Dropdown.Item

--- a/src/DataTable/tests/BulkActions.test.jsx
+++ b/src/DataTable/tests/BulkActions.test.jsx
@@ -198,13 +198,13 @@ describe('<BulkActions />', () => {
     it('displays the user\'s first button as an brand button', () => {
       const wrapper = mount(<BulkActionsWrapper />);
       const buttons = wrapper.find(Button);
-      expect(buttons.length).toEqual(3);
-      expect(buttons.get(2).props.variant).toEqual('brand');
+      expect(buttons.length).toEqual(2);
+      expect(buttons.get(1).props.variant).toEqual('brand');
     });
     it('displays the user\'s second button as an outline button', () => {
       const wrapper = mount(<BulkActionsWrapper />);
       const buttons = wrapper.find(Button);
-      expect(buttons.get(1).props.variant).toEqual('outline-primary');
+      expect(buttons.get(0).props.variant).toEqual('outline-primary');
     });
     describe('dropdown', () => {
       const onClickSpy = jest.fn();

--- a/src/DataTable/tests/TableActions.test.jsx
+++ b/src/DataTable/tests/TableActions.test.jsx
@@ -4,7 +4,7 @@ import { mount } from 'enzyme';
 import TableActions from '../TableActions';
 import { DROPDOWN_BUTTON_TEXT, SMALL_SCREEN_DROPDOWN_BUTTON_TEXT } from '../CollapsibleButtonGroup';
 import {
-  useWindowSize, Dropdown, Button, Icon,
+  useWindowSize, Dropdown, Button, Icon, IconButton,
 } from '../..';
 import DataTableContext from '../DataTableContext';
 
@@ -166,13 +166,13 @@ describe('<TableActions />', () => {
     it('displays the user\'s first button as an brand button', () => {
       const wrapper = mount(<TableActionsWrapper />);
       const buttons = wrapper.find(Button);
-      expect(buttons.length).toEqual(3);
-      expect(buttons.get(2).props.variant).toEqual('brand');
+      expect(buttons.length).toEqual(2);
+      expect(buttons.get(1).props.variant).toEqual('brand');
     });
     it('displays the user\'s second button as an outline button', () => {
       const wrapper = mount(<TableActionsWrapper />);
       const buttons = wrapper.find(Button);
-      expect(buttons.get(1).props.variant).toEqual('outline-primary');
+      expect(buttons.get(0).props.variant).toEqual('outline-primary');
     });
     describe('dropdown', () => {
       const onClickSpy = jest.fn();
@@ -247,8 +247,8 @@ describe('<TableActions />', () => {
     test.each(actions)('puts all actions in a dropdown %#', (testActions) => {
       useWindowSize.mockReturnValue({ width: 500 });
       const wrapper = mount(<TableActionsWrapper value={{ ...instance, tableActions: testActions }} />);
-      const button = wrapper.find(Icon);
-      expect(button.length).toEqual(1);
+      const iconButton = wrapper.find(IconButton);
+      expect(iconButton.length).toEqual(1);
       expect(wrapper.text()).not.toContain(firstAction.buttonText);
       const buttons = wrapper.find('button');
       expect(buttons.length).toEqual(1);

--- a/src/Dropdown/Dropdown.scss
+++ b/src/Dropdown/Dropdown.scss
@@ -13,3 +13,10 @@
   transform: rotate(135deg);
   width: 0.45rem;
 }
+
+// this is a helper class to remove arrow element from Dropdown.Toggle
+// pass it as bsPrefix prop for Dropdown.Toggle component when you want to render
+// toggle as IconButton (that way it will override underlying react-bootstrap class)
+.pgn__dropdown-toggle-iconbutton {
+  white-space: nowrap;
+}

--- a/src/Dropdown/README.md
+++ b/src/Dropdown/README.md
@@ -6,6 +6,7 @@ components:
 - DropdownItem
 - DropdownMenu
 - DropdownButton
+- DropdownToggle
 categories:
 - Navigation
 status: 'Stable'
@@ -22,7 +23,7 @@ notes: |
   </a>
 </p>
 
-### basic usage
+### Basic Usage
 ```jsx live
 <DropdownButton id="dropdown-basic-button" title="Dropdown button">
   <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
@@ -31,7 +32,7 @@ notes: |
 </DropdownButton>
 ```
 
-### advanced usage
+### Advanced Usage
 
 ```jsx live
 <Dropdown>
@@ -39,6 +40,27 @@ notes: |
     Dropdown Button
   </Dropdown.Toggle>
 
+  <Dropdown.Menu>
+    <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
+    <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
+    <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
+  </Dropdown.Menu>
+</Dropdown>
+```
+
+### With IconButton
+
+You can use `Dropdown.Toggle` with [IconButton](/components/iconbutton) component, note that all props you provide to `Dropdown.Toggle` will get passed down to the `IconButton`.
+
+```jsx live
+<Dropdown>
+  <Dropdown.Toggle
+    id="dropdown-toggle-with-iconbutton"
+    as={IconButton}
+    src={MoreVert}
+    iconAs={Icon}
+    variant="primary"
+  />
   <Dropdown.Menu>
     <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
     <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>

--- a/src/Dropdown/index.jsx
+++ b/src/Dropdown/index.jsx
@@ -1,8 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
 import Dropdown from 'react-bootstrap/Dropdown';
+import BaseDropdownToggle from 'react-bootstrap/DropdownToggle';
 import DropdownDeprecated from './deprecated';
+import { IconButton, Button } from '..';
+
+const DropdownToggle = React.forwardRef(({
+  as,
+  bsPrefix,
+  ...otherProps
+}, ref) => {
+  // hide arrow from the toggle if it is rendered as IconButton
+  // because it hinders the positioning of IconButton
+  const prefix = as === IconButton ? 'pgn__dropdown-toggle-iconbutton' : bsPrefix;
+  return <BaseDropdownToggle {...otherProps} as={as} bsPrefix={prefix} ref={ref} />;
+});
+
+DropdownToggle.propTypes = {
+  /** Specifies the base element. */
+  as: PropTypes.element,
+  /** Overrides underlying component base CSS class name. */
+  bsPrefix: PropTypes.string,
+  /** An html id attribute, necessary for assistive technologies, such as screen readers. */
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};
+
+DropdownToggle.defaultProps = {
+  as: Button,
+  bsPrefix: 'dropdown-toggle',
+};
 
 Dropdown.Deprecated = DropdownDeprecated;
+Dropdown.Toggle = DropdownToggle;
 
 export default Dropdown;
+export { DropdownToggle };
 export { default as DropdownButton } from 'react-bootstrap/DropdownButton';
 export { default as SplitButton } from 'react-bootstrap/SplitButton';

--- a/src/IconButton/index.jsx
+++ b/src/IconButton/index.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-const IconButton = ({
+const IconButton = React.forwardRef(({
   alt,
   invertColors,
   icon,
@@ -15,7 +15,7 @@ const IconButton = ({
   variant,
   iconAs: IconComponent,
   ...attrs
-}) => {
+}, ref) => {
   const invert = invertColors ? 'inverse-' : '';
   return (
     <button
@@ -29,9 +29,11 @@ const IconButton = ({
       )}
       onClick={onClick}
       type="button"
+      ref={ref}
     >
       <span className="btn-icon__icon-container">
         <IconComponent
+          {...attrs}
           className={`btn-icon__icon ${iconClassNames}`}
           icon={icon}
           src={src}
@@ -39,7 +41,7 @@ const IconButton = ({
       </span>
     </button>
   );
-};
+});
 
 IconButton.defaultProps = {
   iconAs: FontAwesomeIcon,

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,12 @@ export { Col, Row } from './Layout';
 export { default as Collapse } from './Collapse';
 export { default as Collapsible } from './Collapsible';
 export { default as Scrollable } from './Scrollable';
-export { default as Dropdown, DropdownButton, SplitButton } from './Dropdown';
+export {
+  default as Dropdown,
+  DropdownToggle,
+  DropdownButton,
+  SplitButton,
+} from './Dropdown';
 export { default as Fade } from './Fade';
 export { default as Fieldset } from './Fieldset';
 export {


### PR DESCRIPTION
- allow using `IconButton` as a base element for `Dropdown.Toggle`
- refactor usage of `Dropdown.Toggle` in `DataTable` as a result of the first change

JIRA: [PAR-334](https://openedx.atlassian.net/browse/PAR-334)

Preview: https://deploy-preview-939--paragon-edx.netlify.app/components/dropdown/#with-iconbutton