### PR TITLE
fix: native a11y support for Spinner and improve docs

### DIFF
--- a/src/Button/README.md
+++ b/src/Button/README.md
@@ -80,7 +80,7 @@ This component utilizes `Button` from React-Bootstrap and extends it with an abi
 </>
 ```
 
-### When to use the inline size
+#### When to use the inline size
 
 Use inline size buttons for when a button sits with a line of text.
 
@@ -115,6 +115,30 @@ Use inline size buttons for when a button sits with a line of text.
   <Button variant="primary" iconBefore={Remove} iconAfter={Add}>Primary</Button>{' '}
   <Button variant="outline-primary" iconBefore={Highlight}>Outline Primary</Button>{' '}
   <Button variant="tertiary" iconAfter={Add}>Tertiary</Button>{' '}
+</>
+```
+
+### With a Spinner
+```jsx live
+<>
+  <Button variant="primary" className="mr-2">
+    <Spinner animation="border" screenReaderText="loading some stuff" />
+  </Button>
+  <Button variant="brand" className="mr-2">
+    <Spinner animation="border" />
+  </Button>
+  <Button variant="outline-primary" className="mr-2">
+    <Spinner animation="border" />
+  </Button>
+  <Button variant="outline-brand" className="mr-2">
+    <Spinner animation="border" />
+  </Button>
+  <Button variant="inverse-primary" className="mr-2">
+    <Spinner animation="border" />
+  </Button>
+  <Button variant="inverse-brand" className="mr-2">
+    <Spinner animation="border" />
+  </Button>
 </>
 ```
 

--- a/src/Spinner/README.md
+++ b/src/Spinner/README.md
@@ -2,6 +2,8 @@
 title: 'Spinner'
 type: 'component'
 status: 'Stable'
+components:
+- Spinner
 categories:
 - Status & metadata
 - Choreography
@@ -21,5 +23,18 @@ notes: |
 ### Basic Usage
 
 ```jsx live
-<Spinner animation="border" variant="primary" />
+<>
+  <Spinner animation="border" className="mr-3" />
+  <Spinner animation="grow" />
+</>
+```
+### Color Variants
+
+```jsx live
+() => {
+  const variants = ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'light', 'dark'];
+  return variants.map((variant) => (
+    <Spinner animation="border" variant={variant} className="mr-3" />
+  ));
+}
 ```

--- a/src/Spinner/README.md
+++ b/src/Spinner/README.md
@@ -13,7 +13,7 @@ notes: |
 
 ---
 
-<p className="lead">
+<p>
   This is a pass through component from React-Bootstrap.<br/>
   <a href="https://react-bootstrap.github.io/components/spinners" target="_blank" rel="noopener noreferrer">
     See React-Bootstrap for documentation.
@@ -24,8 +24,8 @@ notes: |
 
 ```jsx live
 <>
-  <Spinner animation="border" className="mr-3" />
-  <Spinner animation="grow" />
+  <Spinner animation="border" className="mr-3" screenReaderText="loading" />
+  <Spinner animation="grow" screenReaderText="loading" />
 </>
 ```
 ### Color Variants
@@ -34,7 +34,7 @@ notes: |
 () => {
   const variants = ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'light', 'dark'];
   return variants.map((variant) => (
-    <Spinner animation="border" variant={variant} className="mr-3" />
+    <Spinner animation="border" variant={variant} className="mr-3" screenReaderText="loading" />
   ));
 }
 ```

--- a/src/Spinner/Spinner.test.jsx
+++ b/src/Spinner/Spinner.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Spinner from './index';
+
+describe('Spinner', () => {
+  it('should render a spinner', () => {
+    const wrapper = shallow(<Spinner animation="border" />);
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+  it('should render a spinner with screen reader text', () => {
+    const wrapper = shallow(<Spinner animation="border" screenReaderText="loading" />);
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+});

--- a/src/Spinner/__snapshots__/Spinner.test.jsx.snap
+++ b/src/Spinner/__snapshots__/Spinner.test.jsx.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Spinner should render a spinner 1`] = `"<div class=\\"pgn__spinner spinner-border\\"></div>"`;
+
+exports[`Spinner should render a spinner with screen reader text 1`] = `"<div role=\\"status\\" class=\\"pgn__spinner spinner-border\\"><span class=\\"sr-only\\">loading</span></div>"`;

--- a/src/Spinner/index.jsx
+++ b/src/Spinner/index.jsx
@@ -1,1 +1,37 @@
-export { default } from 'react-bootstrap/Spinner';
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import BaseSpinner from 'react-bootstrap/Spinner';
+
+const Spinner = React.forwardRef(({
+  className,
+  screenReaderText,
+  ...attrs
+}, ref) => {
+  const spinnerProps = {
+    ...attrs,
+    className: classNames('pgn__spinner', className),
+    role: screenReaderText ? 'status' : undefined,
+  };
+  return (
+    <BaseSpinner {...spinnerProps} ref={ref}>
+      {screenReaderText && (
+        <span className="sr-only">{screenReaderText}</span>
+      )}
+    </BaseSpinner>
+  );
+});
+
+Spinner.propTypes = {
+  /** Specifies the class name for the component. */
+  className: PropTypes.string,
+  /** Specifies the screen reader content for a11y. */
+  screenReaderText: PropTypes.node,
+};
+
+Spinner.defaultProps = {
+  className: undefined,
+  screenReaderText: undefined,
+};
+
+export default Spinner;

--- a/src/Spinner/index.jsx
+++ b/src/Spinner/index.jsx
@@ -15,9 +15,7 @@ const Spinner = React.forwardRef(({
   };
   return (
     <BaseSpinner {...spinnerProps} ref={ref}>
-      {screenReaderText && (
-        <span className="sr-only">{screenReaderText}</span>
-      )}
+      {screenReaderText && <span className="sr-only">{screenReaderText}</span>}
     </BaseSpinner>
   );
 });

--- a/www/src/components/CodeBlock.jsx
+++ b/www/src/components/CodeBlock.jsx
@@ -1,4 +1,9 @@
-import React, { useCallback, useState, useMemo } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useState,
+  useMemo,
+} from 'react';
 import PropTypes from 'prop-types';
 import Highlight, { defaultProps } from 'prism-react-renderer';
 import theme from 'prism-react-renderer/themes/duotoneDark';
@@ -49,6 +54,7 @@ function CodeBlock({ children, className, live }) {
             ...ParagonIcons,
             ...ParagonReact,
             useCallback,
+            useEffect,
             useState,
             useMemo,
             FontAwesome,


### PR DESCRIPTION
Paragon ticket: https://openedx.atlassian.net/browse/PAR-457

* Added optional `screenReaderText` prop to provide accessible screenreader-only text and a `role="status"`.
* Added additional (pre-existing) examples to the `Spinner` docs.

PR previews:
1. [brand-edx.org](https://deploy-preview-976--paragon-edx.netlify.app/components/spinner/)
2. [core](https://deploy-preview-976--paragon-openedx.netlify.app/components/spinner/)