### PR TITLE
feat: add dataViewToggle within DataTable PAR-577

### DIFF
--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -138,7 +138,7 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
   justify-content: space-between;
 
   .pgn__data-table-status-left {
-    align-self: center;
+    align-self: end;
   }
 }
 

--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -28,8 +28,22 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
   display: flex;
 }
 
+.pgn__data-table-dataview-toggle {
+  flex: auto;
+}
+
 .pgn__data-table-actions-right {
   display: flex;
+}
+
+.pgn__data-table-actions-right-toggle-bottom {
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: flex-end;
+
+  .pgn__data-table-dataview-toggle {
+    margin-top: map_get($spacers, 4);
+  }
 }
 
 .pgn__data-table-container {

--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -28,6 +28,10 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
   display: flex;
 }
 
+.pgn__data-table-actions-right {
+  display: flex;
+}
+
 .pgn__data-table-container {
   width: 100%;
   display: block;

--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -100,9 +100,6 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
 
 .pgn__data-table-status-bar {
   padding: $data-table-padding-y $data-table-padding-x;
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
 }
 
 .pgn__data-table-filters {

--- a/src/DataTable/DataTable.scss
+++ b/src/DataTable/DataTable.scss
@@ -1,4 +1,3 @@
-
 $data-table-border: 1px solid $gray-200 !default;
 $data-table-box-shadow: $box-shadow-sm !default;
 $data-table-padding-x: 0.75rem !default;
@@ -24,7 +23,8 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
   }
 }
 
-.pgn__bulk-actions, .pgn__table-actions {
+.pgn__bulk-actions,
+.pgn__table-actions {
   display: flex;
 }
 
@@ -35,10 +35,10 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
   -webkit-overflow-scrolling: touch;
 }
 
