### PR TITLE
fix: no longer pass extra attrs to `IconComponent` in `IconButton`

### DIFF
--- a/src/DataTable/CollapsibleButtonGroup.jsx
+++ b/src/DataTable/CollapsibleButtonGroup.jsx
@@ -65,7 +65,7 @@ const CollapsibleButtonGroup = ({
             iconAs={Icon}
             as={IconButton}
             src={MoreVert}
-            screenReaderText={width > breakpoints.small.minWidth
+            alt={width > breakpoints.small.minWidth
               ? DROPDOWN_BUTTON_TEXT : SMALL_SCREEN_DROPDOWN_BUTTON_TEXT}
             id="actions-dropdown"
           />

--- a/src/DataTable/tests/BulkActions.test.jsx
+++ b/src/DataTable/tests/BulkActions.test.jsx
@@ -230,8 +230,8 @@ describe('<BulkActions />', () => {
         onClickSpy.mockClear();
       });
       it('displays additional actions in a dropdown', () => {
-        const icon = wrapper.find(Icon);
-        expect(icon.props().screenReaderText).toEqual(DROPDOWN_BUTTON_TEXT);
+        const dropdownToggle = wrapper.find('DropdownToggle');
+        expect(dropdownToggle.props().alt).toEqual(DROPDOWN_BUTTON_TEXT);
         const actionItems = wrapper.find(Dropdown.Item);
         // we subtract two for the two main buttons that aren't in the dropdown
         expect(actionItems.length).toEqual(4);
@@ -295,8 +295,8 @@ describe('<BulkActions />', () => {
     it('renders the correct alt text for the dropdown', () => {
       useWindowSize.mockReturnValue({ width: 500 });
       const wrapper = mount(<BulkActionsWrapper />);
-      const icon = wrapper.find(Icon);
-      expect(icon.props().screenReaderText).toEqual(SMALL_SCREEN_DROPDOWN_BUTTON_TEXT);
+      const dropdownToggle = wrapper.find('DropdownToggle');
+      expect(dropdownToggle.props().alt).toEqual(SMALL_SCREEN_DROPDOWN_BUTTON_TEXT);
     });
   });
 

--- a/src/DataTable/tests/TableActions.test.jsx
+++ b/src/DataTable/tests/TableActions.test.jsx
@@ -4,7 +4,7 @@ import { mount } from 'enzyme';
 import TableActions from '../TableActions';
 import { DROPDOWN_BUTTON_TEXT, SMALL_SCREEN_DROPDOWN_BUTTON_TEXT } from '../CollapsibleButtonGroup';
 import {
-  useWindowSize, Dropdown, Button, Icon, IconButton,
+  useWindowSize, Dropdown, Button, IconButton,
 } from '../..';
 import DataTableContext from '../DataTableContext';
 
@@ -198,8 +198,8 @@ describe('<TableActions />', () => {
         onClickSpy.mockClear();
       });
       it('displays additional actions in a dropdown', () => {
-        const icon = wrapper.find(Icon);
-        expect(icon.props().screenReaderText).toEqual(DROPDOWN_BUTTON_TEXT);
+        const dropdownToggle = wrapper.find('DropdownToggle');
+        expect(dropdownToggle.props().alt).toEqual(DROPDOWN_BUTTON_TEXT);
         const actionItems = wrapper.find(Dropdown.Item);
         // we subtract two for the two main buttons that aren't in the dropdown
         expect(actionItems.length).toEqual(4);
@@ -262,8 +262,8 @@ describe('<TableActions />', () => {
     it('renders the correct alt text for the dropdown', () => {
       useWindowSize.mockReturnValue({ width: 500 });
       const wrapper = mount(<TableActionsWrapper />);
-      const icon = wrapper.find(Icon);
-      expect(icon.props().screenReaderText).toEqual(SMALL_SCREEN_DROPDOWN_BUTTON_TEXT);
+      const dropdownToggle = wrapper.find('DropdownToggle');
+      expect(dropdownToggle.props().alt).toEqual(SMALL_SCREEN_DROPDOWN_BUTTON_TEXT);
     });
   });
   describe('with over ride function', () => {

--- a/src/IconButton/index.jsx
+++ b/src/IconButton/index.jsx
@@ -39,8 +39,7 @@ const IconButton = React.forwardRef(({
     >
       <span className="btn-icon__icon-container">
         <IconComponent
-          {...attrs}
-          className={`btn-icon__icon ${iconClassNames}`}
+          className={classNames('btn-icon__icon', iconClassNames)}
           icon={icon}
           src={src}
         />


### PR DESCRIPTION
Resolves erroneous errors in the test suite(s) of at least one consuming repository. No longer passes through `attrs` to `IconComponent` in the `IconButton` component. This change prevents the error previously seen where props were unintentionally being added in 2 places, causing failures with test selectors (e.g., `wrapper.find(...)` was returning more nodes than the expected 1).