### PR TITLE
docs: link to github code example of component usages

### DIFF
--- a/www/src/components/insights/ProjectNameWithComponentUsageModal.jsx
+++ b/www/src/components/insights/ProjectNameWithComponentUsageModal.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  StandardModal,
+  Hyperlink,
+  useToggle,
+} from '~paragon-react';
+
+const ProjectNameWithComponentUsageModal = ({ componentName, row }) => {
+  const [isOpen, open, close] = useToggle(false);
+  const projectName = row.original.folderName;
+  const repositoryUrl = row.original.repositoryUrl;
+  const projectUsages = row.original.usages;
+  return (
+    <>
+      <Button
+        variant="link"
+        className="p-0 text-left"
+        onClick={isOpen ? close : open}
+      >
+        {projectName}
+      </Button>
+      <StandardModal
+        size="xl"
+        title={`${componentName} in ${projectName}`}
+        isOpen={isOpen}
+        hasCloseButton={false}
+        onClose={close}
+        footerNode={(
+          <Button variant="primary" onClick={close}>OK</Button>
+        )}
+      >
+        <div className="pgn-doc__component-usage__project">
+          <ul className="list-unstyled">
+            {projectUsages.map(({
+              filePath,
+              line,
+            }) => (
+              <li key={`${filePath}#L${line}`}>
+                {repositoryUrl ? (
+                  <>
+                    <Hyperlink
+                      destination={`${repositoryUrl}/${filePath}#L${line}`}
+                      target="_blank"
+                    >
+                      {filePath}
+                    </Hyperlink>
+                    {' '}(line {line})
+                  </>
+                ) : (
+                  <>{filePath} (line {line})</>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </StandardModal>
+    </>
+  );
+};
+
+ProjectNameWithComponentUsageModal.propTypes = {
+  componentName: PropTypes.string.isRequired,
+  row: PropTypes.shape({
+    original: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      repositoryUrl: PropTypes.string,
+      usages: PropTypes.arrayOf(PropTypes.shape({
+        filePath: PropTypes.string.isRequired,
+        line: PropTypes.number.isRequired,
+      })).isRequired,
+    }).isRequired,
+  }).isRequired,
+};
+
+export default ProjectNameWithComponentUsageModal;

--- a/www/src/components/insights/ProjectNameWithUsageModal.jsx
+++ b/www/src/components/insights/ProjectNameWithUsageModal.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  StandardModal,
+  Hyperlink,
+  useToggle,
+} from '~paragon-react';
+
+const ProjectNameWithUsageModal = ({ row }) => {
+  const [isOpen, open, close] = useToggle(false);
+  const projectName = row.original.folderName;
+  const componentUsages = row.original.usages;
+  const repositoryUrl = row.original.repositoryUrl;
+  return (
+    <>
+      <Button
+        variant="link"
+        className="p-0 text-left"
+        onClick={isOpen ? close : open}
+      >
+        {projectName}
+      </Button>
+      <StandardModal
+        size="xl"
+        title={projectName}
+        isOpen={isOpen}
+        hasCloseButton={false}
+        onClose={close}
+        footerNode={(
+          <Button variant="primary" onClick={close}>OK</Button>
+        )}
+      >
+        {Object.keys(componentUsages).length === 0 && (
+          <p>This project does not import any Paragon components, but may still use its SCSS styles.</p>
+        )}
+        {Object.entries(componentUsages).map(([componentName, componentUsages]) => (
+          <div className="pgn-doc__usages-modal mb-4" key={componentName}>
+            <h4 className="font-weight-bold">{componentName}</h4>
+            <ul className="list-unstyled">
+              {componentUsages.map(({
+                filePath,
+                line,
+              }) => (
+                <li key={`${filePath}L#${line}`}>
+                  {repositoryUrl ? (
+                    <>
+                      <Hyperlink
+                        destination={`${repositoryUrl}/${filePath}#L${line}`}
+                        target="_blank"
+                      >
+                        {filePath}
+                      </Hyperlink>
+                      {' '}(line {line})
+                    </>
+                  ) : (
+                    <>{filePath} (line {line})</>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </StandardModal>
+    </>
+  );
+};
+
+ProjectNameWithUsageModal.propTypes = {
+  row: PropTypes.shape({
+    original: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      repositoryUrl: PropTypes.string,
+      usages: PropTypes.arrayOf(PropTypes.shape({
+        filePath: PropTypes.string.isRequired,
+        line: PropTypes.number.isRequired,
+      })).isRequired,
+    }).isRequired,
+  }).isRequired,
+};
+
+export default ProjectNameWithUsageModal;

--- a/www/src/components/insights/SummaryComponentNameWithUsageModal.jsx
+++ b/www/src/components/insights/SummaryComponentNameWithUsageModal.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  StandardModal,
+  Hyperlink,
+  useToggle,
+} from '~paragon-react';
+
+const SummaryComponentNameWithUsageModal = ({ row }) => {
+  const [isOpen, open, close] = useToggle(false);
+  const componentName = row.original.name;
+  const componentUsages = row.original.usages;
+  return (
+    <>
+      <Button
+        variant="link"
+        className="p-0 text-left"
+        onClick={isOpen ? close : open}
+      >
+        {componentName}
+      </Button>
+      <StandardModal
+        size="xl"
+        title={componentName}
+        isOpen={isOpen}
+        hasCloseButton={false}
+        onClose={close}
+        footerNode={(
+          <Button variant="primary" onClick={close}>OK</Button>
+        )}
+      >
+        {componentUsages.map(({
+          name: projectName,
+          usages: projectUsages,
+          repositoryUrl,
+        }) => (
+          <div className="pgn-doc__summary-usages__project mb-4" key={projectName}>
+            <h4 className="font-weight-bold">{projectName}</h4>
+            <ul className="list-unstyled">
+              {projectUsages.map(({
+                filePath,
+                line,
+              }) => (
+                <li key={`${filePath}L#${line}`}>
+                  {repositoryUrl ? (
+                    <>
+                      <Hyperlink
+                        destination={`${repositoryUrl}/${filePath}#L${line}`}
+                        target="_blank"
+                      >
+                        {filePath}
+                      </Hyperlink>
+                      {' '}(line {line})
+                    </>
+                  ) : (
+                    <>{filePath} (line {line})</>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </StandardModal>
+    </>
+  );
+};
+
+SummaryComponentNameWithUsageModal.propTypes = {
+  row: PropTypes.shape({
+    original: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      repositoryUrl: PropTypes.string,
+      usages: PropTypes.arrayOf(PropTypes.shape({
+        filePath: PropTypes.string.isRequired,
+        line: PropTypes.number.isRequired,
+      })).isRequired,
+    }).isRequired,
+  }).isRequired,
+};
+
+export default SummaryComponentNameWithUsageModal;

--- a/www/src/pages/insights.jsx
+++ b/www/src/pages/insights.jsx
@@ -1,9 +1,16 @@
 import React from 'react';
 import {
-  DataTable, Tabs, Tab, Container,
+  DataTable,
+  Tabs,
+  Tab,
+  Container,
 } from '~paragon-react'; // eslint-disable-line
 import SEO from '../components/SEO';
 import Layout from '../components/PageLayout';
+import SummaryComponentNameWithUsageModal from '../components/insights/SummaryComponentNameWithUsageModal';
+import ProjectNameWithUsageModal from '../components/insights/ProjectNameWithUsageModal';
+import ProjectNameWithComponentUsageModal from '../components/insights/ProjectNameWithComponentUsageModal';
+import getGithubProjectUrl from '../utils/getGithubProjectUrl';
 import dependentProjectsAnalysis from '../../../dependent-usage.json';
 
 const {
@@ -13,6 +20,7 @@ const {
 
 const dependentProjects = dependentProjectsUsages.map(dependentUsage => ({
   ...dependentUsage,
+  repositoryUrl: getGithubProjectUrl(dependentUsage.repository?.url),
   count: Object.values(dependentUsage.usages).reduce((accumulator, usage) => accumulator += usage.length, 0),
 }));
 
@@ -25,7 +33,9 @@ const componentsUsage = dependentProjectsUsages.reduce((accumulator, project) =>
       name: project.name,
       folderName: project.folderName,
       version: project.version,
+      repositoryUrl: getGithubProjectUrl(project.repository?.url),
       componentUsageCount: project.usages[componentName].length,
+      usages: project.usages[componentName],
     });
   });
   return accumulator;
@@ -36,8 +46,13 @@ const summaryComponentsUsage = Object.entries(componentsUsage).map(([componentNa
   return {
     name: componentName,
     count: componentUsageCounts,
+    usages: componentsUsage[componentName],
   };
 });
+
+console.log('componentsUsage', componentsUsage);
+console.log('dependentProjects', dependentProjects);
+console.log('summaryComponentsUsage', summaryComponentsUsage);
 
 const SummaryUsage = () => {
   const summaryTableData = summaryComponentsUsage.sort((a, b) => {
@@ -62,7 +77,11 @@ const SummaryUsage = () => {
         itemCount={summaryTableData.length}
         data={summaryTableData}
         columns={[
-          { Header: 'Component Name', accessor: 'name' },
+          {
+            Header: 'Component Name',
+            accessor: 'name',
+            Cell: SummaryComponentNameWithUsageModal,
+          },
           { Header: 'Instance Count', accessor: 'count' },
         ]}
       >
@@ -84,7 +103,11 @@ const ProjectsUsage = () => (
       itemCount={dependentProjects.length}
       data={dependentProjects}
       columns={[
-        { Header: 'Project Name', accessor: 'folderName' },
+        {
+          Header: 'Project Name',
+          accessor: 'folderName',
+          Cell: ProjectNameWithUsageModal,
+        },
         { Header: 'Paragon Version', accessor: 'version' },
         { Header: 'Instance Count', accessor: 'count' },
       ]}
@@ -98,7 +121,6 @@ const ProjectsUsage = () => (
 );
 
 // Usage info about a single component
-// eslint-disable-next-line
 const ComponentUsage = ({ name, componentUsageInProjects }) => (
   <div className="mb-5">
     <h3 className="mb-4">{name}</h3>
@@ -107,7 +129,11 @@ const ComponentUsage = ({ name, componentUsageInProjects }) => (
       itemCount={componentUsageInProjects.length} // eslint-disable-line
       data={componentUsageInProjects}
       columns={[
-        { Header: 'Project Name', accessor: 'folderName' },
+        {
+          Header: 'Project Name',
+          accessor: 'folderName',
+          Cell: (props) => <ProjectNameWithComponentUsageModal {...props} componentName={name} />,
+        },
         { Header: 'Paragon Version', accessor: 'version' },
         { Header: 'Instance Count', accessor: 'componentUsageCount' },
       ]}

--- a/www/src/pages/insights.jsx
+++ b/www/src/pages/insights.jsx
@@ -50,10 +50,6 @@ const summaryComponentsUsage = Object.entries(componentsUsage).map(([componentNa
   };
 });
 
-console.log('componentsUsage', componentsUsage);
-console.log('dependentProjects', dependentProjects);
-console.log('summaryComponentsUsage', summaryComponentsUsage);
-
 const SummaryUsage = () => {
   const summaryTableData = summaryComponentsUsage.sort((a, b) => {
     const nameA = a.name.toUpperCase();

--- a/www/src/utils/getGithubProjectUrl.js
+++ b/www/src/utils/getGithubProjectUrl.js
@@ -1,0 +1,12 @@
+const getGithubProjectUrl = (repositoryUrl) => {
+  if (!repositoryUrl) {
+    return;
+  }
+  const parts = repositoryUrl.split('/');
+  const githubDomainIndex = parts.findIndex(part => part === 'github.com');
+  parts.splice(0, githubDomainIndex);
+  const parsedRepositoryUrl = parts.join('/').replace('.git', '');
+  return `https://${parsedRepositoryUrl}/blob/master`;
+};
+
+export default getGithubProjectUrl;


### PR DESCRIPTION
[PAR-394](https://openedx.atlassian.net/browse/PAR-394)

Provide links to specific code examples of usages of Paragon components.

**Demo:** https://deploy-preview-983--paragon-edx.netlify.app/insights

**Known bugs**
* Hyperlinks to monorepo packages (e.g., `catalog-search`) will lead to a 404 on Github since they are linking to the root of the repository instead of the relative package path.
* Some repositories don't have a repository url specified, so there are no hyperlinks for their code usages.
* `edx/frontend-app-ora-enhanced-staff-grader` as a Github repository doesn't exist (the actual repository name is different), so links to it will lead to a 404 on Github.

### Example

![image](https://user-images.githubusercontent.com/2828721/146802069-2f4b287c-5a7d-4913-82b9-1bc07316eec1.png)
