### PR TITLE
"Show code example" as button link, resolve errors and add spacing to docs

### DIFF
--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -43,12 +43,12 @@ This header displays a title, subtitle, and may contain actions.
 
 ```jsx live
 <div>
-  <Card>
-    <Card.Header 
+  <Card className="mb-2">
+    <Card.Header
       title="Title"
     />
   </Card>
-  <Card className="mt-1">
+  <Card>
     <Card.Header 
       title="Title"
       subtitle="Subtitle"
@@ -62,45 +62,38 @@ The CardHeader supports custom actions via the the actions prop and renders them
 
 ```jsx live
 <div>
-  <Card>
+  <Card className="mb-2">
     <Card.Header
       title="Title"
       subtitle="Subtitle"
       actions={
         <ActionRow>
+          <Button variant="tertiary">Action</Button>
           <Button>Action</Button>
         </ActionRow>
       } 
     />
   </Card>
-  <Card className="mt-1">
+  <Card>
     <Card.Header
       title="Title"
       subtitle="Subtitle"
       actions={
-        <>
-          <ExtraSmall>
-            <IconButton
-              icon={FontAwesome.faBars}
-              alt="Menu"
-              onClick={() => console.log("You clicked the menu button")}
-              variant="primary"
-            />
-          </ExtraSmall>
-          <LargerThanExtraSmall>
-            <ActionRow>
-              <Button>Action 1</Button>
-              <Button variant="secondary">Action 2</Button>
-              <IconButton
-                icon={FontAwesome.faBars}
-                alt="Menu"
-                onClick={() => console.log("You clicked the menu button")}
-                variant="primary"
-              />
-            </ActionRow>
-          </LargerThanExtraSmall>
-        </>
-      } 
+        <Dropdown>
+          <Dropdown.Toggle
+            id="dropdown-toggle-with-iconbutton"
+            as={IconButton}
+            src={MoreVert}
+            iconAs={Icon}
+            variant="primary"
+          />
+          <Dropdown.Menu>
+            <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
+            <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
+            <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
+      }
     />
   </Card>
 </div>

--- a/src/IconButton/_IconButton.scss
+++ b/src/IconButton/_IconButton.scss
@@ -33,7 +33,7 @@ $btn-icon-accent-color: white !default;
 
     &.focus,
     &:focus {
-        outline: 0;
+        outline: 2px transparent;
         background-color: $btn-icon-bg;
         color: $icon-color;
         box-shadow: inset 0 0 0 $btn-focus-width $icon-color;

--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,6 @@ export {
   useMediaQuery,
   Context as ResponsiveContext,
 } from 'react-responsive';
-
 export {
   useTable,
   useFilters,

--- a/www/src/components/CodeBlock.jsx
+++ b/www/src/components/CodeBlock.jsx
@@ -11,7 +11,7 @@ import * as ParagonIcons from '~paragon-icons'; // eslint-disable-line
 import MiyazakiCard from './exampleComponents/MiyazakiCard';
 import HipsterIpsum from './exampleComponents/HipsterIpsum';
 
-const { Collapsible } = ParagonReact;
+const { Button, Collapsible } = ParagonReact;
 
 function CollapsibleLiveEditor({ children }) {
   const [collapseIsOpen, setCollapseIsOpen] = useState(false);
@@ -21,11 +21,9 @@ function CollapsibleLiveEditor({ children }) {
         open={collapseIsOpen}
         onToggle={(isOpen) => setCollapseIsOpen(isOpen)}
       >
-        <Collapsible.Trigger>
-          <div className="font-weight-bold">
-            <Collapsible.Visible whenClosed>Show code example</Collapsible.Visible>
-            <Collapsible.Visible whenOpen>Hide code example</Collapsible.Visible>
-          </div>
+        <Collapsible.Trigger tag={Button} variant="link">
+          <Collapsible.Visible whenClosed>Show code example</Collapsible.Visible>
+          <Collapsible.Visible whenOpen>Hide code example</Collapsible.Visible>
         </Collapsible.Trigger>
         <Collapsible.Body className="mt-2">
           {children}


### PR DESCRIPTION
* Update the "Show code example" collapsible to be a button link
* Resolve errors when using now-deleted responsive components
* Add some spacing between docs examples
* Update `IconButton` focus outline for High Contrast mode support

![image](https://user-images.githubusercontent.com/2828721/146579991-c89c2314-caf2-4953-be29-ee109dea6f9a.png)