-.pgn__data-table-layout-wrapper{
+.pgn__data-table-layout-wrapper {
   display: flex;
   align-items: flex-start;
-  .pgn__data-table-layout-sidebar{
+  .pgn__data-table-layout-sidebar {
     border-radius: $border-radius;
     box-shadow: $data-table-box-shadow;
     padding: $data-table-padding-small;
@@ -46,20 +46,18 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
     flex-grow: 0;
   }
 
-  .pgn__data-table-side-filters{
-    .pgn__data-table-side-filters-title{
+  .pgn__data-table-side-filters {
+    .pgn__data-table-side-filters-title {
       margin-bottom: map_get($spacers, 3);
     }
-    .pgn__data-table-side-filters-status{
+    .pgn__data-table-side-filters-status {
       margin-bottom: map_get($spacers, 2);
       display: flex;
       justify-content: flex-end;
     }
   }
-  
 
-
-  .pgn__data-table-layout-main{
+  .pgn__data-table-layout-main {
     flex-grow: 1;
   }
 }
@@ -79,7 +77,7 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
     line-height: 24px;
   }
   & tr.is-selected {
-    background-color: $info-100!important;
+    background-color: $info-100 !important;
   }
 }
 
@@ -91,7 +89,7 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
 }
 
 .pgn__data-table-empty {
-  padding: $data-table-padding-x $data-table-padding-y
+  padding: $data-table-padding-x $data-table-padding-y;
 }
 
 .pgn__data-table-actions {
@@ -100,9 +98,11 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
   padding-bottom: $data-table-padding-small;
 }
 
-
 .pgn__data-table-status-bar {
   padding: $data-table-padding-y $data-table-padding-x;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
 }
 
 .pgn__data-table-filters {
@@ -119,8 +119,8 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
 }
 
 .pgn__data-table-status {
-    display: flex;
-    justify-content: space-between;
+  display: flex;
+  justify-content: space-between;
 
   .pgn__data-table-status-left {
     align-self: center;
@@ -159,15 +159,15 @@ $data-table-pagination-dropdown-min-width: 6rem !default;
 .pgn__checkbox-filter {
   display: flex;
   input .form-check-input {
-    margin-top: .36rem;
+    margin-top: 0.36rem;
   }
 }
 
 .pgn__dropdown-filter-checkbox-group {
-  margin-left: .75rem;
-  margin-right: .75rem;
+  margin-left: 0.75rem;
+  margin-right: 0.75rem;
   input .form-check-input {
-    margin-top: .36rem;
+    margin-top: 0.36rem;
   }
 }
 

--- a/src/DataTable/DataViewToggle.jsx
+++ b/src/DataTable/DataViewToggle.jsx
@@ -18,7 +18,9 @@ const DataViewToggle = () => {
   const [activeValue, setActiveValue] = useState(defaultActiveStateValue || 'card');
   const handleOnChange = value => {
     setActiveValue(value);
-    onDataViewToggle(value);
+    if (onDataViewToggle) {
+      onDataViewToggle(value);
+    }
   };
   return (
     <div className="pgn__data-table-dataview-toggle">

--- a/src/DataTable/DataViewToggle.jsx
+++ b/src/DataTable/DataViewToggle.jsx
@@ -4,6 +4,11 @@ import {
 } from '..';
 import { GridView, ListView } from '../../icons';
 
+export const DATA_VIEW_TOGGLE_VALUES = {
+  card: { value: 'card', alt: 'Card', tooltipContent: 'Card view' },
+  list: { value: 'list', alt: 'List', tooltipContent: 'List view' },
+};
+
 const DataViewToggle = () => {
   const {
     dataViewToggleOptions: {
@@ -22,14 +27,28 @@ const DataViewToggle = () => {
       onDataViewToggle(value);
     }
   };
+  const { value: cardValue, alt: cardAlt, tooltipContent: cardTooltip } = DATA_VIEW_TOGGLE_VALUES.card;
+  const { value: listValue, alt: listAlt, tooltipContent: listTooltip } = DATA_VIEW_TOGGLE_VALUES.list;
   return (
     <div role="group" className="pgn__data-table-dataview-toggle">
       <IconButtonToggle
         activeValue={activeValue}
         onChange={handleOnChange}
       >
-        <IconButtonWithTooltip tooltipContent="Card view" value="card" src={GridView} iconAs={Icon} alt="Card" />
-        <IconButtonWithTooltip tooltipContent="List view" value="list" src={ListView} iconAs={Icon} alt="List" />
+        <IconButtonWithTooltip
+          tooltipContent={cardTooltip}
+          value={cardValue}
+          src={GridView}
+          iconAs={Icon}
+          alt={cardAlt}
+        />
+        <IconButtonWithTooltip
+          tooltipContent={listTooltip}
+          value={listValue}
+          src={ListView}
+          iconAs={Icon}
+          alt={listAlt}
+        />
       </IconButtonToggle>
     </div>
   );

--- a/src/DataTable/DataViewToggle.jsx
+++ b/src/DataTable/DataViewToggle.jsx
@@ -1,0 +1,23 @@
+import React, { useContext } from 'react';
+import {
+  DataTableContext, Icon, IconButtonToggle, IconButtonWithTooltip,
+} from '..';
+import { GridView, ListView } from '../../icons';
+
+const DataViewToggle = () => {
+  const {
+    enableDataViewToggle,
+    onDataViewToggle,
+  } = useContext(DataTableContext);
+  if (!enableDataViewToggle) { return null; }
+  return (
+    <div className="pgn__data-table-dataview-toggle">
+      <IconButtonToggle activeValue="card" onChange={value => onDataViewToggle(value)}>
+        <IconButtonWithTooltip tooltipContent="Card view" value="card" src={GridView} iconAs={Icon} alt="Card" />
+        <IconButtonWithTooltip tooltipContent="List view" value="list" src={ListView} iconAs={Icon} alt="List" />
+      </IconButtonToggle>
+    </div>
+  );
+};
+
+export default DataViewToggle;

--- a/src/DataTable/DataViewToggle.jsx
+++ b/src/DataTable/DataViewToggle.jsx
@@ -9,13 +9,13 @@ const DataViewToggle = () => {
     dataViewToggleOptions: {
       isDataViewToggleEnabled,
       onDataViewToggle,
-      defaultToggleValue,
+      defaultActiveStateValue,
     },
   } = useContext(DataTableContext);
 
   if (!isDataViewToggleEnabled) { return null; }
 
-  const [activeValue, setActiveValue] = useState(defaultToggleValue);
+  const [activeValue, setActiveValue] = useState(defaultActiveStateValue || 'card');
   const handleOnChange = value => {
     setActiveValue(value);
     onDataViewToggle(value);

--- a/src/DataTable/DataViewToggle.jsx
+++ b/src/DataTable/DataViewToggle.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import {
   DataTableContext, Icon, IconButtonToggle, IconButtonWithTooltip,
 } from '..';
@@ -6,13 +6,26 @@ import { GridView, ListView } from '../../icons';
 
 const DataViewToggle = () => {
   const {
-    enableDataViewToggle,
-    onDataViewToggle,
+    dataViewToggleOptions: {
+      isDataViewToggleEnabled,
+      onDataViewToggle,
+      defaultToggleValue,
+    },
   } = useContext(DataTableContext);
-  if (!enableDataViewToggle) { return null; }
+
+  if (!isDataViewToggleEnabled) { return null; }
+
+  const [activeValue, setActiveValue] = useState(defaultToggleValue);
+  const handleOnChange = value => {
+    setActiveValue(value);
+    onDataViewToggle(value);
+  };
   return (
     <div className="pgn__data-table-dataview-toggle">
-      <IconButtonToggle activeValue="card" onChange={value => onDataViewToggle(value)}>
+      <IconButtonToggle
+        activeValue={activeValue}
+        onChange={handleOnChange}
+      >
         <IconButtonWithTooltip tooltipContent="Card view" value="card" src={GridView} iconAs={Icon} alt="Card" />
         <IconButtonWithTooltip tooltipContent="List view" value="list" src={ListView} iconAs={Icon} alt="List" />
       </IconButtonToggle>

--- a/src/DataTable/DataViewToggle.jsx
+++ b/src/DataTable/DataViewToggle.jsx
@@ -23,7 +23,7 @@ const DataViewToggle = () => {
     }
   };
   return (
-    <div className="pgn__data-table-dataview-toggle">
+    <div role="group" className="pgn__data-table-dataview-toggle">
       <IconButtonToggle
         activeValue={activeValue}
         onChange={handleOnChange}

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -302,8 +302,10 @@ function() {
   return (
     <DataTable
       isFilterable
-      enableDataViewToggle
-      onDataViewToggle={ val => setCurrentView(val) }
+      dataViewToggleOptions={{
+        isDataViewToggleEnabled: true,
+        onDataViewToggle: val => setCurrentView(val)
+      }}
       isSortable
       defaultColumnValues={{ Filter: TextFilter }}
       itemCount={7}

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -3,6 +3,7 @@ title: 'DataTable'
 type: 'component'
 components:
 - DataTable
+- DataViewToggle
 - BulkActions
 - TableActions
 - Table
@@ -297,6 +298,8 @@ To enable proper selection behavior with backend pagination (i.e., when ``isSele
 ## View Switching
 
 Card view is default when ``isDataViewToggleEnabled`` is true
+
+See ``dataViewToggleOptions`` props documentation for all supported props
 
 ```jsx live
 function() {

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -296,6 +296,8 @@ To enable proper selection behavior with backend pagination (i.e., when ``isSele
 
 ## View Switching
 
+Card view is default when ``isDataViewToggleEnabled`` is true
+
 ```jsx live
 function() {
   const [currentView, setCurrentView] = useState('card');
@@ -305,6 +307,91 @@ function() {
       dataViewToggleOptions={{
         isDataViewToggleEnabled: true,
         onDataViewToggle: val => setCurrentView(val)
+      }}
+      isSortable
+      defaultColumnValues={{ Filter: TextFilter }}
+      itemCount={7}
+      data={[
+        {
+          name: 'Lil Bub',
+          color: 'brown tabby',
+          famous_for: 'weird tongue',
+        },
+        {
+          name: 'Grumpy Cat',
+          color: 'siamese',
+          famous_for: 'serving moods',
+        },
+        {
+          name: 'Smoothie',
+          color: 'orange tabby',
+          famous_for: 'modeling',
+        },
+      ]}
+      columns={[
+        {
+          Header: 'Name',
+          accessor: 'name',
+
+        },
+        {
+          Header: 'Famous For',
+          accessor: 'famous_for',
+        },
+        {
+          Header: 'Coat Color',
+          accessor: 'color',
+          Filter: CheckboxFilter,
+          filter: 'includesValue',
+          filterChoices: [{
+            name: 'russian white',
+            number: 1,
+            value: 'russian white',
+          },
+          {
+            name: 'orange tabby',
+            number: 2,
+            value: 'orange tabby',
+          },
+          {
+            name: 'brown tabby',
+            number: 3,
+            value: 'brown tabby',
+          },
+          {
+            name: 'siamese',
+            number: 1,
+            value: 'siamese',
+          }]
+        },
+      ]}
+    >
+      <DataTable.TableControlBar />
+
+      {/* which kind of body content to show */}
+      { currentView === "card" && <CardView CardComponent={MiyazakiCard} /> }
+      { currentView === "list" && <DataTable.Table /> }
+
+      <DataTable.EmptyTable content="No results found" />
+      <DataTable.TableFooter />
+    </DataTable>
+  )
+}
+```
+
+### With a default active state specified
+
+```jsx live
+function() {
+  const defaultVal = "list";
+  const [currentView, setCurrentView] = useState(defaultVal);
+  return (
+    <DataTable
+      isFilterable
+      dataViewToggleOptions={{
+        isDataViewToggleEnabled: true,
+        onDataViewToggle: val => setCurrentView(val),
+        defaultActiveStateValue: defaultVal,
       }}
       isSortable
       defaultColumnValues={{ Filter: TextFilter }}

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -304,7 +304,7 @@ See ``dataViewToggleOptions`` props documentation for all supported props
 ```jsx live
 function() {
   const [currentView, setCurrentView] = useState('card');
-  const togglePlacement = 'bottom'; // this defaults to left if omitted
+  const togglePlacement = 'left'; // 'bottom' is the only other supported value
   return (
     <DataTable
       isFilterable

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -304,12 +304,14 @@ See ``dataViewToggleOptions`` props documentation for all supported props
 ```jsx live
 function() {
   const [currentView, setCurrentView] = useState('card');
+  const togglePlacement = 'bottom'; // this defaults to left if omitted
   return (
     <DataTable
       isFilterable
       dataViewToggleOptions={{
         isDataViewToggleEnabled: true,
-        onDataViewToggle: val => setCurrentView(val)
+        onDataViewToggle: val => setCurrentView(val),
+        togglePlacement,
       }}
       isSortable
       defaultColumnValues={{ Filter: TextFilter }}
@@ -588,6 +590,120 @@ You can pass a function to render custom components for bulk actions and table a
     <DataTable.EmptyTable content="No results found" />
     <DataTable.TableFooter />
   </DataTable>
+```
+
+#### Actions with Data view toggle enabled
+
+
+```jsx live
+function() {
+    const [currentView, setCurrentView] = useState('card');
+
+  return (<DataTable
+            dataViewToggleOptions={{
+              isDataViewToggleEnabled: true,
+              onDataViewToggle: val => setCurrentView(val),
+              defaultActiveStateValue: "card",
+            }}
+            isSelectable
+            itemCount={7}
+            tableActions={[
+                {
+                  buttonText: 'Table Action',
+                  handleClick: (data) => console.log('Table Action', data),
+                },
+            ]}
+            bulkActions={[
+                // Function defined button
+                ({selectedFlatRows})=>{
+                  return {
+                    buttonText: `Enroll (${selectedFlatRows.length})`,
+                    handleClick: () => console.log('Enroll', selectedFlatRows),
+                  }
+                },
+                {
+                  buttonText: 'Assign',
+                  handleClick: (data) => console.log('Assign', data),
+                },
+                {
+                  buttonText: 'Extra action 1',
+                  handleClick: (data) => console.log('Extra action 1', data),
+                },
+                {
+                  buttonText: 'Extra action 2',
+                  handleClick: (data) => console.log('Extra action 2', data),
+                },
+              ]}
+            additionalColumns={[
+              {
+                id: 'action',
+                Header: 'Action',
+                Cell: ({ row }) => <Button variant="link" onClick={() => console.log(`Assigning ${row.values.name}`)}>Assign</Button>,
+              }
+            ]}
+            data={[
+              {
+                name: 'Lil Bub',
+                color: 'brown tabby',
+                famous_for: 'weird tongue',
+              },
+              {
+                name: 'Grumpy Cat',
+                color: 'siamese',
+                famous_for: 'serving moods',
+              },
+              {
+                name: 'Smoothie',
+                color: 'orange tabby',
+                famous_for: 'modeling',
+              },
+              {
+                name: 'Maru',
+                color: 'brown tabby',
+                famous_for: 'being a lovable oaf',
+              },
+              {
+                name: 'Keyboard Cat',
+                color: 'orange tabby',
+                famous_for: 'piano virtuoso',
+              },
+              {
+                name: 'Long Cat',
+                color: 'russian white',
+                famous_for:
+                  'being loooooooooooooooooooooooooooooooooooooooooooooooooooooong',
+              },
+              {
+                name: 'Zeno',
+                color: 'brown tabby',
+                famous_for: 'getting halfway there'
+              },
+            ]}
+            columns={[
+              {
+                Header: 'Name',
+                accessor: 'name',
+
+              },
+              {
+                Header: 'Famous For',
+                accessor: 'famous_for',
+              },
+              {
+                Header: 'Coat Color',
+                accessor: 'color',
+              },
+            ]}
+          >
+            <DataTable.TableControlBar />
+            {/* which kind of body content to show */}
+            { currentView === "card" && <CardView CardComponent={MiyazakiCard} /> }
+            { currentView === "list" && <DataTable.Table /> }
+            <DataTable.EmptyTable content="No results found" />
+            <DataTable.TableFooter />
+          </DataTable>
+          );
+}
 ```
 
 ## CardView and alternate table components

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -505,7 +505,7 @@ You can pass a function to render custom components for bulk actions and table a
         // Function defined button
         ({selectedFlatRows})=>{
           return {
-            buttonText: `Enroll ${selectedFlatRows.length}`,
+            buttonText: `Enroll (${selectedFlatRows.length})`,
             handleClick: () => console.log('Enroll', selectedFlatRows),
           }
         },

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -6,6 +6,7 @@ components:
 - BulkActions
 - TableActions
 - Table
+- CardView
 - TableCell
 - TableHeaderCell
 - TableHeaderRow
@@ -284,12 +285,93 @@ To enable proper selection behavior with backend pagination (i.e., when ``isSele
             handleClick: () => {
               console.log('Clear selection');
               tableInstance.clearSelection()
-            }, 
+            },
           }
         },
       ]}
     />
   );
+}
+```
+
+## View Switching
+
+```jsx live
+function() {
+  const [currentView, setCurrentView] = useState('card');
+  return (
+    <DataTable
+      isFilterable
+      enableDataViewToggle
+      onDataViewToggle={ val => setCurrentView(val) }
+      isSortable
+      defaultColumnValues={{ Filter: TextFilter }}
+      itemCount={7}
+      data={[
+        {
+          name: 'Lil Bub',
+          color: 'brown tabby',
+          famous_for: 'weird tongue',
+        },
+        {
+          name: 'Grumpy Cat',
+          color: 'siamese',
+          famous_for: 'serving moods',
+        },
+        {
+          name: 'Smoothie',
+          color: 'orange tabby',
+          famous_for: 'modeling',
+        },
+      ]}
+      columns={[
+        {
+          Header: 'Name',
+          accessor: 'name',
+
+        },
+        {
+          Header: 'Famous For',
+          accessor: 'famous_for',
+        },
+        {
+          Header: 'Coat Color',
+          accessor: 'color',
+          Filter: CheckboxFilter,
+          filter: 'includesValue',
+          filterChoices: [{
+            name: 'russian white',
+            number: 1,
+            value: 'russian white',
+          },
+          {
+            name: 'orange tabby',
+            number: 2,
+            value: 'orange tabby',
+          },
+          {
+            name: 'brown tabby',
+            number: 3,
+            value: 'brown tabby',
+          },
+          {
+            name: 'siamese',
+            number: 1,
+            value: 'siamese',
+          }]
+        },
+      ]}
+    >
+      <DataTable.TableControlBar />
+
+      {/* which kind of body content to show */}
+      { currentView === "card" && <CardView CardComponent={MiyazakiCard} /> }
+      { currentView === "list" && <DataTable.Table /> }
+
+      <DataTable.EmptyTable content="No results found" />
+      <DataTable.TableFooter />
+    </DataTable>
+  )
 }
 ```
 
@@ -313,7 +395,7 @@ Bulk actions are not visible unless rows have been selected.
 
 ### Actions
 An action can also be definied as an additional column on the table. The Cell property can be defined to display
-any component that a user requires. It will receive the row as props. 
+any component that a user requires. It will receive the row as props.
 You can pass a function to render custom components for bulk actions and table actions.
 
 
@@ -332,7 +414,7 @@ You can pass a function to render custom components for bulk actions and table a
         ({selectedFlatRows})=>{
           return {
             buttonText: `Enroll ${selectedFlatRows.length}`,
-            handleClick: () => console.log('Enroll', selectedFlatRows), 
+            handleClick: () => console.log('Enroll', selectedFlatRows),
           }
         },
         {
@@ -628,7 +710,7 @@ a responsive grid of cards.
 ```
 
 ## Sidebar Filter
-For a more desktop friendly view, you can move filters into a sidebar by providing ``showFiltersInSidebar`` prop, try it out! 
+For a more desktop friendly view, you can move filters into a sidebar by providing ``showFiltersInSidebar`` prop, try it out!
 
 ```jsx live
   <DataTable

--- a/src/DataTable/TableControlBar.jsx
+++ b/src/DataTable/TableControlBar.jsx
@@ -6,18 +6,13 @@ import SmartStatus from './SmartStatus';
 import DropdownFilters from './DropdownFilters';
 import DataTableContext from './DataTableContext';
 import ActionDisplay from './ActionDisplay';
-import { Icon, IconButtonToggle, IconButtonWithTooltip } from '..';
-import { GridView, ListView } from '../../icons';
+import DataViewToggle from './DataViewToggle';
 
 // handles layout for filters, status, and bulk actions
-const TableControlBar = ({
-  className,
-}) => {
+const TableControlBar = ({ className }) => {
   const {
     setFilter,
     showFiltersInSidebar,
-    enableDataViewToggle,
-    onDataViewToggle,
   } = useContext(DataTableContext);
 
   return (
@@ -29,6 +24,7 @@ const TableControlBar = ({
             <DropdownFilters />
           </div>
           <div className="pgn__data-table-actions-right">
+            <DataViewToggle />
             <ActionDisplay />
           </div>
         </div>
@@ -39,16 +35,6 @@ const TableControlBar = ({
         </div>
         {(!setFilter || (setFilter && showFiltersInSidebar)) && (<ActionDisplay />)}
       </div>
-      {enableDataViewToggle
-      && (
-      <div className="pgn__data-table-view-switching">
-        <IconButtonToggle activeValue="card" onChange={value => onDataViewToggle(value)}>
-          <IconButtonWithTooltip tooltipContent="Card view" value="card" src={GridView} iconAs={Icon} alt="Card" />
-          <IconButtonWithTooltip tooltipContent="List view" value="list" src={ListView} iconAs={Icon} alt="List" />
-        </IconButtonToggle>
-      </div>
-      )}
-
     </div>
   );
 };

--- a/src/DataTable/TableControlBar.jsx
+++ b/src/DataTable/TableControlBar.jsx
@@ -13,8 +13,14 @@ const TableControlBar = ({ className }) => {
   const {
     setFilter,
     showFiltersInSidebar,
+    dataViewToggleOptions: { togglePlacement },
   } = useContext(DataTableContext);
 
+  const invalidtogglePlacement = !togglePlacement || !(['left', 'bottom']).includes(togglePlacement);
+  const actionsSectionClassName = classNames({
+    'pgn__data-table-actions-right-toggle-bottom': togglePlacement === 'bottom',
+    'pgn__data-table-actions-right': invalidtogglePlacement || togglePlacement === 'left',
+  });
   return (
     <div className={classNames('pgn__data-table-status-bar', className)}>
       {/* Using setFilter as a proxy for isFilterable */}
@@ -23,7 +29,7 @@ const TableControlBar = ({ className }) => {
           <div className="pgn__data-table-actions-left">
             <DropdownFilters />
           </div>
-          <div className="pgn__data-table-actions-right">
+          <div className={actionsSectionClassName}>
             <DataViewToggle />
             <ActionDisplay />
           </div>
@@ -34,7 +40,7 @@ const TableControlBar = ({ className }) => {
           <SmartStatus />
         </div>
         {(!setFilter || (setFilter && showFiltersInSidebar)) && (
-          <div className="pgn__data-table-actions-right">
+          <div className={actionsSectionClassName}>
             <DataViewToggle />
             <ActionDisplay />
           </div>

--- a/src/DataTable/TableControlBar.jsx
+++ b/src/DataTable/TableControlBar.jsx
@@ -33,7 +33,12 @@ const TableControlBar = ({ className }) => {
         <div className="pgn__data-table-status-left">
           <SmartStatus />
         </div>
-        {(!setFilter || (setFilter && showFiltersInSidebar)) && (<ActionDisplay />)}
+        {(!setFilter || (setFilter && showFiltersInSidebar)) && (
+          <div className="pgn__data-table-actions-right">
+            <DataViewToggle />
+            <ActionDisplay />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/DataTable/TableControlBar.jsx
+++ b/src/DataTable/TableControlBar.jsx
@@ -17,7 +17,7 @@ const TableControlBar = ({ className }) => {
   } = useContext(DataTableContext);
 
   const invalidtogglePlacement = !togglePlacement || !(['left', 'bottom']).includes(togglePlacement);
-  const actionsSectionClassName = classNames({
+  const actionsSectionClassName = classNames('mb-3', {
     'pgn__data-table-actions-right-toggle-bottom': togglePlacement === 'bottom',
     'pgn__data-table-actions-right': invalidtogglePlacement || togglePlacement === 'left',
   });

--- a/src/DataTable/TableControlBar.jsx
+++ b/src/DataTable/TableControlBar.jsx
@@ -16,34 +16,45 @@ const TableControlBar = ({ className }) => {
     dataViewToggleOptions: { togglePlacement },
   } = useContext(DataTableContext);
 
-  const invalidtogglePlacement = !togglePlacement || !(['left', 'bottom']).includes(togglePlacement);
-  const actionsSectionClassName = classNames('mb-3', {
+  const invalidTogglePlacement = !togglePlacement || !(['left', 'bottom']).includes(togglePlacement);
+  const actionsSectionClassName = classNames({
     'pgn__data-table-actions-right-toggle-bottom': togglePlacement === 'bottom',
-    'pgn__data-table-actions-right': invalidtogglePlacement || togglePlacement === 'left',
+    'pgn__data-table-actions-right': invalidTogglePlacement || togglePlacement === 'left',
   });
   return (
     <div className={classNames('pgn__data-table-status-bar', className)}>
       {/* Using setFilter as a proxy for isFilterable */}
       {(setFilter && !showFiltersInSidebar) && (
-        <div className="pgn__data-table-actions">
-          <div className="pgn__data-table-actions-left">
-            <DropdownFilters />
-          </div>
-          <div className={actionsSectionClassName}>
+      <div className="pgn__data-table-actions">
+        <div className="pgn__data-table-actions-left">
+          <DropdownFilters />
+        </div>
+        <div className={actionsSectionClassName}>
+          <div className="pgn__data-table-toggle">
             <DataViewToggle />
+          </div>
+          <div>
             <ActionDisplay />
           </div>
         </div>
+
+      </div>
       )}
       <div className="pgn__data-table-status">
         <div className="pgn__data-table-status-left">
           <SmartStatus />
         </div>
         {(!setFilter || (setFilter && showFiltersInSidebar)) && (
-          <div className={actionsSectionClassName}>
-            <DataViewToggle />
-            <ActionDisplay />
-          </div>
+          <>
+            <div className={actionsSectionClassName}>
+              <div className="pgn__data-table-toggle">
+                <DataViewToggle />
+              </div>
+              <div>
+                <ActionDisplay />
+              </div>
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/src/DataTable/TableControlBar.jsx
+++ b/src/DataTable/TableControlBar.jsx
@@ -6,12 +6,19 @@ import SmartStatus from './SmartStatus';
 import DropdownFilters from './DropdownFilters';
 import DataTableContext from './DataTableContext';
 import ActionDisplay from './ActionDisplay';
+import { Icon, IconButtonToggle, IconButtonWithTooltip } from '..';
+import { GridView, ListView } from '../../icons';
 
 // handles layout for filters, status, and bulk actions
 const TableControlBar = ({
   className,
 }) => {
-  const { setFilter, showFiltersInSidebar } = useContext(DataTableContext);
+  const {
+    setFilter,
+    showFiltersInSidebar,
+    enableDataViewToggle,
+    onDataViewToggle,
+  } = useContext(DataTableContext);
 
   return (
     <div className={classNames('pgn__data-table-status-bar', className)}>
@@ -32,6 +39,16 @@ const TableControlBar = ({
         </div>
         {(!setFilter || (setFilter && showFiltersInSidebar)) && (<ActionDisplay />)}
       </div>
+      {enableDataViewToggle
+      && (
+      <div className="pgn__data-table-view-switching">
+        <IconButtonToggle activeValue="card" onChange={value => onDataViewToggle(value)}>
+          <IconButtonWithTooltip tooltipContent="Card view" value="card" src={GridView} iconAs={Icon} alt="Card" />
+          <IconButtonWithTooltip tooltipContent="List view" value="list" src={ListView} iconAs={Icon} alt="List" />
+        </IconButtonToggle>
+      </div>
+      )}
+
     </div>
   );
 };

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -43,8 +43,7 @@ function DataTable({
   EmptyTableComponent,
   manualSelectColumn,
   showFiltersInSidebar,
-  enableDataViewToggle,
-  onDataViewToggle,
+  dataViewToggleOptions,
   children,
   ...props
 }) {
@@ -122,8 +121,7 @@ function DataTable({
     tableActions,
     controlledTableSelections,
     showFiltersInSidebar,
-    enableDataViewToggle,
-    onDataViewToggle,
+    dataViewToggleOptions,
     ...selectionProps,
     ...selectionActions,
     ...props,
@@ -170,8 +168,7 @@ DataTable.defaultProps = {
   FilterStatusComponent: FilterStatus,
   RowStatusComponent: RowStatus,
   showFiltersInSidebar: false,
-  enableDataViewToggle: false,
-  onDataViewToggle: () => {},
+  dataViewToggleOptions: { isDataViewToggleEnabled: false, onDataViewToggle: () => {}, defaultToggleValue: 'card' },
 };
 
 DataTable.propTypes = {
@@ -298,10 +295,15 @@ DataTable.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
   /** If true filters will be shown on sidebar instead */
   showFiltersInSidebar: PropTypes.bool,
-  /** Whether to show a toggle button group which allows view switching between card and table views */
-  enableDataViewToggle: PropTypes.bool,
-  /** Callback invoked when the toggle buttons are clicked, with value of selected button passed in */
-  onDataViewToggle: PropTypes.func,
+  /** options for data view toggle */
+  dataViewToggleOptions: PropTypes.shape({
+    /** Whether to show a toggle button group which allows view switching between card and table views */
+    isDataViewToggleEnabled: PropTypes.bool,
+    /** Callback invoked when the toggle buttons are clicked, with value of selected button passed in */
+    onDataViewToggle: PropTypes.func,
+    /** default value for toggle active state */
+    defaultActiveStateValue: PropTypes.string,
+  }),
 };
 
 DataTable.BulkActions = BulkActions;

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -168,7 +168,12 @@ DataTable.defaultProps = {
   FilterStatusComponent: FilterStatus,
   RowStatusComponent: RowStatus,
   showFiltersInSidebar: false,
-  dataViewToggleOptions: { isDataViewToggleEnabled: false, onDataViewToggle: () => {}, defaultActiveStateValue: 'card' },
+  dataViewToggleOptions: {
+    isDataViewToggleEnabled: false,
+    onDataViewToggle: () => {},
+    defaultActiveStateValue: 'card',
+    togglePlacement: 'left',
+  },
 };
 
 DataTable.propTypes = {
@@ -303,6 +308,9 @@ DataTable.propTypes = {
     onDataViewToggle: PropTypes.func,
     /** default value for toggle active state */
     defaultActiveStateValue: PropTypes.string,
+    /** placement of toggle 'bottom' will push it to the bottom row in
+     * actions section. Only 'left' and 'bottom' are supported */
+    togglePlacement: PropTypes.string,
   }),
 };
 

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -168,7 +168,7 @@ DataTable.defaultProps = {
   FilterStatusComponent: FilterStatus,
   RowStatusComponent: RowStatus,
   showFiltersInSidebar: false,
-  dataViewToggleOptions: { isDataViewToggleEnabled: false, onDataViewToggle: () => {}, defaultToggleValue: 'card' },
+  dataViewToggleOptions: { isDataViewToggleEnabled: false, onDataViewToggle: () => {}, defaultActiveStateValue: 'card' },
 };
 
 DataTable.propTypes = {

--- a/src/DataTable/index.jsx
+++ b/src/DataTable/index.jsx
@@ -43,6 +43,8 @@ function DataTable({
   EmptyTableComponent,
   manualSelectColumn,
   showFiltersInSidebar,
+  enableDataViewToggle,
+  onDataViewToggle,
   children,
   ...props
 }) {
@@ -120,6 +122,8 @@ function DataTable({
     tableActions,
     controlledTableSelections,
     showFiltersInSidebar,
+    enableDataViewToggle,
+    onDataViewToggle,
     ...selectionProps,
     ...selectionActions,
     ...props,
@@ -166,6 +170,8 @@ DataTable.defaultProps = {
   FilterStatusComponent: FilterStatus,
   RowStatusComponent: RowStatus,
   showFiltersInSidebar: false,
+  enableDataViewToggle: false,
+  onDataViewToggle: () => {},
 };
 
 DataTable.propTypes = {
@@ -292,6 +298,10 @@ DataTable.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
   /** If true filters will be shown on sidebar instead */
   showFiltersInSidebar: PropTypes.bool,
+  /** Whether to show a toggle button group which allows view switching between card and table views */
+  enableDataViewToggle: PropTypes.bool,
+  /** Callback invoked when the toggle buttons are clicked, with value of selected button passed in */
+  onDataViewToggle: PropTypes.func,
 };
 
 DataTable.BulkActions = BulkActions;

--- a/src/DataTable/tests/DataViewToggle.test.jsx
+++ b/src/DataTable/tests/DataViewToggle.test.jsx
@@ -24,6 +24,19 @@ describe('data view toggle default state', () => {
     );
     expect(screen.queryByRole('group')).not.toBeInTheDocument();
   });
+  it('no rendering when isDataViewToggleEnabled is absent/malformed', () => {
+    const instanceCorrupt = {
+      dataViewToggleOptions: {
+        defaultActiveStateValue: 'a_val',
+      },
+    };
+    render(
+      <DataTableContext.Provider value={instanceCorrupt}>
+        <DataViewToggle />
+      </DataTableContext.Provider>,
+    );
+    expect(screen.queryByRole('group')).not.toBeInTheDocument();
+  });
   it('onDataViewToggle is invoked when clicking on buttons', () => {
     const onDataViewToggle = jest.fn();
     render(

--- a/src/DataTable/tests/DataViewToggle.test.jsx
+++ b/src/DataTable/tests/DataViewToggle.test.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import userEvent from '@testing-library/user-event';
+import DataTableContext from '../DataTableContext';
+import DataViewToggle from '../DataViewToggle';
+
+const instance = {
+  dataViewToggleOptions: {
+    isDataViewToggleEnabled: false,
+    onDataViewToggle: jest.fn(),
+    defaultActiveStateValue: 'a_val',
+  },
+};
+
+describe('data view toggle default state', () => {
+  it('no rendering when isDataViewToggleEnabled is false', () => {
+    render(
+      <DataTableContext.Provider value={instance}>
+        <DataViewToggle />
+      </DataTableContext.Provider>,
+    );
+    expect(screen.queryByRole('group')).not.toBeInTheDocument();
+  });
+  it('onDataViewToggle is invoked when clicking on buttons', () => {
+    const onDataViewToggle = jest.fn();
+    render(
+      <DataTableContext.Provider
+        value={{
+          ...instance,
+          dataViewToggleOptions: {
+            ...instance.dataViewToggleOptions,
+            isDataViewToggleEnabled: true,
+            onDataViewToggle,
+          },
+        }}
+      >
+        <DataViewToggle />
+      </DataTableContext.Provider>,
+    );
+    expect(screen.queryByRole('group')).toBeInTheDocument();
+    const cardButton = screen.getByLabelText('Card');
+    userEvent.click(cardButton);
+    expect(onDataViewToggle).toHaveBeenCalledWith('card');
+
+    const listButton = screen.getByLabelText('List');
+    userEvent.click(listButton);
+    expect(onDataViewToggle).toHaveBeenCalledWith('list');
+  });
+});

--- a/src/DataTable/tests/DataViewToggle.test.jsx
+++ b/src/DataTable/tests/DataViewToggle.test.jsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 
 import userEvent from '@testing-library/user-event';
 import DataTableContext from '../DataTableContext';
-import DataViewToggle from '../DataViewToggle';
+import DataViewToggle, { DATA_VIEW_TOGGLE_VALUES } from '../DataViewToggle';
 
 const instance = {
   dataViewToggleOptions: {
@@ -15,8 +15,8 @@ const instance = {
   },
 };
 
-describe('data view toggle default state', () => {
-  it('no rendering when isDataViewToggleEnabled is false', () => {
+describe('data view toggle behavior', () => {
+  test('no rendering when isDataViewToggleEnabled is false', () => {
     render(
       <DataTableContext.Provider value={instance}>
         <DataViewToggle />
@@ -24,7 +24,47 @@ describe('data view toggle default state', () => {
     );
     expect(screen.queryByRole('group')).not.toBeInTheDocument();
   });
-  it('no rendering when isDataViewToggleEnabled is absent/malformed', () => {
+
+  test('The card button is marked active when defaultActiveStateValue is missing', () => {
+    const noActiveValue = {
+      dataViewToggleOptions: {
+        isDataViewToggleEnabled: true,
+        onDataViewToggle: jest.fn(),
+      },
+    };
+    render(
+      <DataTableContext.Provider value={noActiveValue}>
+        <DataViewToggle />
+      </DataTableContext.Provider>,
+    );
+    expect(screen.queryByRole('group')).toBeInTheDocument();
+    expect(screen.getByLabelText(DATA_VIEW_TOGGLE_VALUES.card.alt)).toHaveClass('btn-icon-primary-active');
+
+    expect(screen.getByLabelText(DATA_VIEW_TOGGLE_VALUES.list.alt)).not.toHaveClass('btn-icon-primary-active');
+    expect(screen.getByLabelText(DATA_VIEW_TOGGLE_VALUES.list.alt)).toHaveClass('btn-icon-primary');
+  });
+
+  test('The list button is marked active when defaultActiveStateValue is list', () => {
+    const listIsDefaultActive = {
+      dataViewToggleOptions: {
+        isDataViewToggleEnabled: true,
+        onDataViewToggle: jest.fn(),
+        defaultActiveStateValue: DATA_VIEW_TOGGLE_VALUES.list.value,
+      },
+    };
+    render(
+      <DataTableContext.Provider value={listIsDefaultActive}>
+        <DataViewToggle />
+      </DataTableContext.Provider>,
+    );
+    expect(screen.queryByRole('group')).toBeInTheDocument();
+    expect(screen.getByLabelText(DATA_VIEW_TOGGLE_VALUES.list.alt)).toHaveClass('btn-icon-primary-active');
+
+    expect(screen.getByLabelText(DATA_VIEW_TOGGLE_VALUES.card.alt)).not.toHaveClass('btn-icon-primary-active');
+    expect(screen.getByLabelText(DATA_VIEW_TOGGLE_VALUES.card.alt)).toHaveClass('btn-icon-primary');
+  });
+
+  test('no rendering when isDataViewToggleEnabled is absent/malformed', () => {
     const instanceCorrupt = {
       dataViewToggleOptions: {
         defaultActiveStateValue: 'a_val',
@@ -37,7 +77,8 @@ describe('data view toggle default state', () => {
     );
     expect(screen.queryByRole('group')).not.toBeInTheDocument();
   });
-  it('onDataViewToggle is invoked when clicking on buttons', () => {
+
+  test('onDataViewToggle is invoked when clicking on buttons', () => {
     const onDataViewToggle = jest.fn();
     render(
       <DataTableContext.Provider
@@ -54,12 +95,12 @@ describe('data view toggle default state', () => {
       </DataTableContext.Provider>,
     );
     expect(screen.queryByRole('group')).toBeInTheDocument();
-    const cardButton = screen.getByLabelText('Card');
+    const cardButton = screen.getByLabelText(DATA_VIEW_TOGGLE_VALUES.card.alt);
     userEvent.click(cardButton);
-    expect(onDataViewToggle).toHaveBeenCalledWith('card');
+    expect(onDataViewToggle).toHaveBeenCalledWith(DATA_VIEW_TOGGLE_VALUES.card.value);
 
-    const listButton = screen.getByLabelText('List');
+    const listButton = screen.getByLabelText(DATA_VIEW_TOGGLE_VALUES.list.alt);
     userEvent.click(listButton);
-    expect(onDataViewToggle).toHaveBeenCalledWith('list');
+    expect(onDataViewToggle).toHaveBeenCalledWith(DATA_VIEW_TOGGLE_VALUES.list.value);
   });
 });

--- a/src/IconButtonToggle/IconButtonToggle.scss
+++ b/src/IconButtonToggle/IconButtonToggle.scss
@@ -1,4 +1,5 @@
 .pgn__icon-button-toggle__container {
+    display: flex;
     .btn-icon + .btn-icon {
         margin-left: map_get($spacers, 1\.5);
     }


### PR DESCRIPTION
Use an IconButtonToggle as a controlled component, which allows switching between multiple views, CardView and Table, using a state variable as desired by the user

There is one known bug here I could not figure out at first try, where filters if used, are cleared when switching view. Since it does not block Explore Catalog usage I am moving forward with feedback from Alena, Mariana and Adam S. But I created https://openedx.atlassian.net/browse/PAR-615 to track and fix that bug

Usage is seen in the DataTable demo page: https://deploy-preview-988--paragon-openedx.netlify.app/components/datatable/#view-switching

Did not add screenshots here since the preview page int he 'Checks' section has a live preview!


### Left placement

<img width="1041" alt="Screen Shot 2022-01-05 at 2 01 53 PM" src="https://user-images.githubusercontent.com/528166/148275197-74313ef4-e839-4414-9097-9843e6d89500.png">



### bottom placement

<img width="1089" alt="Screen Shot 2022-01-05 at 2 01 13 PM" src="https://user-images.githubusercontent.com/528166/148274902-6b9533a6-1880-48eb-9f36-f1024ccbf15e.png">
