### PR TITLE
fix: test updates to reduce prop type warnings and reduces size of expand/collapse IconButton in DataTable

### DIFF
--- a/src/DataTable/ExpandRow.jsx
+++ b/src/DataTable/ExpandRow.jsx
@@ -3,11 +3,13 @@ import PropTypes from 'prop-types';
 import { Icon, IconButton } from '..';
 import { ExpandLess, ExpandMore } from '../../icons';
 
+const EXPAND_COLLAPSE_ICON_SIZE = 'inline';
+
 const ExpandRow = ({ row }) => (
   <span {...row.getToggleRowExpandedProps()}>
     {row.isExpanded
-      ? <IconButton src={ExpandLess} iconAs={Icon} alt="Collapse row" />
-      : <IconButton src={ExpandMore} iconAs={Icon} alt="Expand row" />}
+      ? <IconButton src={ExpandLess} iconAs={Icon} alt="Collapse row" size={EXPAND_COLLAPSE_ICON_SIZE} />
+      : <IconButton src={ExpandMore} iconAs={Icon} alt="Expand row" size={EXPAND_COLLAPSE_ICON_SIZE} />}
   </span>
 );
 

--- a/src/IconButton/IconButton.test.jsx
+++ b/src/IconButton/IconButton.test.jsx
@@ -44,7 +44,7 @@ describe('<IconButton />', () => {
       const spy = jest.fn();
       const wrapper = mount((<IconButton {...props} onClick={spy} />));
       expect(spy).toHaveBeenCalledTimes(0);
-      wrapper.props().onClick();
+      wrapper.simulate('click');
       expect(spy).toHaveBeenCalledTimes(1);
     });
     it('only clicks one icon at a time', () => {
@@ -57,11 +57,11 @@ describe('<IconButton />', () => {
         </div>
       ));
       const icon1 = wrapper.find(IconButton).at(0);
-      icon1.props().onClick();
+      icon1.simulate('click');
       expect(spy1).toHaveBeenCalledTimes(1);
       expect(spy2).toHaveBeenCalledTimes(0);
       const icon2 = wrapper.find(IconButton).at(1);
-      icon2.props().onClick();
+      icon2.simulate('click');
       expect(spy1).toHaveBeenCalledTimes(1);
       expect(spy2).toHaveBeenCalledTimes(1);
     });

--- a/src/IconButtonToggle/IconButtonToggle.test.jsx
+++ b/src/IconButtonToggle/IconButtonToggle.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-
 import { render, screen, waitFor } from '@testing-library/react';
+import { faInfoCircle, faPlane } from '@fortawesome/free-solid-svg-icons';
 
 // adds special assertions like toHaveTextContent
 import '@testing-library/jest-dom/extend-expect';
@@ -9,11 +9,14 @@ import userEvent from '@testing-library/user-event';
 import { IconButton, IconButtonToggle } from '..';
 
 describe('IconButtonToggle tests', () => {
+  const iconInfo = faInfoCircle;
+  const iconPlane = faPlane;
+
   test('activeValue is correctly applied', () => {
     render(
       <IconButtonToggle activeValue="abc">
-        <IconButton value="def">def</IconButton>
-        <IconButton value="abc">abc</IconButton>
+        <IconButton value="def" alt="def" icon={iconInfo} />
+        <IconButton value="abc" alt="abc" icon={iconPlane} />
       </IconButtonToggle>,
     );
     expect(screen.getByTestId('icon-btn-val-abc')).toHaveClass('btn-icon-primary-active');
@@ -22,8 +25,8 @@ describe('IconButtonToggle tests', () => {
     const spyChanger = jest.fn();
     render(
       <IconButtonToggle activeValue="abc" onChange={spyChanger}>
-        <IconButton alt="def button" value="def">def</IconButton>
-        <IconButton alt="abc button" value="abc">abc</IconButton>
+        <IconButton value="def" alt="def" icon={iconInfo} />
+        <IconButton value="abc" alt="abc" icon={iconPlane} />
       </IconButtonToggle>,
     );
     const btnDef = screen.getByTestId('icon-btn-val-def');


### PR DESCRIPTION
* Simulate clicks to trigger `onClick` callback instead of calling the callback directly in tests.
* Fix a couple prop type warnings in tests
* Reduces size of `IconButton` in `ExpandRow` within `DataTable` to be inline