### PR TITLE
docs: collapse codeblocks by default

### DIFF
--- a/www/src/components/CodeBlock.jsx
+++ b/www/src/components/CodeBlock.jsx
@@ -44,28 +44,28 @@ function CodeBlock({ children, className, live }) {
 
   if (live) {
     return (
-        <div className="pgn-doc__code-block">
-          <LiveProvider
-            code={children}
-            scope={{
-              ...ParagonIcons,
-              ...ParagonReact,
-              useCallback,
-              useState,
-              useMemo,
-              FontAwesome,
-              MiyazakiCard,
-              HipsterIpsum,
-            }}
-            theme={theme}
-          >
-            <LivePreview className="pgn-doc__code-block-preview" />
-            <CollapsibleLiveEditor>
-              <LiveEditor className="pgn-doc__code-block-editor" />
-            </CollapsibleLiveEditor>
-            <LiveError className="pgn-doc__code-block-error" />
-          </LiveProvider>
-        </div>
+      <div className="pgn-doc__code-block">
+        <LiveProvider
+          code={children}
+          scope={{
+            ...ParagonIcons,
+            ...ParagonReact,
+            useCallback,
+            useState,
+            useMemo,
+            FontAwesome,
+            MiyazakiCard,
+            HipsterIpsum,
+          }}
+          theme={theme}
+        >
+          <LivePreview className="pgn-doc__code-block-preview" />
+          <CollapsibleLiveEditor>
+            <LiveEditor className="pgn-doc__code-block-editor" />
+          </CollapsibleLiveEditor>
+          <LiveError className="pgn-doc__code-block-error" />
+        </LiveProvider>
+      </div>
     );
   }
 

--- a/www/src/components/CodeBlock.jsx
+++ b/www/src/components/CodeBlock.jsx
@@ -11,31 +11,61 @@ import * as ParagonIcons from '~paragon-icons'; // eslint-disable-line
 import MiyazakiCard from './exampleComponents/MiyazakiCard';
 import HipsterIpsum from './exampleComponents/HipsterIpsum';
 
+const { Collapsible } = ParagonReact;
+
+function CollapsibleLiveEditor({ children }) {
+  const [collapseIsOpen, setCollapseIsOpen] = useState(false);
+  return (
+    <div className="pgn-doc__collapsible-code-block">
+      <Collapsible.Advanced
+        open={collapseIsOpen}
+        onToggle={(isOpen) => setCollapseIsOpen(isOpen)}
+      >
+        <Collapsible.Trigger>
+          <div className="font-weight-bold">
+            <Collapsible.Visible whenClosed>Show code example</Collapsible.Visible>
+            <Collapsible.Visible whenOpen>Hide code example</Collapsible.Visible>
+          </div>
+        </Collapsible.Trigger>
+        <Collapsible.Body className="mt-2">
+          {children}
+        </Collapsible.Body>
+      </Collapsible.Advanced>
+    </div>
+  );
+}
+
+CollapsibleLiveEditor.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
 function CodeBlock({ children, className, live }) {
   const language = className ? className.replace(/language-/, '') : 'jsx';
 
   if (live) {
     return (
-      <div className="pgn-doc__code-block">
-        <LiveProvider
-          code={children}
-          scope={{
-            ...ParagonIcons,
-            ...ParagonReact,
-            useCallback,
-            useState,
-            useMemo,
-            FontAwesome,
-            MiyazakiCard,
-            HipsterIpsum,
-          }}
-          theme={theme}
-        >
-          <LivePreview className="pgn-doc__code-block-preview" />
-          <LiveEditor className="pgn-doc__code-block-editor" />
-          <LiveError className="pgn-doc__code-block-error" />
-        </LiveProvider>
-      </div>
+        <div className="pgn-doc__code-block">
+          <LiveProvider
+            code={children}
+            scope={{
+              ...ParagonIcons,
+              ...ParagonReact,
+              useCallback,
+              useState,
+              useMemo,
+              FontAwesome,
+              MiyazakiCard,
+              HipsterIpsum,
+            }}
+            theme={theme}
+          >
+            <LivePreview className="pgn-doc__code-block-preview" />
+            <CollapsibleLiveEditor>
+              <LiveEditor className="pgn-doc__code-block-editor" />
+            </CollapsibleLiveEditor>
+            <LiveError className="pgn-doc__code-block-error" />
+          </LiveProvider>
+        </div>
     );
   }
 

--- a/www/src/components/CodeBlock.jsx
+++ b/www/src/components/CodeBlock.jsx
@@ -16,7 +16,7 @@ const { Collapsible } = ParagonReact;
 function CollapsibleLiveEditor({ children }) {
   const [collapseIsOpen, setCollapseIsOpen] = useState(false);
   return (
-    <div className="pgn-doc__collapsible-code-block">
+    <div className="pgn-doc__collapsible-live-editor">
       <Collapsible.Advanced
         open={collapseIsOpen}
         onToggle={(isOpen) => setCollapseIsOpen(isOpen)}


### PR DESCRIPTION
**Collapsed**
![image](https://user-images.githubusercontent.com/2828721/146463944-f29923f1-1fa1-4e7b-b9b2-fbe035c5edad.png)

**Expanded**
![image](https://user-images.githubusercontent.com/2828721/146463858-b0c059ee-5458-4f9d-90de-f80199e8a292.png)
