### PR TITLE
fix: remove default outline on btn-icon-variant mixin

### DIFF
--- a/src/IconButton/_IconButton.scss
+++ b/src/IconButton/_IconButton.scss
@@ -33,6 +33,7 @@ $btn-icon-accent-color: white !default;
 
     &.focus,
     &:focus {
+        outline: 0;
         background-color: $btn-icon-bg;
         color: $icon-color;
         box-shadow: inset 0 0 0 $btn-focus-width $icon-color;


### PR DESCRIPTION
Removes the default blue outline on the `IconButton` component when focused since it has its own custom focus styles.

**Before:**
![image](https://user-images.githubusercontent.com/2828721/146549587-1d846e07-6b5e-431d-9966-e77970417b65.png)

**After:**
![image](https://user-images.githubusercontent.com/2828721/146549621-41f32e33-2fc6-485c-8f4e-0cd223e7de97.png)


https://deploy-preview-972--paragon-edx.netlify.app/components/iconbutton/#basic-usage-with-paragon-icon